### PR TITLE
Revert: do not modify auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,10 +16,9 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          # GITHUB_TOKEN cannot approve user-created PRs; use a PAT stored as AUTO_APPROVE_TOKEN.
-          github-token: ${{ secrets.AUTO_APPROVE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.workflow_run?.pull_requests?.[0]?.number;
+            const prNumber = github.event.workflow_run.pull_requests?.[0]?.number;
             
             if (!prNumber) {
               console.log('No PR found in workflow_run');


### PR DESCRIPTION
Reverts commit 7b41ea7 ("Fix auto-approve workflow").

Rationale: keep workflows unchanged per request.
