### PR TITLE
docs: 移除 README 中重複的 commit author 規範

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ CI/CD Workflow 定義：
 4. 開啟 Pull Request
 
 **注意**：
-- 所有 commit 的 author 必須使用 `thepagent <thepagent@users.noreply.github.com>`
 - Commit message 格式：`type: description`（如 `feat:`, `fix:`, `docs:`, `refactor:`）
 - 在 PR description 中加入 `Fixes: #issue_number`（若為 issue 修復）
 


### PR DESCRIPTION
## 問題描述

`README.md` 的「程式碼貢獻」章節中，有重複說明 commit author 規范：

> **注意**：
> - 所有 commit 的 author 必須使用 `thepagent <thepagent@users.noreply.github.com>`
> - Commit message 格式：`type: description`（如 `feat:`, `fix:`, `docs:`, `refactor:`）
> - 在 PR description 中加入 `Fixes: #issue_number`（若為 issue 修復）

然而，此規範已在 `.github/workflows/check-commit-author.yml` 中由 CI 自動檢查，README 中的重複說明顯得冗餘。

## 修正內容

移除「所有 commit 的 author 必須使用 `thepagent <thepagent@users.noreply.github.com>`」這一行，僅保留其他兩條說明。

## 相關

- Issue: #12
- Workflow: `.github/workflows/check-commit-author.yml`

Fixes: #12