### PR TITLE
Release notes: link issue IDs to URLs

### DIFF
--- a/release-notes/2026-02-17.md
+++ b/release-notes/2026-02-17.md
@@ -5,193 +5,193 @@
 ## 概述
 
 ### 功能更新 (Features)
-- ⭐⭐⭐ iOS 分享擴充：分享 URL/文字/圖片可直接轉送到 Gateway `agent.request` (#19424)
-- ⭐⭐⭐ Slack 原生單則訊息串流（startStream/appendStream/stopStream），失敗自動降級 (#9972)
-- ⭐⭐⭐ 新增 `/subagents spawn` 指令：可從聊天指令確定性啟動 subagent (#18218)
-- ⭐⭐ iOS Talk：可關閉「Voice Directive Hint」以節省 token（避免不必要的語音切換指示）(#18250)
-- ⭐⭐ Slack：新增可設定的串流模式以支援 draft preview 情境 (#18555)
-- ⭐⭐ Telegram：inline button `style`（primary/success/danger）支援 (#18241)
-- ⭐⭐ Cron：每次 run 記錄 model/provider 用量 telemetry，並提供本地彙總腳本 (#18172)
-- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist (#18584)
-- ⭐ Browser：新增 `extraArgs` 以傳入自訂 Chrome 啟動參數 (#18443)
-- ⭐ Docker：新增 `OPENCLAW_INSTALL_BROWSER` build arg 以預裝 Chromium + Xvfb (#18449)
+- ⭐⭐⭐ iOS 分享擴充：分享 URL/文字/圖片可直接轉送到 Gateway `agent.request` ([#19424](https://github.com/openclaw/openclaw/pull/19424))
+- ⭐⭐⭐ Slack 原生單則訊息串流（startStream/appendStream/stopStream），失敗自動降級 ([#9972](https://github.com/openclaw/openclaw/pull/9972))
+- ⭐⭐⭐ 新增 `/subagents spawn` 指令：可從聊天指令確定性啟動 subagent ([#18218](https://github.com/openclaw/openclaw/pull/18218))
+- ⭐⭐ iOS Talk：可關閉「Voice Directive Hint」以節省 token（避免不必要的語音切換指示）([#18250](https://github.com/openclaw/openclaw/pull/18250))
+- ⭐⭐ Slack：新增可設定的串流模式以支援 draft preview 情境 ([#18555](https://github.com/openclaw/openclaw/pull/18555))
+- ⭐⭐ Telegram：inline button `style`（primary/success/danger）支援 ([#18241](https://github.com/openclaw/openclaw/pull/18241))
+- ⭐⭐ Cron：每次 run 記錄 model/provider 用量 telemetry，並提供本地彙總腳本 ([#18172](https://github.com/openclaw/openclaw/pull/18172))
+- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
+- ⭐ Browser：新增 `extraArgs` 以傳入自訂 Chrome 啟動參數 ([#18443](https://github.com/openclaw/openclaw/pull/18443))
+- ⭐ Docker：新增 `OPENCLAW_INSTALL_BROWSER` build arg 以預裝 Chromium + Xvfb ([#18449](https://github.com/openclaw/openclaw/pull/18449))
 
 ### 安全性提升 (Security)
-- ⭐⭐⭐ 修補 OC-09：阻擋 exec 環境變數注入造成的憑證竊取路徑 (#18048)
-- ⭐⭐⭐ 強化 `$include`：限制 include 解析在頂層 config 目錄並防穿越/符號連結 (#18652)
-- ⭐⭐ Cron/Gateway：分離 per-job webhook delivery（`delivery.mode=webhook`）並驗證 HTTP(S) URL (#17901)
-- ⭐⭐ Discord/Telegram：讓 per-account message action gates 同時約束 listing 與 execution (#18494)
-- ⭐⭐ Auto-reply：trusted inbound metadata 加入 `sender_id` 便於後續審核/封鎖流程 (#18303)
-- ⭐⭐ Agents/Image：提交前驗證 base64 image payloads (#18263)
-- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist (#18584)
-- ⭐ Models CLI：驗證 `openclaw models set` catalog entries (#18129)
-- ⭐ Discord/Commands：allowFrom 正規化（支援 user:/discord: 前綴與 mention）(#18042)
-- ⭐ Config/Discord：強制 allowlists 使用字串 ID 並提供 doctor repair (#18220)
+- ⭐⭐⭐ 修補 OC-09：阻擋 exec 環境變數注入造成的憑證竊取路徑 ([#18048](https://github.com/openclaw/openclaw/pull/18048))
+- ⭐⭐⭐ 強化 `$include`：限制 include 解析在頂層 config 目錄並防穿越/符號連結 ([#18652](https://github.com/openclaw/openclaw/pull/18652))
+- ⭐⭐ Cron/Gateway：分離 per-job webhook delivery（`delivery.mode=webhook`）並驗證 HTTP(S) URL ([#17901](https://github.com/openclaw/openclaw/pull/17901))
+- ⭐⭐ Discord/Telegram：讓 per-account message action gates 同時約束 listing 與 execution ([#18494](https://github.com/openclaw/openclaw/pull/18494))
+- ⭐⭐ Auto-reply：trusted inbound metadata 加入 `sender_id` 便於後續審核/封鎖流程 ([#18303](https://github.com/openclaw/openclaw/pull/18303))
+- ⭐⭐ Agents/Image：提交前驗證 base64 image payloads ([#18263](https://github.com/openclaw/openclaw/pull/18263))
+- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
+- ⭐ Models CLI：驗證 `openclaw models set` catalog entries ([#18129](https://github.com/openclaw/openclaw/pull/18129))
+- ⭐ Discord/Commands：allowFrom 正規化（支援 user:/discord: 前綴與 mention）([#18042](https://github.com/openclaw/openclaw/pull/18042))
+- ⭐ Config/Discord：強制 allowlists 使用字串 ID 並提供 doctor repair ([#18220](https://github.com/openclaw/openclaw/pull/18220))
 
 ### 錯誤修復 (Bug Fixes)
-- ⭐⭐⭐ iOS Onboarding：停止未授權錯誤造成的重試迴圈/狀態抖動 (#19153)
-- ⭐⭐⭐ Voice-call：媒體流斷線時自動結束通話避免卡住 (#18435)
-- ⭐⭐ Voice call/Gateway：避免 turn race、強化 transcript 去重與 latency 統計穩健性 (#19140)
-- ⭐⭐ iOS/Chat：ChatSheet RPC 改走 operator session，避免 node-role 授權失敗 (#19320)
-- ⭐⭐ Telegram：DM 語音訊息轉寫（含 CLI fallback）(#18564)
-- ⭐ Telegram/Polls：恢復 Telegram poll action wiring (#18122)
-- ⭐ WebChat：移除渲染輸出中的 reply/audio directive tags (#18093)
-- ⭐ Discord：修正 HTTP proxy 設定未被 REST 解析流程使用 (#17958)
-- ⭐ CLI/Doctor：`--fix --non-interactive --yes` 完成後可正常結束不再掛住 (#18502)
-- ⭐ Media understanding：遵守 `agents.defaults.imageModel` 以套用設定的主要/備援影像模型 (#7607)
+- ⭐⭐⭐ iOS Onboarding：停止未授權錯誤造成的重試迴圈/狀態抖動 ([#19153](https://github.com/openclaw/openclaw/pull/19153))
+- ⭐⭐⭐ Voice-call：媒體流斷線時自動結束通話避免卡住 ([#18435](https://github.com/openclaw/openclaw/pull/18435))
+- ⭐⭐ Voice call/Gateway：避免 turn race、強化 transcript 去重與 latency 統計穩健性 ([#19140](https://github.com/openclaw/openclaw/pull/19140))
+- ⭐⭐ iOS/Chat：ChatSheet RPC 改走 operator session，避免 node-role 授權失敗 ([#19320](https://github.com/openclaw/openclaw/pull/19320))
+- ⭐⭐ Telegram：DM 語音訊息轉寫（含 CLI fallback）([#18564](https://github.com/openclaw/openclaw/pull/18564))
+- ⭐ Telegram/Polls：恢復 Telegram poll action wiring ([#18122](https://github.com/openclaw/openclaw/pull/18122))
+- ⭐ WebChat：移除渲染輸出中的 reply/audio directive tags ([#18093](https://github.com/openclaw/openclaw/pull/18093))
+- ⭐ Discord：修正 HTTP proxy 設定未被 REST 解析流程使用 ([#17958](https://github.com/openclaw/openclaw/pull/17958))
+- ⭐ CLI/Doctor：`--fix --non-interactive --yes` 完成後可正常結束不再掛住 ([#18502](https://github.com/openclaw/openclaw/pull/18502))
+- ⭐ Media understanding：遵守 `agents.defaults.imageModel` 以套用設定的主要/備援影像模型 ([#7607](https://github.com/openclaw/openclaw/pull/7607))
 
 ## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ iOS 分享擴充：分享內容直送 Gateway `agent.request` (#19424)
+### ⭐⭐⭐ iOS 分享擴充：分享內容直送 Gateway `agent.request` ([#19424](https://github.com/openclaw/openclaw/pull/19424))
 - **用途**: 讓 iOS 使用者從系統分享面板直接把 URL/文字/圖片交給 OpenClaw。
 - **解決問題**: 過去需手動複製貼上或透過其他中繼流程，分享摩擦高。
 - **影響**: 降低「隨手丟給代理」成本，強化行動端工作流。
 
-### ⭐⭐⭐ Slack 原生單則訊息串流 (#9972)
+### ⭐⭐⭐ Slack 原生單則訊息串流 ([#9972](https://github.com/openclaw/openclaw/pull/9972))
 - **用途**: 以 Slack 串流 API 在同一則訊息內即時追加內容。
 - **解決問題**: 過去可能拆成多則訊息，thread 對齊與閱讀性較差。
 - **影響**: 串流體驗更一致，且失敗時可自動回退確保可靠投遞。
 
-### ⭐⭐⭐ `/subagents spawn` 聊天指令 (#18218)
+### ⭐⭐⭐ `/subagents spawn` 聊天指令 ([#18218](https://github.com/openclaw/openclaw/pull/18218))
 - **用途**: 從指令介面直接、可預期地啟動 subagent。
 - **解決問題**: 過去啟動 subagent 較仰賴工具或模型自行決策，不易控管。
 - **影響**: 提升長任務/專用子流程的可控性與可重現性。
 
-### ⭐⭐ iOS Talk：Voice Directive Hint 可關閉 (#18250)
+### ⭐⭐ iOS Talk：Voice Directive Hint 可關閉 ([#18250](https://github.com/openclaw/openclaw/pull/18250))
 - **用途**: 允許使用者關閉 Talk Mode 中的語音指示提示。
 - **解決問題**: 若不使用 ElevenLabs/不需要語音切換指示，提示會增加 token 成本。
 - **影響**: 讓 Talk Mode 更可依需求「省 token」。
 
-### ⭐⭐ Slack：可設定串流模式以支援 draft preview (#18555)
+### ⭐⭐ Slack：可設定串流模式以支援 draft preview ([#18555](https://github.com/openclaw/openclaw/pull/18555))
 - **用途**: 提供可配置的串流行為模式。
 - **解決問題**: 不同團隊對「草稿預覽」與「最終輸出」的串流策略需求不同。
 - **影響**: 讓 Slack 端串流更可調，降低誤用與體驗不一致。
 
-### ⭐⭐ Telegram：inline button `style` 支援 (#18241)
+### ⭐⭐ Telegram：inline button `style` 支援 ([#18241](https://github.com/openclaw/openclaw/pull/18241))
 - **用途**: 支援 `primary|success|danger` 按鈕樣式，貫通 schema/解析/送信管線。
 - **解決問題**: 重要操作缺乏視覺層級，不易凸顯。
 - **影響**: 互動介面更清楚，降低誤觸。
 
-### ⭐⭐ Cron：run 用量 telemetry + 彙總腳本 (#18172)
+### ⭐⭐ Cron：run 用量 telemetry + 彙總腳本 ([#18172](https://github.com/openclaw/openclaw/pull/18172))
 - **用途**: 在 cron run log/webhook 中記錄 model/provider 用量，並提供本地彙總。
 - **解決問題**: 缺乏 per-job 成本/用量可觀測性，難以優化與控管。
 - **影響**: 更容易找出高成本任務並進行調整。
 
-### ⭐ Tools/Web：URL allowlist (#18584)
+### ⭐ Tools/Web：URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
 - **用途**: 允許限制 `web_search`/`web_fetch` 可存取的 URL 範圍。
 - **解決問題**: 在受控環境中需避免抓取不可信來源或內網風險。
 - **影響**: 讓 Web 工具更容易符合企業/個人安全政策。
 
-### ⭐ Browser：Chrome `extraArgs` (#18443)
+### ⭐ Browser：Chrome `extraArgs` ([#18443](https://github.com/openclaw/openclaw/pull/18443))
 - **用途**: 允許自訂 Chromium/Chrome 啟動參數。
 - **解決問題**: 需要代理、旗標或相容性參數時缺乏正式入口。
 - **影響**: 提升瀏覽器自動化在多環境部署的彈性。
 
-### ⭐ Docker：`OPENCLAW_INSTALL_BROWSER` 預裝 Chromium + Xvfb (#18449)
+### ⭐ Docker：`OPENCLAW_INSTALL_BROWSER` 預裝 Chromium + Xvfb ([#18449](https://github.com/openclaw/openclaw/pull/18449))
 - **用途**: Docker build 時可選擇預裝瀏覽器與顯示環境。
 - **解決問題**: 避免 runtime Playwright 安裝造成啟動慢、失敗率高或網路受限問題。
 - **影響**: 容器化部署更穩定、啟動更快。
 
 ## 安全性提升 (Security) - by Star Rating
 
-### ⭐⭐⭐ 修補 OC-09：憑證竊取路徑修補 (#18048)
+### ⭐⭐⭐ 修補 OC-09：憑證竊取路徑修補 ([#18048](https://github.com/openclaw/openclaw/pull/18048))
 - **用途**: 修補 exec 相關的 credential-theft 攻擊面。
 - **解決問題**: 惡意輸入可能透過環境變數注入影響執行內容，造成憑證外洩風險。
 - **影響**: 降低高風險攻擊面，對自動化/遠端執行尤為關鍵。
 
-### ⭐⭐⭐ `$include` 解析限制與路徑防護強化 (#18652)
+### ⭐⭐⭐ `$include` 解析限制與路徑防護強化 ([#18652](https://github.com/openclaw/openclaw/pull/18652))
 - **用途**: 將 `$include` 解析限制在頂層 config 目錄，並強化 traversal/symlink 檢查。
 - **解決問題**: 若 include 可跨目錄解析，可能造成讀取不該被讀取的檔案。
 - **影響**: 強化配置層面的檔案存取邊界。
 
-### ⭐⭐ Cron webhook delivery 模式拆分與 URL 驗證 (#17901)
+### ⭐⭐ Cron webhook delivery 模式拆分與 URL 驗證 ([#17901](https://github.com/openclaw/openclaw/pull/17901))
 - **用途**: 分離 per-job webhook 與 announce，並驗證 webhook URL 為有效 HTTP(S)。
 - **解決問題**: 混用模式與弱驗證可能造成誤送或不安全 URL。
 - **影響**: cron 外送更可控、更安全。
 
-### ⭐⭐ Discord/Telegram：per-account action gates 生效於 listing + execution (#18494)
+### ⭐⭐ Discord/Telegram：per-account action gates 生效於 listing + execution ([#18494](https://github.com/openclaw/openclaw/pull/18494))
 - **用途**: 將動作閘門一致套用到「可見性」與「實際執行」。
 - **解決問題**: 僅限制一端會造成權限行為不一致。
 - **影響**: 降低越權與配置誤解風險。
 
-### ⭐⭐ trusted inbound metadata 加入 `sender_id` (#18303)
+### ⭐⭐ trusted inbound metadata 加入 `sender_id` ([#18303](https://github.com/openclaw/openclaw/pull/18303))
 - **用途**: 讓後續 moderation/流程能以可信 sender_id 進行定位。
 - **解決問題**: 依賴不可信文本取得 sender 資訊可能被偽造。
 - **影響**: 提升審核/封鎖等自動化工作流的正確性。
 
-### ⭐⭐ base64 image payloads 驗證 (#18263)
+### ⭐⭐ base64 image payloads 驗證 ([#18263](https://github.com/openclaw/openclaw/pull/18263))
 - **用途**: 送往 provider 前先驗證影像 payload。
 - **解決問題**: 非法/破損 payload 可能造成 provider 錯誤或不可預期行為。
 - **影響**: 降低錯誤面，並改善對外部服務互動的健壯性。
 
-### ⭐ Tools/Web：URL allowlist (#18584)
+### ⭐ Tools/Web：URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
 - **用途**: 以 allowlist 方式限制 web 工具存取範圍。
 - **解決問題**: 避免不必要的外部抓取風險。
 - **影響**: 強化可控性，便於合規。
 
-### ⭐ `openclaw models set` catalog 驗證 (#18129)
+### ⭐ `openclaw models set` catalog 驗證 ([#18129](https://github.com/openclaw/openclaw/pull/18129))
 - **用途**: 對 models CLI 的 catalog entries 加入驗證。
 - **解決問題**: 錯誤 catalog 可能導致使用到非預期模型或失敗路徑。
 - **影響**: 降低配置錯誤造成的行為偏差與風險。
 
-### ⭐ Discord allowFrom 正規化 (#18042)
+### ⭐ Discord allowFrom 正規化 ([#18042](https://github.com/openclaw/openclaw/pull/18042))
 - **用途**: 統一 allowFrom 格式（支援前綴與 mention）。
 - **解決問題**: 格式落差會導致授權判斷不一致。
 - **影響**: 權限控管更可預期。
 
-### ⭐ Discord allowlists string ID + doctor repair (#18220)
+### ⭐ Discord allowlists string ID + doctor repair ([#18220](https://github.com/openclaw/openclaw/pull/18220))
 - **用途**: 強制使用字串 ID 並提供修復。
 - **解決問題**: 數字型態差異可能造成解析/比對錯誤。
 - **影響**: 降低因配置錯誤造成的授權風險。
 
 ## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐⭐ iOS Onboarding：停止重試迴圈與狀態抖動 (#19153)
+### ⭐⭐⭐ iOS Onboarding：停止重試迴圈與狀態抖動 ([#19153](https://github.com/openclaw/openclaw/pull/19153))
 - **用途**: 未授權/缺 token 時暫停重連並保持狀態可手動重試。
 - **解決問題**: 持續重試會造成電量消耗與使用者困惑。
 - **影響**: 配對/授權流程更穩定。
 
-### ⭐⭐⭐ Voice-call：媒體流斷線自動結束 (#18435)
+### ⭐⭐⭐ Voice-call：媒體流斷線自動結束 ([#18435](https://github.com/openclaw/openclaw/pull/18435))
 - **用途**: 在媒體斷線時自動清理通話狀態。
 - **解決問題**: 通話可能卡在「仍在通話中」造成後續操作失敗。
 - **影響**: 降低 stuck call、提升通話可靠性。
 
-### ⭐⭐ Voice call/Gateway：turn lock、transcript 去重與 latency 統計強化 (#19140)
+### ⭐⭐ Voice call/Gateway：turn lock、transcript 去重與 latency 統計強化 ([#19140](https://github.com/openclaw/openclaw/pull/19140))
 - **用途**: 加鎖避免重疊回合競態，並改進統計與去重策略。
 - **解決問題**: 競態可能造成重複轉錄、狀態錯亂或統計崩潰。
 - **影響**: 提升語音通話穩定性與可觀測性。
 
-### ⭐⭐ iOS/Chat：ChatSheet RPC 走 operator session (#19320)
+### ⭐⭐ iOS/Chat：ChatSheet RPC 走 operator session ([#19320](https://github.com/openclaw/openclaw/pull/19320))
 - **用途**: 調整 RPC 路由以符合權限模型。
 - **解決問題**: 走 node session 可能導致 `chat.history/chat.send/sessions.list` 授權失敗。
 - **影響**: iOS ChatSheet 功能更可靠。
 
-### ⭐⭐ Telegram：DM 語音訊息轉寫 (#18564)
+### ⭐⭐ Telegram：DM 語音訊息轉寫 ([#18564](https://github.com/openclaw/openclaw/pull/18564))
 - **用途**: 啟用 DM voice-note transcription，並提供 CLI fallback。
 - **解決問題**: 轉寫缺失會降低語音訊息可搜尋性與可讀性。
 - **影響**: 改善 Telegram DM 的語音工作流。
 
-### ⭐ Telegram/Polls：poll action wiring 復原 (#18122)
+### ⭐ Telegram/Polls：poll action wiring 復原 ([#18122](https://github.com/openclaw/openclaw/pull/18122))
 - **用途**: 修復 Telegram poll actions 的 handler 接線。
 - **解決問題**: 互動投票失效會中斷自動化/互動流程。
 - **影響**: 恢復 Telegram 投票功能可用性。
 
-### ⭐ WebChat：移除 reply/audio directive tags (#18093)
+### ⭐ WebChat：移除 reply/audio directive tags ([#18093](https://github.com/openclaw/openclaw/pull/18093))
 - **用途**: 清理 UI 渲染中的指令標籤。
 - **解決問題**: 標籤外露會干擾閱讀與前端呈現。
 - **影響**: WebChat 顯示更乾淨。
 
-### ⭐ Discord：HTTP proxy 設定生效於 REST 解析 (#17958)
+### ⭐ Discord：HTTP proxy 設定生效於 REST 解析 ([#17958](https://github.com/openclaw/openclaw/pull/17958))
 - **用途**: 讓 proxy 設定被 app-id/allowlist REST resolution 正確使用。
 - **解決問題**: 企業網路下可能因無 proxy 而解析失敗。
 - **影響**: Discord 相關流程在受限網路更穩定。
 
-### ⭐ CLI/Doctor：非互動修復不再掛住 (#18502)
+### ⭐ CLI/Doctor：非互動修復不再掛住 ([#18502](https://github.com/openclaw/openclaw/pull/18502))
 - **用途**: 讓 doctor 非互動模式在完成後可正常退出。
 - **解決問題**: 自動化/CI 會因掛住而浪費資源。
 - **影響**: 一鍵修復更適合自動化情境。
 
-### ⭐ Media understanding：遵守 `agents.defaults.imageModel` (#7607)
+### ⭐ Media understanding：遵守 `agents.defaults.imageModel` ([#7607](https://github.com/openclaw/openclaw/pull/7607))
 - **用途**: 讓自動影像分析使用配置的 primary/fallback image model。
 - **解決問題**: auto-discovery 若忽略設定，會導致不一致的模型選擇。
 - **影響**: 影像理解行為更可預期、與配置一致。


### PR DESCRIPTION
Updates `release-notes/2026-02-17.md` so each referenced issue/PR ID is a clickable link back to GitHub.

Source release: https://github.com/openclaw/openclaw/releases/tag/v2026.2.17
