### PR TITLE
Release notes: link IDs across all files

### DIFF
--- a/release-notes/2026-02-13.md
+++ b/release-notes/2026-02-13.md
@@ -10,7 +10,7 @@
 
 ## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ 全新 Hugging Face 無伺服器推理支援 (#13472)
+### ⭐⭐⭐ 全新 Hugging Face 無伺服器推理支援 ([#13472](https://github.com/openclaw/openclaw/pull/13472))
 - **用途**: 引入 Hugging Face Inference 提供者一級支援，整合於認證流程與模型選擇
 - **解決問題**: 使用者需手動配置 API 金鑰與模型端點，操作複雜且易出錯
 - **影響**: 降低 AI 模型接入門檻，支援 hf:zai-org/GLM-5 等預設模型，提升部署彈性
@@ -20,54 +20,54 @@
 - **解決問題**: 模型識別不完整導致無法使用 Codex OAuth 憑證，影響企業用戶體驗
 - **影響**: 強化企業級模型兼容性，確保認證與模型 Discovery 機制一致性
 
-### ⭐⭐ Discord 語音訊訊息波形預覽 (#7253)
+### ⭐⭐ Discord 語音訊訊息波形預覽 ([#7253](https://github.com/openclaw/openclaw/pull/7253))
 - **用途**: 支援上傳本地音訊檔案作為語音訊息，包含靜音傳遞選項
 - **解決問題**: 現有語音訊息缺乏預覽功能，使用者無法確認內容正確性
 - **影響**: 提升 Discord 平台語音溝通體驗，特別適合檔案共享與快速回覆場景
 
-### ⭐⭐ Slack 插件自訂狀態與活動整合 (#10855)
+### ⭐⭐ Slack 插件自訂狀態與活動整合 ([#10855](https://github.com/openclaw/openclaw/pull/10855))
 - **用途**: 可配置 presence status、activity type、url 等參數，默认使用活動文本
 - **解決問題**: Slack 機器人狀態顯示過於固定，無法反映實際工作狀態
 - **影響**: 使機器人狀態更加動態直觀，提升團隊協作視覺化程度
 
-### ⭐⭐ Agents 前置提示診斷資訊 (#8930)
+### ⭐⭐ Agents 前置提示診斷資訊 ([#8930](https://github.com/openclaw/openclaw/pull/8930))
 - **用途**: 在 embedded runner prompt 呼叫前輸出訊息、systemPrompt 長度、prompt 長度、provider/model 與 session 檔案路徑
 - **解決問題**: Context overflow 問題難以診斷，缺乏即時診斷資訊
 - **影響**: 大幅縮短調試時間，提升開發者故障排除效率
 
-### ⭐⭐ vLLM 認證流程整合 (#12577)
+### ⭐⭐ vLLM 認證流程整合 ([#12577](https://github.com/openclaw/openclaw/pull/12577))
 - **用途**: 在 onboarding 流程中新增 vLLM 提供者，支援模型 Discovery 與非互動式認證
 - **解決問題**: 使用者需手動編輯配置檔以新增 vLLM，操作繁琐且容易出錯
 - **影響**: 統一提供者設定體驗，促進本地模型部署採用
 
 ## 安全性提升 (Security) - by Star Rating
 
-### ⭐⭐⭐ Gateway 工具調用防護強化 (#15390)
+### ⭐⭐⭐ Gateway 工具調用防護強化 ([#15390](https://github.com/openclaw/openclaw/pull/15390))
 - **用途**: 預設封鎖高風險工具（sessions_spawn、sessions_send、gateway、whatsapp_login）透過 HTTP /tools/invoke 調用
 - **解決問題**: 攻擊者可能透過弱勢 API 權限取得敏感工具調用權限
 - **影響**: 防止未經授權的跨會話操作，大幅提升 HTTP API 端點安全性
 
-### ⭐⭐ Canvas 服務路徑安全加固 (#10525)
+### ⭐⭐ Canvas 服務路徑安全加固 ([#10525](https://github.com/openclaw/openclaw/pull/10525))
 - **用途**: 使用 shared safe-open 路徑服務 A2UI 靜態資源，杜絕路徑遍歷與 TOCTOU 間隙
 - **解決問題**: 以往直接提供文件路徑可能被濫用進行路徑遍歷攻擊
 - **影響**: 強化 Web UI 安全邊界，防止靜態資源意外暴露
 
-### ⭐⭐ WhatsApp 憑證檔案權限強化 (#10529)
+### ⭐⭐ WhatsApp 憑證檔案權限強化 ([#10529](https://github.com/openclaw/openclaw/pull/10529))
 - **用途**: 強制 creds.json 與 creds.json.bak 權限為 0o600（僅所有者可讀寫）
 - **解決問題**: 憑證檔案可能因過寬的檔案權限被其他進程讀取
 - **影響**: 降低憑證洩漏風險，符合最小權限原則
 
-### ⭐⭐ WebSocket 標頭清理防止 Log Poisioning (#15848)
+### ⭐⭐ WebSocket 標頭清理防止 Log Poisioning ([#15848](https://github.com/openclaw/openclaw/pull/15848))
 - **用途**: 清理並截斷 WebSocket 握手前的不信任標頭值，減少日誌污染風險
 - **解決問題**: 攻擊者可注入惡意字串污染 gateway 日誌，影響監控與審計
 - **影響**: 提升日誌品質與可讀性，防止日誌驅動誤判
 
-### ⭐⭐ 隱藏 Discord 自訂指令超限防護 (#15844)
+### ⭐⭐ 隱藏 Discord 自訂指令超限防護 ([#15844](https://github.com/openclaw/openclaw/pull/15844))
 - **用途**: 將 bots 註冊指令數量限制在 Telegram 的 100 條上限，超出時顯示警告但保留隱藏指令
 - **解決問題**: 超過指令上限會導致 setMyCommands 失敗，影響整個 bot 功能
 - **影響**: 保持 bot 基本功能運作，同時讓開發者知悉指令過多問題
 
-### ⭐⭐ 鉤子權限區分外部與內部觸發 (#13474)
+### ⭐⭐ 鉤子權限區分外部與內部觸發 ([#13474](https://github.com/openclaw/openclaw/pull/13474))
 - **用途**: 在攻擊面摘要中明確區分外部 webhook（hooks.enabled）與內部鉤子（hooks.internal.enabled）
 - **解決問題**: 無法區分鉤子類型導致誤報安全風險，影響決策判斷
 - **影響**: 提升安全審計準確性，讓風險評估更貼近實際威脅
@@ -77,29 +77,29 @@
 - **解決問題**: 配置錯誤可能導致權限昇高或功能異常，但不易被發現
 - **影響**: 及早發現潛在安全與功能性問題，提升系統穩定性
 
-### ⭐⭐ 外部 Webhook SSRF 防堵 (#15604)
+### ⭐⭐ 外部 Webhook SSRF 防堵 ([#15604](https://github.com/openclaw/openclaw/pull/15604))
 - **用途**: 阻擋 loopback、內部主機模式與私有 IPv6 位址在 URL 解析中的使用
 - **解決問題**: 攻擊者可透過特製 URL 觸發 SSRF 漏洞，存取內部資源
 - **影響**: 堵住 SSRF 攻擊途徑，防止內部網路資訊外洩
 
-### ⭐⭐ OAuth 對話流程防呆增強 (#15406)
+### ⭐⭐ OAuth 對話流程防呆增強 ([#15406](https://github.com/openclaw/openclaw/pull/15406))
 - **用途**: 認證流程中OAuth失敗時保留會話並提供直接幫助提示，而非終止向導
 - **解決問題**: 使用者在OAuth流程中遇到問題時流程中斷，導致無法完成配置
 - **影響**: 提升新用戶上手成功率，減少設定失敗導致的用戶流失
 
-### ⭐⭐ Android 應用程式更新強化 (#13541)
+### ⭐⭐ Android 應用程式更新強化 ([#13541](https://github.com/openclaw/openclaw/pull/13541))
 - **用途**: 要求 HTTPS 連線、網域比對與 SHA-256 摘要驗證，並停止使用除錯金鑰簽署 RELEASE 版本
 - **解決問題**: 除錯金鑰簽署的 release 版本有潛在安全風險，且缺少校驗機制
 - **影響**: 防止惡意更新與中間人攻擊，保障使用者裝置安全
 
 ## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐⭐ Outbound 發送隊列寫前日誌機制 (#15636)
+### ⭐⭐⭐ Outbound 發送隊列寫前日誌機制 ([#15636](https://github.com/openclaw/openclaw/pull/15636))
 - **用途**: 新增寫前隊列機制，在 gateway 重啟後仍可恢復未完成的訊息發送
 - **解決問題**: 系統異常中止後已接收的 outbound 訊息會遺失，導致訊息缺失
 - **影響**: 保障關鍵訊息不遺失，提升系統可靠性與企業級可用性
 
-### ⭐⭐ 嵌入式執行時命令執行預設值統一 (#15833)
+### ⭐⭐ 嵌入式執行時命令執行預設值統一 ([#15833](https://github.com/openclaw/openclaw/pull/15833))
 - **用途**: 將 exec 預設參數（host、security、ask、node）集中於工具工廠，確保 compaction 重試時參數不遺失
 - **解決問題**: 某些情況下重試時 exec 參數被覆蓋為系統預設，忽略 agent 自訂設定
 - **影響**: 保障 agent 自訂執行環境不被中斷，提升多代理場景穩定性
@@ -109,162 +109,162 @@
 - **解決問題**: 非預設 agent 會話檔案路徑解析失敗，導致會話狀態無法載入
 - **影響**: 恢復多 agent 會話管理功能，保障自定義 agent 正常運作
 
-### ⭐⭐ Gateway 重啟後清理過期狀態 (#15195)
+### ⭐⭐ Gateway 重啟後清理過期狀態 ([#15195](https://github.com/openclaw/openclaw/pull/15195))
 - **用途**: SIGUSR1 緩存重啟後清除舊有的 command queue 與 heartbeat wake 狀態
 - **解決問題**: 殘留狀態導致重啟後 gateway 行為異常，queue 無法繼續處理
 - **影響**: 確保重啟流程乾淨完整，防止 zombie gateway 狀態
 
-### ⭐⭐ 自動回覆媒體訊息路徑修復 (#11916)
+### ⭐⭐ 自動回覆媒體訊息路徑修復 ([#11916](https://github.com/openclaw/openclaw/pull/11916))
 - **用途**: 允許無文字說明的純圖片訊息傳遞至 agent，並在佇列/後續處理中保留 thread context
 - **解決問題**: 純媒體訊息被當作空訊息跳過，導致重要圖片訊息遺失
 - **影響**: 恢復多媒體溝通完整性，特別適合圖形化指令與文件共享
 
-### ⭐⭐ Telegram MP3/M4A 語音訊息支援 (#15438)
+### ⭐⭐ Telegram MP3/M4A 語音訊息支援 ([#15438](https://github.com/openclaw/openclaw/pull/15438))
 - **用途**: 將 MP3 與 M4A（含 audio/mp4）標記為語音訊息，WAV/AAC 保留為一般音訊
 - **解決問題**: 使用者上傳 MP3 檔案時被當作一般檔案處理，無法以語音方式播放
 - **影響**: 提升 Telegram 平台語音體驗一致性
 
-### ⭐⭐ OAuth 憑證跨模組橋接 (#15184)
+### ⭐⭐ OAuth 憑證跨模組橋接 ([#15184](https://github.com/openclaw/openclaw/pull/15184))
 - **用途**: 將 OpenClaw OAuth 設定橋接至 pi auth.json，使模型 Discovery 可使用 Codex 憑證
 - **解決問題**: Codex OAuth 登錄後模型清單仍無法使用該憑證，導致功能斷層
 - **影響**: 統一認證系統，提升企業 OAuth 使用體驗
 
-### ⭐⭐ Web UI Markdown 圖片渲染修復 (#15437)
+### ⭐⭐ Web UI Markdown 圖片渲染修復 ([#15437](https://github.com/openclaw/openclaw/pull/15437))
 - **用途**: 將 img 標籤與 src/alt 屬性新增至 DOMPurify 白名單，使 markdown 圖片正確渲染
 - **解決問題**: WebChat 中 markdown 圖片被安全过滤器移除，僅顯示文字
 - **影響**: 恢復視覺化內容呈現，提升 Web UI 交互性
 
-### ⭐⭐ 命令重複消除修復 (#15892)
+### ⭐⭐ 命令重複消除修復 ([#15892](https://github.com/openclaw/openclaw/pull/15892))
 - **用途**: 統一 webhook 事件處理至共享管理器，避免重複處理掛斷事件
 - **解決問題**: 同一事件被多次處理導致呼叫狀態異常，可能誤斷通話
 - **影響**: 保障通話流程正確性，防止重複操作導致的問題
 
-### ⭐⭐ WhatsApp 文檔檔案名稱保留 (#15594)
+### ⭐⭐ WhatsApp 文檔檔案名稱保留 ([#15594](https://github.com/openclaw/openclaw/pull/15594))
 - **用途**: 在 web-session 發送文件時保留原始檔名，而非一律使用 "file"
 - **解決問題**: 使用者上傳的文件缺少明確檔名，導致接收端難以辨識內容
 - **影響**: 提升文件共享體驗，特別適合多文件溝通場景
 
-### ⭐⭐ 內嵌命令處理heredoc 容錯增強 (#13811)
+### ⭐⭐ 內嵌命令處理heredoc 容錯增強 ([#13811](https://github.com/openclaw/openclaw/pull/13811))
 - **用途**: 在 exec 批准解析中接受 heredoc 主體（<<, <<-），同時保持阻擋一般多行命令鏈
 - **解決問題**: heredoc 常用於多行腳本，被誤判為不安全命令鏈
 - **影響**: 提供安全的多行命令輸入途徑，便利腳本編寫
 
-### ⭐⭐ 非預設 agent sessions.path 驗證修復 (#15103)
+### ⭐⭐ 非預設 agent sessions.path 驗證修復 ([#15103](https://github.com/openclaw/openclaw/pull/15103))
 - **用途**: 修復 status 與 usage 路徑解析時的 agentId 缺失，使非預設 agent 可取得檔案
 - **解決問題**: 自定義 agent 會話檔案路徑驗證失敗，導致功能中斷
 - **影響**: 恢復非預設 agent 元資料功能，保障多代理環境完整性
 
-### ⭐⭐ 狀態報告預防 100% 誤报 (#15114)
+### ⭐⭐ 狀態報告預防 100% 誤报 ([#15114](https://github.com/openclaw/openclaw/pull/15114))
 - **用途**: 停止強制將 tokens 計算限制至 context window 大小，當新快照缺失時標示為未知
 - **解決問題**: 部分情境下誤報 context 使用率 100%，導致錯誤警報
 - **影響**: 使狀態報表更準確，減少誤報干擾
 
-### ⭐⭐ Discord 自動 Thread 路由修復 (#8302)
+### ⭐⭐ Discord 自動 Thread 路由修復 ([#8302](https://github.com/openclaw/openclaw/pull/8302))
 - **用途**: 將 autoThread 自動回覆導向現有 thread，而非根通道
 - **解決問題**: 自動回覆建立新 thread 而非沿用既有會話，導致對話碎片化
 - **影響**: 保持對話脈絡連貫，提升使用者體驗
 
-### ⭐⭐ macOS 字元處理修復 (#11052)
+### ⭐⭐ macOS 字元處理修復 ([#11052](https://github.com/openclaw/openclaw/pull/11052))
 - **用途**: 使用原始字串範圍匹配 CJK/Unicode 字元，修復 trigger trimming 崩潰問題
 - **解決問題**: 事件觸發詞在中文環境下索引越界導致應用崩潰
 - **影響**: 保障 macOS 平台中文使用者的正常使用
 
-### ⭐⭐ Mattermost WebSocket 重試機制 (#14962)
+### ⭐⭐ Mattermost WebSocket 重試機制 ([#14962](https://github.com/openclaw/openclaw/pull/14962))
 - **用途**: 使用指數退避重試 WebSocket 監控連線，異常中斷時清除監控
 - **解決問題**: 單次連線失敗即永久停止監控，需手動重新連線
 - **影響**: 提升 Mattermost 模組穩定性與自動恢復能力
 
-### ⭐⭐ 多路徑代理路由修復 (#15274)
+### ⭐⭐ 多路徑代理路由修復 ([#15274](https://github.com/openclaw/openclaw/pull/15274))
 - **用途**: 強制 peer/guild/team/roles 之間的綁定範圍匹配，防止誤匹配 unrelated 上下文
 - **解決問題**: Discord/Slack 接收者路由錯亂，訊息發送至錯誤頻道
 - **影响**: 保障路由精確性，防止訊息投錯對象
 
-### ⭐⭐ 退出目錄檔案路徑損壞修復 (#15642)
+### ⭐⭐ 退出目錄檔案路徑損壞修復 ([#15642](https://github.com/openclaw/openclaw/pull/15642))
 - **用途**: Windows 平台上正確保留 gateway.cmd 中的字面反斜線，避免 drive 與 UNC 路徑損壞
 - **解決問題**: Windows 環境下路徑被錯誤解析導致 gateway 啟動失敗
 - **影响**: 修復 Windows 平台部署問題，提升跨平台支援
 
-### ⭐⭐ CLI 完整性修復 (#15481)
+### ⭐⭐ CLI 完整性修復 ([#15481](https://github.com/openclaw/openclaw/pull/15481))
 - **用途**: 將 plugin 加載日誌導向 stderr，completion 腳本導向 stdout，避免 source 錯誤
 - **解決問題**: shell completion 腳本因混用輸出流而損壞，導致補齊功能失效
 - **影响**: 恢復 CLI 補全功能，提升開發者體驗
 
-### ⭐⭐ 原生 Markdown 提取增強 (#15376)
+### ⭐⭐ 原生 Markdown 提取增強 ([#15376](https://github.com/openclaw/openclaw/pull/15376))
 - **用途**: 優先接受 text/markdown 回應，新增 Cloudflare Markdown 服務提取，並隱藏 debug log 中的 URL
 - **解決問題**: 服務器傳回 HTML 而非 Markdown，導致解析錯誤或敏感資訊洩漏
 - **影响**: 提升 web_fetch 工具準確性與安全性
 
-### ⭐⭐ 儀表板會話檔案歸檔修復 (#14869)
+### ⭐⭐ 儀表板會話檔案歸檔修復 ([#14869](https://github.com/openclaw/openclaw/pull/14869))
 - **用途**: /new /reset 時歸檔先前的轉錄檔案，避免磁碟累積過期檔案
 - **解決問題**: 會話重置後舊轉錄檔案無限制累積，佔用磁碟空間
 - **影响**: 保持磁碟空間健康，避免無效檔案堆積
 
-### ⭐⭐ Ollama API 版本標準化 (#11853)
+### ⭐⭐ Ollama API 版本標準化 ([#11853](https://github.com/openclaw/openclaw/pull/11853))
 - **用途**: 使用解析後的模型/提供者基礎 URL，統一 /v1 端點，正確轉發 abort 與 maxTokens 流控選項
 - **解決問題**: 不同 Ollama 版本端點不一致，導致流式回應異常
 - **影响**: 提升本地模型支援穩定性，保障 Ollama 部署體驗
 
-### ⭐⭐ 模型選擇器 Spark 識別修復 (#14990)
+### ⭐⭐ 模型選擇器 Spark 識別修復 ([#14990](https://github.com/openclaw/openclaw/pull/14990))
 - **用途**: 修復 model-picker 對 spark 變體的識別邏輯，確保 forward-compat fallback 正確運作
 - **解決問題**: gpt-5.3-codex-spark 無法被正確識別為可用模型
 - **影响**: 恢復企業級模型可用性，保障 Codex 使用體驗
 
-### ⭐⭐ 檔案上傳目標解析強化 (#13578)
+### ⭐⭐ 檔案上傳目標解析強化 ([#13578](https://github.com/openclaw/openclaw/pull/13578))
 - **用途**: 對 Discord/Twitch/Google Chat 回退路徑採用嚴格 fail closed 策略，無效目標直接捨棄而非路由
 - **解決問題**: 無效 target 導致訊息錯誤路由至其他通道
 - **影响**: 降低訊息投遞錯誤機率，提升目標解析可靠性
 
-### ⭐⭐ 簡單文字 MIME 類型修復 (#12237)
+### ⭐⭐ 簡單文字 MIME 類型修復 ([#12237](https://github.com/openclaw/openclaw/pull/12237))
 - **用途**: 將 text/* MIME 類型歸類為 documents，而非 unknown
 - **解決问题**: 純文字附件（.txt、.md 等）被當作未知類型處理，導致發送異常
 - **影响**: 恢復文字附件正常功能，提升多格式支援
 
-### ⭐⭐ Web UI 等號保留修復 (#11547)
+### ⭐⭐ Web UI 等號保留修復 ([#11547](https://github.com/openclaw/openclaw/pull/11547))
 - **用途**: 在輸入文字規範化時保留字面換行符 \n，避免 Windows 路徑損壞
 - **解決问题**: C:\\Work\\nxxx\\README.md 之類路徑被錯誤轉換為 C:\\Work\\xxx\\README.md
 - **影响**: 保障 Windows 路徑正確性，避免指令誤解
 
-### ⭐⭐ 渲染訊息內容保留修復 (#15452)
+### ⭐⭐ 渲染訊息內容保留修復 ([#15452](https://github.com/openclaw/openclaw/pull/15452))
 - **用途**: 在最終負載省略預先工具呼叫文本區塊時保留更豐富的串流助理文本
 - **解決问题**: 工具呼叫後助理訊息被截斷，遺失關鍵內容
 - **影响**: 保障串流輸出完整性，提升使用者體驗
 
-### ⭐⭐ 模型能力限制修復 (#11770)
+### ⭐⭐ 模型能力限制修復 ([#11770](https://github.com/openclaw/openclaw/pull/11770))
 - **用途**: 將 image-analysis 完成時 maxTokens 設為 min(4096, model.maxTokens)，避免超出模型限制
 - **解決问题**: 大圖分析時因 maxTokens 設定過高導致 provider 回傳錯誤
 - **影响**: 修復圖像分析功能，保障 multimodal usage 穩定性
 
-### ⭐⭐ 非heredoc 多行命令阻擋修復 (#13811)
+### ⭐⭐ 非heredoc 多行命令阻擋修復 ([#13811](https://github.com/openclaw/openclaw/pull/13811))
 - **用途**: 在 exec 批准解析中保持阻擋一般多行命令（非heredoc），防止命令鏈注入
 - **解決问题**: 一般多行命令被誤判為安全，導致潛在命令注入漏洞
 - **影响**: 強化命令執行安全邊界，防止注入攻擊
 
-### ⭐⭐ 插件生命週期修復 (#15635)
+### ⭐⭐ 插件生命週期修復 ([#15635](https://github.com/openclaw/openclaw/pull/15635))
 - **用途**: 確保內嵌執行中 before_tool_call 事件僅觸發一次，移除重複派發路徑
 - **解決问题**: 多次觸發��致 plugin 狀態不一致與效能下降
 - **影响**: 提升插件系統穩定性與效能
 
-### ⭐⭐ 會話檔案路徑歸檔修復 (#14869)
+### ⭐⭐ 會話檔案路徑歸檔修復 ([#14869](https://github.com/openclaw/openclaw/pull/14869))
 - **用途**: 在會話重置時歸檔先前的轉錄文件，避免碟片累積過期文件
 - **解決问题**: 會話重置後舊轉錄文件無限制累積，佔用碟片空間
 - **影响**: 保持碟片空間健康，避免無效文件堆積
 
-### ⭐⭐ 檔案上傳檔名修復 (#15594)
+### ⭐⭐ 檔案上傳檔名修復 ([#15594](https://github.com/openclaw/openclaw/pull/15594))
 - **用途**: 在 WhatsApp web-session 发送文件时保留原始檔名，而非全部使用 "file"
 - **解決问题**: 接收端無法辨識文件內容，需額外開啟才能確認
 - **影响**: 提升文件共享體驗，使接收端一目了然
 
-### ⭐⭐ 指令輸入格式修復 (#5042)
+### ⭐⭐ 指令輸入格式修復 ([#5042](https://github.com/openclaw/openclaw/pull/5042))
 - **用途**: 拒絶非字串或不安全的指令 token，同時保留有效的自訂指令可執行檔
 - **解決问题**: 非字串指令導致解析錯誤，影響自訂指令功能
 - **影响**: 保障指令系統穩定，避免配置錯誤導致功能中斷
 
-### ⭐⭐ Config 寫入跨請求 Race 修復 (#11560)
+### ⭐⭐ Config 寫入跨請求 Race 修復 ([#11560](https://github.com/openclaw/openclaw/pull/11560))
 - **用途**: 在 config 寫入時攜帶讀取時間的 env 上下文，防止連線寫入時 race condition
 - **解決问题**: 配置寫入時環境變數快照不同步，導致 ${VAR} 參數遺失
 - **影响**: 保障配置檔案完整性，防止敏感資訊誤寫入
 
-### ⭐⭐ Gateway /tools/invoke 失敗處理修復 (#13185)
+### ⭐⭐ Gateway /tools/invoke 失敗處理修復 ([#13185](https://github.com/openclaw/openclaw/pull/13185))
 - **用途**: 正確回傳 400 作為工具輸入錯誤與 500 作為執行時錯誤，增加回歸測試與文件更新
 - **解決问题**: 錯誤代碼混淆導致 API 消費端難以區分問題類型
 - **影响**: 提升 API 錯誤诊断能力，改善開發體驗

--- a/release-notes/2026-02-14.md
+++ b/release-notes/2026-02-14.md
@@ -59,7 +59,7 @@
 
 ## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ Telegram: add poll sending (#16209)
+### ⭐⭐⭐ Telegram: add poll sending ([#16209](https://github.com/openclaw/openclaw/pull/16209))
 - **用途**：支援透過 openclaw message poll 發送投票
 - **解決問題**：先前無法發送投票
 - **影響**：提供投票功能支援（持續時間秒數、靜默投遞、匿名控制）
@@ -69,39 +69,39 @@
 - **解決問題**：配置名稱不一致
 - **影響**：簡化 DM 配置，保留舊配置支援
 
-### ⭐⭐ Discord: allow exec approval prompts to target channels (#16051)
+### ⭐⭐ Discord: allow exec approval prompts to target channels ([#16051](https://github.com/openclaw/openclaw/pull/16051))
 - **用途**：允許 exec approval prompts 發送到頻道或 DM+頻道
 - **解決問題**：exec approval 只能發送到 DM
-- **影響**：提升 exec approval 的靈活性 (#16051)
+- **影響**：提升 exec approval 的靈活性 ([#16051](https://github.com/openclaw/openclaw/pull/16051))
 
-### ⭐ Sandbox: add sandbox.browser.binds (#16230)
+### ⭐ Sandbox: add sandbox.browser.binds ([#16230](https://github.com/openclaw/openclaw/pull/16230))
 - **用途**：新增 sandbox.browser.binds 用於獨立配置瀏覽器容器的綁定掛載
 - **解決問題**：無法獨立配置瀏覽器和執行容器的綁定掛載
-- **影響**：提升 sandbox 配置的靈活性 (#16230)
+- **影響**：提升 sandbox 配置的靈活性 ([#16230](https://github.com/openclaw/openclaw/pull/16230))
 
-### ⭐ Discord: add debug logging for message routing decisions (#16202)
+### ⭐ Discord: add debug logging for message routing decisions ([#16202](https://github.com/openclaw/openclaw/pull/16202))
 - **用途**：為訊息路由決策添加 debug 日誌
 - **解決問題**：調試時無法看到路由決策原因
-- **影響**：改善 --debug 追蹤能力 (#16202)
+- **影響**：改善 --debug 追蹤能力 ([#16202](https://github.com/openclaw/openclaw/pull/16202))
 
 ---
 
 ## 安全性提升 (Security) - by Star Rating
 
-### ⭐⭐⭐ Security/Memory-LanceDB: treat recalled memories as untrusted (#12524)
+### ⭐⭐⭐ Security/Memory-LanceDB: treat recalled memories as untrusted ([#12524](https://github.com/openclaw/openclaw/pull/12524))
 - **用途**：將召回的記憶視為不受信任的上下文
 - **解決問題**：記憶中毒攻擊風險
 - **影響**：防止記憶中毒，增加記憶處理的安全性
 
-### ⭐⭐⭐ Security/Memory-LanceDB: require explicit autoCapture opt-in (#12552)
+### ⭐⭐⭐ Security/Memory-LanceDB: require explicit autoCapture opt-in ([#12552](https://github.com/openclaw/openclaw/pull/12552))
 - **用途**：需要明確的 autoCapture: true 選項（默認為禁用）
 - **解決問題**：未經選擇自動捕獲 PII
 - **影響**：防止未經意的 PII 捕獲
 
-### ⭐⭐⭐ Security/BlueBubbles: require explicit mediaLocalRoots allowlists (#16322)
+### ⭐⭐⭐ Security/BlueBubbles: require explicit mediaLocalRoots allowlists ([#16322](https://github.com/openclaw/openclaw/pull/16322))
 - **用途**：要求明確的 mediaLocalRoots allowlists 用於本地媒體路徑讀取
 - **解決問題**：本地文件洩漏風險
-- **影響**：防止本地文件意外洩露 (#16322)
+- **影響**：防止本地文件意外洩露 ([#16322](https://github.com/openclaw/openclaw/pull/16322))
 
 ### ⭐⭐⭐ Security/Nostr: require loopback source
 - **用途**：要求 loopback 來源並阻止跨域配置文件變更/導入嘗試
@@ -131,7 +131,7 @@
 ### ⭐⭐ Security/Agents (macOS): prevent shell injection
 - **用途**：寫入 Claude CLI 金鑰鏈憑據時防止 shell 注入
 - **解決問題**：不明確 CLI 參數的 shell 注入
-- **影響**：防止 macOS 上的 Claude CLI 金鑰鏈注入漏洞 (#15924)
+- **影響**：防止 macOS 上的 Claude CLI 金鑰鏈注入漏洞 ([#15924](https://github.com/openclaw/openclaw/pull/15924))
 
 ### ⭐⭐ Security/Gateway: harden tool-supplied gatewayUrl overrides
 - **用途**：限制工具提供的 gatewayUrl 覆蓋到 loopback 或配置的 gateway.remote.url
@@ -187,22 +187,22 @@
 
 ## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐ CLI/Plugins: ensure exit after successful delivery (#16491)
+### ⭐⭐ CLI/Plugins: ensure exit after successful delivery ([#16491](https://github.com/openclaw/openclaw/pull/16491))
 - **用途**：確保 openclaw message send 在成功交付後退出
 - **解決問題**：一次性發送掛起
 - **影響**：防止 CLI 發送命令掛起
 
-### ⭐⭐ CLI/Plugins: run gateway_stop hooks (#16580)
+### ⭐⭐ CLI/Plugins: run gateway_stop hooks ([#16580](https://github.com/openclaw/openclaw/pull/16580))
 - **用途**：在 openclaw message 退出前運行註冊的 plugin gateway_stop hooks
 - **解決問題**：plugin 資源清理不完整
 - **影響**：確保 plugin 支持的渠道清理資源
 
-### ⭐ WhatsApp: honor per-account dmPolicy overrides (#10082)
+### ⭐ WhatsApp: honor per-account dmPolicy overrides ([#10082](https://github.com/openclaw/openclaw/pull/10082))
 - **用途**：遵循每帳戶 dmPolicy 覆蓋
 - **解決問題**：帳戶級別設定未被遵守
 - **影響**：確保帳戶級別 DM 策略正確執行
 
-### ⭐ Telegram: exclude plugin commands when native is false (#15132)
+### ⭐ Telegram: exclude plugin commands when native is false ([#15132](https://github.com/openclaw/openclaw/pull/15132))
 - **用途**：當 channels.telegram.commands.native 為 false 時，排除插件命令
 - **解決問題**：插件命令與原生命令衝突
 - **影響**：確保插件命令正確註冊
@@ -217,17 +217,17 @@
 - **解決問題**：cron 收件人收到摘要而不是完整輸出
 - **影響**：確保完整輸出傳遞到 cron 收件人
 
-### ⭐ Cron/Slack: preserve agent identity (#16242)
+### ⭐ Cron/Slack: preserve agent identity ([#16242](https://github.com/openclaw/openclaw/pull/16242))
 - **用途**：cron 作業傳遞輸出訊息時保留代理身份
 - **解決問題**：cron 發送訊息時丢失身份
 - **影響**：確保 cron 訊息保留代理名稱和圖標
 
-### ⭐ Media: accept MEDIA:-prefixed paths (#13107)
+### ⭐ Media: accept MEDIA:-prefixed paths ([#13107](https://github.com/openclaw/openclaw/pull/13107))
 - **用途**：接受 MEDIA:-prefixed 路徑以防止 ENOENT
 - **解決問題**：工具返回的本地媒體路徑被拒絕
 - **影響**：支援工具返回的媒體路徑
 
-### ⭐ Agents: deliver tool result media (#11735)
+### ⭐ Agents: deliver tool result media ([#11735](https://github.com/openclaw/openclaw/pull/11735))
 - **用途**：Regardless of verbose level，向渠道傳遞工具結果媒體
 - **解決問題**：工具結果媒體未傳遞
 - **影響**：確保工具結果媒體正確傳遞
@@ -242,7 +242,7 @@
 - **解決問題**：長時間處理導致 webhook 500s
 - **影響**：防止 webhook 500s 和重試風暴
 
-### ⭐ Signal: preserve case-sensitive group IDs (#16748)
+### ⭐ Signal: preserve case-sensitive group IDs ([#16748](https://github.com/openclaw/openclaw/pull/16748))
 - **用途**：在规范化期间保留大小寫敏感的 group: target IDs
 - **解決問題**：混合大小寫組 ID 失敗
 - **影響**：確保 Signal 組 ID 正確處理

--- a/release-notes/2026-02-15.md
+++ b/release-notes/2026-02-15.md
@@ -61,30 +61,30 @@
 ### ⭐⭐⭐ Discord Components v2 支援
 - **用途**：在 Discord 中支援原生互動代理提示，包括按鈕、選單、模態框和附件檔案塊
 - **解決問題**：原先無法通過 Discord 使用原生互動功能
-- **影響**：實現 Discord 的豐富互動代理提示能力 (#17486)
+- **影響**：實現 Discord 的豐富互動代理提示能力 ([#17486](https://github.com/openclaw/openclaw/pull/17486))
 - **相關**：Discord Components v2 UI + embeds passthrough + exec approval UX 改進
 
-### ⭐⭐⭐ Subagents: 巢狀子代理 (#14447)
+### ⭐⭐⭐ Subagents: 巢狀子代理 ([#14447](https://github.com/openclaw/openclaw/pull/14447))
 - **用途**：支援巢狀子代理 (sub-sub-agents)，可配置深度
 - **解決問題**：多層代理調用的支援不足
 - **影響**：實現 sub-agents 能 spawn 自己的子代，包含 maxChildrenPerAgent 限制與深度感知工具策略
 
-### ⭐ Plugins: LLM Input/Output Hook Payloads (#16724)
+### ⭐ Plugins: LLM Input/Output Hook Payloads ([#16724](https://github.com/openclaw/openclaw/pull/16724))
 - **用途**：暴露 llm_input 和 llm_output hook payload，使擴展可以觀察提示/輸入上下文和模型輸出使用細節
 - **解決問題**：擴展無法觀測模型調用的內部細節
 - **影響**：提升擴展可見性與除錯能力
 
-### ⭐ Slack/Discord/Telegram: 每頻道 ack 反應覆蓋 (#17092)
+### ⭐ Slack/Discord/Telegram: 每頻道 ack 反應覆蓋 ([#17092](https://github.com/openclaw/openclaw/pull/17092))
 - **用途**：支援每頻道的 ack reaction 覆蓋，以支持平台特定的 emoji 格式
 - **解決問題**：不同平台的 emoji 格式不兼容
 - **影響**：提升平台特定的用戶體驗
 
-### ⭐ Cron/Gateway: Webhook 遞送控制 (#14535)
+### ⭐ Cron/Gateway: Webhook 遞送控制 ([#14535](https://github.com/openclaw/openclaw/pull/14535))
 - **用途**：新增完成 run webhook 遞送開關 (notify) 與專用 webhook auth token 支援 (cron.webhookToken)
 - **解決問題**：缺乏 webhook 遞送的精細控制
 - **影響**：提升 webhook 安全性與靈活性
 
-### ⭐ Channels: 減少探針/Token 解析冗餘 (#16986)
+### ⭐ Channels: 減少探針/Token 解析冗餘 ([#16986](https://github.com/openclaw/openclaw/pull/16986))
 - **用途**：在核心與擴展之間減去探針/token 解析基類的冗餘，同時保留每頻道錯誤類型
 - **解決問題**：核心與擴展間的程式碼重複
 - **影響**：提高代碼維護性與一致性
@@ -116,12 +116,12 @@
 ### ⭐⭐ Gateway/Security: 敏感資訊脫敏
 - **用途**：從非管理用戶的狀態回應中脫敏敏感會話/路徑細節
 - **解決問題**：敏感資訊可能被非管理用戶讀取
-- **影響**：實現最小權限原則 (#8590)
+- **影響**：實現最小權限原則 ([#8590](https://github.com/openclaw/openclaw/pull/8590))
 
 ### ⭐⭐ Gateway/Chat: 聊天.send 輸入處理增強
 - **用途**：增強 chat.send 輸入訊息處理，拒絕 null bytes，去除不安全的控制字符，並在派發前將 Unicode 正規化為 NFC
 - **解決問題**：非法字符可能導致處理錯誤
-- **影響**：防止字符處理異常 (#8593)
+- **影響**：防止字符處理異常 ([#8593](https://github.com/openclaw/openclaw/pull/8593))
 
 ### ⭐⭐ Skills/Security: 限制安裝程序 targetDir
 - **用途**：限制下載安裝程序的 targetDir 到每技能 tools 目錄
@@ -131,7 +131,7 @@
 ### ⭐⭐ Group chats: 每個 turn 注入群組聊天上下文
 - **用途**：每次 turn 注入群組聊天上下文 (名稱、參與者、回覆指導)
 - **解決問題**：模型失去對群組的意識，錯誤地使用 message tool 發送到同一群組
-- **影響**：確保群組聊天的正確上下文感知 (#14447)
+- **影響**：確保群組聊天的正確上下文感知 ([#14447](https://github.com/openclaw/openclaw/pull/14447))
 
 ### ⭐ Sandbox: 保留陣列順序於配置雜湊
 - **用途**：在配置雜湊中保留陣列順序，使順序敏感的 Docker 瀏覽器設置能正確觸發容器重建
@@ -141,17 +141,17 @@
 ### ⭐ Gateway/Control UI: 操作範圍保留
 - **用途**：當設備身份不可用時，保留 Control UI bypass mode 的操作範圍設定
 - **解決問題**：代理端失敗時導致 false missing scope 失敗
-- **影響**：防止 LAN/HTTP 代理會話的誤失敗 (#17682)
+- **影響**：防止 LAN/HTTP 代理會話的誤失敗 ([#17682](https://github.com/openclaw/openclaw/pull/17682))
 
 ### ⭐ LINE/Security: Webhook 啟動失敗關閉
 - **用途**：當 channel token 或 channel secret 缺失時，webhook 啟動時 fail closed
 - **解決問題**：LINE 帳戶可能被錯誤地認為已配置
-- **影響**：防止未正確配置的 LINE 帳戶運行 (#17587)
+- **影響**：防止未正確配置的 LINE 帳戶運行 ([#17587](https://github.com/openclaw/openclaw/pull/17587))
 
 ### ⭐ Skills/Linux: 增強 go 安裝程序
 - **用途**：在 apt-based 系統上增強 go 安裝程序的 fallback，安全處理 root/no-sudo 環境
 - **解決問題**：無 sudo 權限時安裝失敗
-- **影響**：改善 Linux 環境下的安裝可靠性 (#17687)
+- **影響**：改善 Linux 環境下的安裝可靠性 ([#17687](https://github.com/openclaw/openclaw/pull/17687))
 
 ### ⭐ Web Fetch/Security: 限制回應主體大小
 - **用途**：在 HTML 解析前限制下載的回應主體大小
@@ -161,7 +161,7 @@
 ### ⭐ Config/Gateway: 敏感鍵匹配不區分大小寫
 - **用途**：使敏感鍵白名單後綴匹配不區分大小寫，同時保留 passwordFile 路徑豁免
 - **解決問題**：非秘密配置值 (如 maxTokens) 被誤判
-- **影響**：防止誤判而導致非敏感配置被錯誤脱敏 (#16042)
+- **影響**：防止誤判而導致非敏感配置被錯誤脱敏 ([#16042](https://github.com/openclaw/openclaw/pull/16042))
 
 ### ⭐ Dev Tooling: Git Pre-commit Hook 增強
 - **用途**：增強 git pre-commit hook 以對抗恶意文件名稱選項注入 (如 --force)
@@ -171,12 +171,12 @@
 ### ⭐ Gateway/Agent: 拒絕格式錯誤的 Session Keys
 - **用途**：拒絕格式錯誤的 agent:-prefixed session keys (如 agent:main)
 - **解決問題**：意外的跨 session 路由
-- **影響**：防止意外的跨 session 路由 (#15707)
+- **影響**：防止意外的跨 session 路由 ([#15707](https://github.com/openclaw/openclaw/pull/15707))
 
 ### ⭐ Gateway/Send: Webchat 目��錯誤處理
 - **用途**：當 send 目標為內部 only 的 webchat 時，返回可操作錯誤，引導調用者使用 chat.send 或可遞送的頻道
 - **解決問題**：內部渠道的誤用
-- **影響**：防止混淆的渠道使用 (#15703)
+- **影響**：防止混淆的渠道使用 ([#15703](https://github.com/openclaw/openclaw/pull/15703))
 
 ### ⭐ Agents/Security: 清理工作區路徑
 - **用途**：在嵌入 LLM 提示前清理工作區路徑 (去除 Unicode 控制/格式字符)
@@ -186,32 +186,32 @@
 ### ⭐ Agents/Sandbox: 澄清系統提示路徑
 - **用途**：澄清系統提示路徑指導，使 sandbox bash/exec 使用容器路徑 (如 /workspace)，而檔案工具保持主機橋接映射
 - **解決問題**：主機絕對路徑導致第一次嘗試失敗
-- **影響**：避免路徑解析錯誤 (#17693)
+- **影響**：避免路徑解析錯誤 ([#17693](https://github.com/openclaw/openclaw/pull/17693))
 
 ### ⭐ Agents/Context: ContextWindow 覆蓋後置應用
 - **用途**：在提供商發現後應用配置的 model contextWindow 覆蓋
 - **解決問題**：lookupContextTokens() 忽略操作器配置值
-- **影響**：確保配置值被正確使用 (#17404)
+- **影響**：確保配置值被正確使用 ([#17404](https://github.com/openclaw/openclaw/pull/17404))
 
 ### ⭐ Agents/OpenAI: 為直接 OpenAI Responses/Codex 強制 store=true
 - **用途**：為直接 OpenAI Responses/Codex 強制 store=true，以保留多輪 server-side 對話狀態
 - **解決問題**：缺少 store=true 導致對話狀態遺失
-- **影響**：確保 OpenAI Responses/Codex 的多輪對話State (#16803)
+- **影響**：確保 OpenAI Responses/Codex 的多輪對話State ([#16803](https://github.com/openclaw/openclaw/pull/16803))
 
 ### ⭐ Memory/FTS: Unicode-aware 查詢
 - **用途**：使 buildFtsQuery Unicode-aware，這樣非 ASCII 查詢 (包括 CJK) 產生關鍵字記號而不是回退到僅 vector search
 - **解決問題**：非 ASCII 查詢回退到向量搜尋
-- **影響**：提升非英文字元的搜尋品質 (#17672)
+- **影響**：提升非英文字元的搜尋品質 ([#17672](https://github.com/openclaw/openclaw/pull/17672))
 
 ### ⭐ Agents: 為嵌入式 run 超時返回明確超時錯誤
 - **用途**：在嵌入式 run 超時前產生任何 payload 時，返回明確的超時錯誤回應
 - **解決問題**：緩慢的快取刷新轉換期間的 silent dropped turns
-- **影響**：防止 silent dropped turns (#16659)
+- **影響**：防止 silent dropped turns ([#16659](https://github.com/openclaw/openclaw/pull/16659))
 
 ### ⭐ Browser/Agents: 當瀏覽器控制服務不可用時返回明確非重試指導
 - **用途**：當瀏覽器控制服務不可用時，返回明確的非重試指導 (而不是 "try again")
 - **解決問題**：模型在反覆瀏覽器工具調用時直到超時
-- **影響**：防止無限循環 (#17673)
+- **影響**：防止無限循環 ([#17673](https://github.com/openclaw/openclaw/pull/17673))
 
 ---
 
@@ -220,37 +220,37 @@
 ### ⭐⭐⭐ Telegram: DM 傳送省略 message_thread_id
 - **用途**：為 DM 傳送與草稿預覽省略 message_thread_id，並保留論壇主題處理
 - **解決問題**：DM 傳送時出現 400 Bad Request: message thread not found
-- **影響**：修復 DM 傳送失敗 (#10942)
+- **影響**：修復 DM 傳送失敗 ([#10942](https://github.com/openclaw/openclaw/pull/10942))
 
 ### ⭐⭐⭐ Telegram: 重試傳入媒體getFile
 - **用途**：重試傳入媒體 getFile 呼叫 (3 次重試，帶退避)，並在重試失敗時溫和回退到佔位符處理
 - **解決問題**：傳輸 Telegram 網路錯誤時傳入媒體/語音訊息遺失
-- **影響**：防止媒體訊息遺失 (#16154)
+- **影響**：防止媒體訊息遺失 ([#16154](https://github.com/openclaw/openclaw/pull/16154))
 
 ### ⭐⭐⭐ Telegram: 原地完成 Streaming Preview 回覆
 - **用途**：原地完成 streaming preview 回覆，而不是發送第二個最終訊息
 - **解決問題**：streaming 完成時出現重複的 Telegram 助手輸出
-- **影響**：避免重複訊息 (#17218)
+- **影響**：避免重複訊息 ([#17218](https://github.com/openclaw/openclaw/pull/17218))
 
 ### ⭐⭐ Memory/QMD: 範圍聚集名稱
 - **用途**：為每個代理範圍管理的集合名稱，並在註冊前預創建 glob-backed 集合目錄
 - **解決問題**：跨代理集合衝突與新工作區的 ENOENT 失敗
-- **影響**：防止集合衝突與啟動失敗 (#17194)
+- **影響**：防止集合衝突與啟動失敗 ([#17194](https://github.com/openclaw/openclaw/pull/17194))
 
 ### ⭐⭐ Telegram: 禁用 Block Streaming
 - **用途**：當 channels.telegram.streamMode 為 off 時禁用 block streaming
 - **解決問題**：新行/內容塊回應在 streamMode = off 時被分割成多個訊息
-- **影響**：防止非流式傳輸的訊息分割 (#17679)
+- **影響**：防止非流式傳輸的訊息分割 ([#17679](https://github.com/openclaw/openclaw/pull/17679))
 
 ### ⭐⭐ Discord: 保留 Channel Session 連續性
 - **用途**：當 runtime payload 省略 message.channelId 時，回退到 event/raw channel_id 值進行路由/session keys
 - **解決問題**：相同頻道的訊息在 turn/restarts 間失去歷史
-- **影響**：保持 channel session 連續性 (#17622)
+- **影響**：保持 channel session 連續性 ([#17622](https://github.com/openclaw/openclaw/pull/17622))
 
 ### ⭐ Discord: 根據技能名稱去重原生技能命令
 - **用途**：在多代理設置中根據技能名稱去重原生技能命令
 - **解決問題**：出現帶有 _2 後綴的重複斜線命令
-- **影響**：避免命令重複 (#17365)
+- **影響**：避免命令重複 ([#17365](https://github.com/openclaw/openclaw/pull/17365))
 
 ### ⭐ Discord: Role Allowlist 匹配原始 Role ID
 - **用途**：確保 role allowlist 匹配使用原始 role ID 進行訊息路由授權
@@ -260,17 +260,17 @@
 ### ⭐ Web UI/Agents: 隱藏完成启動後的 BOOTSTRAP.md
 - **用途**：在启動完成後隱藏 Agents Files list 中的 BOOTSTRAP.md
 - **解決問題**：已完成工作區的混淆 missing-file 警告
-- **影響**：改善啟動工作區體驗 (#17491)
+- **影響**：改善啟動工作區體驗 ([#17491](https://github.com/openclaw/openclaw/pull/17491))
 
 ### ⭐ Auto-reply/WhatsApp/TUI/Web: NO_REPLY 反饋
 - **用途**：當最終助手訊息為 NO_REPLY 且訊息工具送信成功時，將送信的訊息文字鏡像到 session-visible 助手輸出
 - **解決問題**：TUI/Web 顯示 NO_REPLY 占位符
-- **影響**：改善 TUI/Web 的使用者體驗 (#7010)
+- **影響**：改善 TUI/Web 的使用者體驗 ([#7010](https://github.com/openclaw/openclaw/pull/7010))
 
 ### ⭐ Gateway/Agent: 拒絕格式錯誤的 Session Keys
 - **用途**：在 agent 和 agent.identity.get 中拒绝格式错误的 agent:-prefixed session keys (如 agent:main)
 - **解決問題**：silent 到達 default agent 的跨 session 路由
-- **影響**：防止意外的跨 session 路由 (#15707)
+- **影響**：防止意外的跨 session 路由 ([#15707](https://github.com/openclaw/openclaw/pull/15707))
 
 ### ⭐ Memory/QMD: 代理範圍的集合名稱
 - **用途**：為每個代理範圍管理的集合名稱，並在註冊前預創建 glob-backed 集合目錄

--- a/release-notes/2026-02-17.md
+++ b/release-notes/2026-02-17.md
@@ -5,193 +5,193 @@
 ## 概述
 
 ### 功能更新 (Features)
-- ⭐⭐⭐ iOS 分享擴充：分享 URL/文字/圖片可直接轉送到 Gateway `agent.request` (#19424)
-- ⭐⭐⭐ Slack 原生單則訊息串流（startStream/appendStream/stopStream），失敗自動降級 (#9972)
-- ⭐⭐⭐ 新增 `/subagents spawn` 指令：可從聊天指令確定性啟動 subagent (#18218)
-- ⭐⭐ iOS Talk：可關閉「Voice Directive Hint」以節省 token（避免不必要的語音切換指示）(#18250)
-- ⭐⭐ Slack：新增可設定的串流模式以支援 draft preview 情境 (#18555)
-- ⭐⭐ Telegram：inline button `style`（primary/success/danger）支援 (#18241)
-- ⭐⭐ Cron：每次 run 記錄 model/provider 用量 telemetry，並提供本地彙總腳本 (#18172)
-- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist (#18584)
-- ⭐ Browser：新增 `extraArgs` 以傳入自訂 Chrome 啟動參數 (#18443)
-- ⭐ Docker：新增 `OPENCLAW_INSTALL_BROWSER` build arg 以預裝 Chromium + Xvfb (#18449)
+- ⭐⭐⭐ iOS 分享擴充：分享 URL/文字/圖片可直接轉送到 Gateway `agent.request` ([#19424](https://github.com/openclaw/openclaw/pull/19424))
+- ⭐⭐⭐ Slack 原生單則訊息串流（startStream/appendStream/stopStream），失敗自動降級 ([#9972](https://github.com/openclaw/openclaw/pull/9972))
+- ⭐⭐⭐ 新增 `/subagents spawn` 指令：可從聊天指令確定性啟動 subagent ([#18218](https://github.com/openclaw/openclaw/pull/18218))
+- ⭐⭐ iOS Talk：可關閉「Voice Directive Hint」以節省 token（避免不必要的語音切換指示）([#18250](https://github.com/openclaw/openclaw/pull/18250))
+- ⭐⭐ Slack：新增可設定的串流模式以支援 draft preview 情境 ([#18555](https://github.com/openclaw/openclaw/pull/18555))
+- ⭐⭐ Telegram：inline button `style`（primary/success/danger）支援 ([#18241](https://github.com/openclaw/openclaw/pull/18241))
+- ⭐⭐ Cron：每次 run 記錄 model/provider 用量 telemetry，並提供本地彙總腳本 ([#18172](https://github.com/openclaw/openclaw/pull/18172))
+- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
+- ⭐ Browser：新增 `extraArgs` 以傳入自訂 Chrome 啟動參數 ([#18443](https://github.com/openclaw/openclaw/pull/18443))
+- ⭐ Docker：新增 `OPENCLAW_INSTALL_BROWSER` build arg 以預裝 Chromium + Xvfb ([#18449](https://github.com/openclaw/openclaw/pull/18449))
 
 ### 安全性提升 (Security)
-- ⭐⭐⭐ 修補 OC-09：阻擋 exec 環境變數注入造成的憑證竊取路徑 (#18048)
-- ⭐⭐⭐ 強化 `$include`：限制 include 解析在頂層 config 目錄並防穿越/符號連結 (#18652)
-- ⭐⭐ Cron/Gateway：分離 per-job webhook delivery（`delivery.mode=webhook`）並驗證 HTTP(S) URL (#17901)
-- ⭐⭐ Discord/Telegram：讓 per-account message action gates 同時約束 listing 與 execution (#18494)
-- ⭐⭐ Auto-reply：trusted inbound metadata 加入 `sender_id` 便於後續審核/封鎖流程 (#18303)
-- ⭐⭐ Agents/Image：提交前驗證 base64 image payloads (#18263)
-- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist (#18584)
-- ⭐ Models CLI：驗證 `openclaw models set` catalog entries (#18129)
-- ⭐ Discord/Commands：allowFrom 正規化（支援 user:/discord: 前綴與 mention）(#18042)
-- ⭐ Config/Discord：強制 allowlists 使用字串 ID 並提供 doctor repair (#18220)
+- ⭐⭐⭐ 修補 OC-09：阻擋 exec 環境變數注入造成的憑證竊取路徑 ([#18048](https://github.com/openclaw/openclaw/pull/18048))
+- ⭐⭐⭐ 強化 `$include`：限制 include 解析在頂層 config 目錄並防穿越/符號連結 ([#18652](https://github.com/openclaw/openclaw/pull/18652))
+- ⭐⭐ Cron/Gateway：分離 per-job webhook delivery（`delivery.mode=webhook`）並驗證 HTTP(S) URL ([#17901](https://github.com/openclaw/openclaw/pull/17901))
+- ⭐⭐ Discord/Telegram：讓 per-account message action gates 同時約束 listing 與 execution ([#18494](https://github.com/openclaw/openclaw/pull/18494))
+- ⭐⭐ Auto-reply：trusted inbound metadata 加入 `sender_id` 便於後續審核/封鎖流程 ([#18303](https://github.com/openclaw/openclaw/pull/18303))
+- ⭐⭐ Agents/Image：提交前驗證 base64 image payloads ([#18263](https://github.com/openclaw/openclaw/pull/18263))
+- ⭐ Tools/Web：`web_search`/`web_fetch` URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
+- ⭐ Models CLI：驗證 `openclaw models set` catalog entries ([#18129](https://github.com/openclaw/openclaw/pull/18129))
+- ⭐ Discord/Commands：allowFrom 正規化（支援 user:/discord: 前綴與 mention）([#18042](https://github.com/openclaw/openclaw/pull/18042))
+- ⭐ Config/Discord：強制 allowlists 使用字串 ID 並提供 doctor repair ([#18220](https://github.com/openclaw/openclaw/pull/18220))
 
 ### 錯誤修復 (Bug Fixes)
-- ⭐⭐⭐ iOS Onboarding：停止未授權錯誤造成的重試迴圈/狀態抖動 (#19153)
-- ⭐⭐⭐ Voice-call：媒體流斷線時自動結束通話避免卡住 (#18435)
-- ⭐⭐ Voice call/Gateway：避免 turn race、強化 transcript 去重與 latency 統計穩健性 (#19140)
-- ⭐⭐ iOS/Chat：ChatSheet RPC 改走 operator session，避免 node-role 授權失敗 (#19320)
-- ⭐⭐ Telegram：DM 語音訊息轉寫（含 CLI fallback）(#18564)
-- ⭐ Telegram/Polls：恢復 Telegram poll action wiring (#18122)
-- ⭐ WebChat：移除渲染輸出中的 reply/audio directive tags (#18093)
-- ⭐ Discord：修正 HTTP proxy 設定未被 REST 解析流程使用 (#17958)
-- ⭐ CLI/Doctor：`--fix --non-interactive --yes` 完成後可正常結束不再掛住 (#18502)
-- ⭐ Media understanding：遵守 `agents.defaults.imageModel` 以套用設定的主要/備援影像模型 (#7607)
+- ⭐⭐⭐ iOS Onboarding：停止未授權錯誤造成的重試迴圈/狀態抖動 ([#19153](https://github.com/openclaw/openclaw/pull/19153))
+- ⭐⭐⭐ Voice-call：媒體流斷線時自動結束通話避免卡住 ([#18435](https://github.com/openclaw/openclaw/pull/18435))
+- ⭐⭐ Voice call/Gateway：避免 turn race、強化 transcript 去重與 latency 統計穩健性 ([#19140](https://github.com/openclaw/openclaw/pull/19140))
+- ⭐⭐ iOS/Chat：ChatSheet RPC 改走 operator session，避免 node-role 授權失敗 ([#19320](https://github.com/openclaw/openclaw/pull/19320))
+- ⭐⭐ Telegram：DM 語音訊息轉寫（含 CLI fallback）([#18564](https://github.com/openclaw/openclaw/pull/18564))
+- ⭐ Telegram/Polls：恢復 Telegram poll action wiring ([#18122](https://github.com/openclaw/openclaw/pull/18122))
+- ⭐ WebChat：移除渲染輸出中的 reply/audio directive tags ([#18093](https://github.com/openclaw/openclaw/pull/18093))
+- ⭐ Discord：修正 HTTP proxy 設定未被 REST 解析流程使用 ([#17958](https://github.com/openclaw/openclaw/pull/17958))
+- ⭐ CLI/Doctor：`--fix --non-interactive --yes` 完成後可正常結束不再掛住 ([#18502](https://github.com/openclaw/openclaw/pull/18502))
+- ⭐ Media understanding：遵守 `agents.defaults.imageModel` 以套用設定的主要/備援影像模型 ([#7607](https://github.com/openclaw/openclaw/pull/7607))
 
 ## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ iOS 分享擴充：分享內容直送 Gateway `agent.request` (#19424)
+### ⭐⭐⭐ iOS 分享擴充：分享內容直送 Gateway `agent.request` ([#19424](https://github.com/openclaw/openclaw/pull/19424))
 - **用途**: 讓 iOS 使用者從系統分享面板直接把 URL/文字/圖片交給 OpenClaw。
 - **解決問題**: 過去需手動複製貼上或透過其他中繼流程，分享摩擦高。
 - **影響**: 降低「隨手丟給代理」成本，強化行動端工作流。
 
-### ⭐⭐⭐ Slack 原生單則訊息串流 (#9972)
+### ⭐⭐⭐ Slack 原生單則訊息串流 ([#9972](https://github.com/openclaw/openclaw/pull/9972))
 - **用途**: 以 Slack 串流 API 在同一則訊息內即時追加內容。
 - **解決問題**: 過去可能拆成多則訊息，thread 對齊與閱讀性較差。
 - **影響**: 串流體驗更一致，且失敗時可自動回退確保可靠投遞。
 
-### ⭐⭐⭐ `/subagents spawn` 聊天指令 (#18218)
+### ⭐⭐⭐ `/subagents spawn` 聊天指令 ([#18218](https://github.com/openclaw/openclaw/pull/18218))
 - **用途**: 從指令介面直接、可預期地啟動 subagent。
 - **解決問題**: 過去啟動 subagent 較仰賴工具或模型自行決策，不易控管。
 - **影響**: 提升長任務/專用子流程的可控性與可重現性。
 
-### ⭐⭐ iOS Talk：Voice Directive Hint 可關閉 (#18250)
+### ⭐⭐ iOS Talk：Voice Directive Hint 可關閉 ([#18250](https://github.com/openclaw/openclaw/pull/18250))
 - **用途**: 允許使用者關閉 Talk Mode 中的語音指示提示。
 - **解決問題**: 若不使用 ElevenLabs/不需要語音切換指示，提示會增加 token 成本。
 - **影響**: 讓 Talk Mode 更可依需求「省 token」。
 
-### ⭐⭐ Slack：可設定串流模式以支援 draft preview (#18555)
+### ⭐⭐ Slack：可設定串流模式以支援 draft preview ([#18555](https://github.com/openclaw/openclaw/pull/18555))
 - **用途**: 提供可配置的串流行為模式。
 - **解決問題**: 不同團隊對「草稿預覽」與「最終輸出」的串流策略需求不同。
 - **影響**: 讓 Slack 端串流更可調，降低誤用與體驗不一致。
 
-### ⭐⭐ Telegram：inline button `style` 支援 (#18241)
+### ⭐⭐ Telegram：inline button `style` 支援 ([#18241](https://github.com/openclaw/openclaw/pull/18241))
 - **用途**: 支援 `primary|success|danger` 按鈕樣式，貫通 schema/解析/送信管線。
 - **解決問題**: 重要操作缺乏視覺層級，不易凸顯。
 - **影響**: 互動介面更清楚，降低誤觸。
 
-### ⭐⭐ Cron：run 用量 telemetry + 彙總腳本 (#18172)
+### ⭐⭐ Cron：run 用量 telemetry + 彙總腳本 ([#18172](https://github.com/openclaw/openclaw/pull/18172))
 - **用途**: 在 cron run log/webhook 中記錄 model/provider 用量，並提供本地彙總。
 - **解決問題**: 缺乏 per-job 成本/用量可觀測性，難以優化與控管。
 - **影響**: 更容易找出高成本任務並進行調整。
 
-### ⭐ Tools/Web：URL allowlist (#18584)
+### ⭐ Tools/Web：URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
 - **用途**: 允許限制 `web_search`/`web_fetch` 可存取的 URL 範圍。
 - **解決問題**: 在受控環境中需避免抓取不可信來源或內網風險。
 - **影響**: 讓 Web 工具更容易符合企業/個人安全政策。
 
-### ⭐ Browser：Chrome `extraArgs` (#18443)
+### ⭐ Browser：Chrome `extraArgs` ([#18443](https://github.com/openclaw/openclaw/pull/18443))
 - **用途**: 允許自訂 Chromium/Chrome 啟動參數。
 - **解決問題**: 需要代理、旗標或相容性參數時缺乏正式入口。
 - **影響**: 提升瀏覽器自動化在多環境部署的彈性。
 
-### ⭐ Docker：`OPENCLAW_INSTALL_BROWSER` 預裝 Chromium + Xvfb (#18449)
+### ⭐ Docker：`OPENCLAW_INSTALL_BROWSER` 預裝 Chromium + Xvfb ([#18449](https://github.com/openclaw/openclaw/pull/18449))
 - **用途**: Docker build 時可選擇預裝瀏覽器與顯示環境。
 - **解決問題**: 避免 runtime Playwright 安裝造成啟動慢、失敗率高或網路受限問題。
 - **影響**: 容器化部署更穩定、啟動更快。
 
 ## 安全性提升 (Security) - by Star Rating
 
-### ⭐⭐⭐ 修補 OC-09：憑證竊取路徑修補 (#18048)
+### ⭐⭐⭐ 修補 OC-09：憑證竊取路徑修補 ([#18048](https://github.com/openclaw/openclaw/pull/18048))
 - **用途**: 修補 exec 相關的 credential-theft 攻擊面。
 - **解決問題**: 惡意輸入可能透過環境變數注入影響執行內容，造成憑證外洩風險。
 - **影響**: 降低高風險攻擊面，對自動化/遠端執行尤為關鍵。
 
-### ⭐⭐⭐ `$include` 解析限制與路徑防護強化 (#18652)
+### ⭐⭐⭐ `$include` 解析限制與路徑防護強化 ([#18652](https://github.com/openclaw/openclaw/pull/18652))
 - **用途**: 將 `$include` 解析限制在頂層 config 目錄，並強化 traversal/symlink 檢查。
 - **解決問題**: 若 include 可跨目錄解析，可能造成讀取不該被讀取的檔案。
 - **影響**: 強化配置層面的檔案存取邊界。
 
-### ⭐⭐ Cron webhook delivery 模式拆分與 URL 驗證 (#17901)
+### ⭐⭐ Cron webhook delivery 模式拆分與 URL 驗證 ([#17901](https://github.com/openclaw/openclaw/pull/17901))
 - **用途**: 分離 per-job webhook 與 announce，並驗證 webhook URL 為有效 HTTP(S)。
 - **解決問題**: 混用模式與弱驗證可能造成誤送或不安全 URL。
 - **影響**: cron 外送更可控、更安全。
 
-### ⭐⭐ Discord/Telegram：per-account action gates 生效於 listing + execution (#18494)
+### ⭐⭐ Discord/Telegram：per-account action gates 生效於 listing + execution ([#18494](https://github.com/openclaw/openclaw/pull/18494))
 - **用途**: 將動作閘門一致套用到「可見性」與「實際執行」。
 - **解決問題**: 僅限制一端會造成權限行為不一致。
 - **影響**: 降低越權與配置誤解風險。
 
-### ⭐⭐ trusted inbound metadata 加入 `sender_id` (#18303)
+### ⭐⭐ trusted inbound metadata 加入 `sender_id` ([#18303](https://github.com/openclaw/openclaw/pull/18303))
 - **用途**: 讓後續 moderation/流程能以可信 sender_id 進行定位。
 - **解決問題**: 依賴不可信文本取得 sender 資訊可能被偽造。
 - **影響**: 提升審核/封鎖等自動化工作流的正確性。
 
-### ⭐⭐ base64 image payloads 驗證 (#18263)
+### ⭐⭐ base64 image payloads 驗證 ([#18263](https://github.com/openclaw/openclaw/pull/18263))
 - **用途**: 送往 provider 前先驗證影像 payload。
 - **解決問題**: 非法/破損 payload 可能造成 provider 錯誤或不可預期行為。
 - **影響**: 降低錯誤面，並改善對外部服務互動的健壯性。
 
-### ⭐ Tools/Web：URL allowlist (#18584)
+### ⭐ Tools/Web：URL allowlist ([#18584](https://github.com/openclaw/openclaw/pull/18584))
 - **用途**: 以 allowlist 方式限制 web 工具存取範圍。
 - **解決問題**: 避免不必要的外部抓取風險。
 - **影響**: 強化可控性，便於合規。
 
-### ⭐ `openclaw models set` catalog 驗證 (#18129)
+### ⭐ `openclaw models set` catalog 驗證 ([#18129](https://github.com/openclaw/openclaw/pull/18129))
 - **用途**: 對 models CLI 的 catalog entries 加入驗證。
 - **解決問題**: 錯誤 catalog 可能導致使用到非預期模型或失敗路徑。
 - **影響**: 降低配置錯誤造成的行為偏差與風險。
 
-### ⭐ Discord allowFrom 正規化 (#18042)
+### ⭐ Discord allowFrom 正規化 ([#18042](https://github.com/openclaw/openclaw/pull/18042))
 - **用途**: 統一 allowFrom 格式（支援前綴與 mention）。
 - **解決問題**: 格式落差會導致授權判斷不一致。
 - **影響**: 權限控管更可預期。
 
-### ⭐ Discord allowlists string ID + doctor repair (#18220)
+### ⭐ Discord allowlists string ID + doctor repair ([#18220](https://github.com/openclaw/openclaw/pull/18220))
 - **用途**: 強制使用字串 ID 並提供修復。
 - **解決問題**: 數字型態差異可能造成解析/比對錯誤。
 - **影響**: 降低因配置錯誤造成的授權風險。
 
 ## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐⭐ iOS Onboarding：停止重試迴圈與狀態抖動 (#19153)
+### ⭐⭐⭐ iOS Onboarding：停止重試迴圈與狀態抖動 ([#19153](https://github.com/openclaw/openclaw/pull/19153))
 - **用途**: 未授權/缺 token 時暫停重連並保持狀態可手動重試。
 - **解決問題**: 持續重試會造成電量消耗與使用者困惑。
 - **影響**: 配對/授權流程更穩定。
 
-### ⭐⭐⭐ Voice-call：媒體流斷線自動結束 (#18435)
+### ⭐⭐⭐ Voice-call：媒體流斷線自動結束 ([#18435](https://github.com/openclaw/openclaw/pull/18435))
 - **用途**: 在媒體斷線時自動清理通話狀態。
 - **解決問題**: 通話可能卡在「仍在通話中」造成後續操作失敗。
 - **影響**: 降低 stuck call、提升通話可靠性。
 
-### ⭐⭐ Voice call/Gateway：turn lock、transcript 去重與 latency 統計強化 (#19140)
+### ⭐⭐ Voice call/Gateway：turn lock、transcript 去重與 latency 統計強化 ([#19140](https://github.com/openclaw/openclaw/pull/19140))
 - **用途**: 加鎖避免重疊回合競態，並改進統計與去重策略。
 - **解決問題**: 競態可能造成重複轉錄、狀態錯亂或統計崩潰。
 - **影響**: 提升語音通話穩定性與可觀測性。
 
-### ⭐⭐ iOS/Chat：ChatSheet RPC 走 operator session (#19320)
+### ⭐⭐ iOS/Chat：ChatSheet RPC 走 operator session ([#19320](https://github.com/openclaw/openclaw/pull/19320))
 - **用途**: 調整 RPC 路由以符合權限模型。
 - **解決問題**: 走 node session 可能導致 `chat.history/chat.send/sessions.list` 授權失敗。
 - **影響**: iOS ChatSheet 功能更可靠。
 
-### ⭐⭐ Telegram：DM 語音訊息轉寫 (#18564)
+### ⭐⭐ Telegram：DM 語音訊息轉寫 ([#18564](https://github.com/openclaw/openclaw/pull/18564))
 - **用途**: 啟用 DM voice-note transcription，並提供 CLI fallback。
 - **解決問題**: 轉寫缺失會降低語音訊息可搜尋性與可讀性。
 - **影響**: 改善 Telegram DM 的語音工作流。
 
-### ⭐ Telegram/Polls：poll action wiring 復原 (#18122)
+### ⭐ Telegram/Polls：poll action wiring 復原 ([#18122](https://github.com/openclaw/openclaw/pull/18122))
 - **用途**: 修復 Telegram poll actions 的 handler 接線。
 - **解決問題**: 互動投票失效會中斷自動化/互動流程。
 - **影響**: 恢復 Telegram 投票功能可用性。
 
-### ⭐ WebChat：移除 reply/audio directive tags (#18093)
+### ⭐ WebChat：移除 reply/audio directive tags ([#18093](https://github.com/openclaw/openclaw/pull/18093))
 - **用途**: 清理 UI 渲染中的指令標籤。
 - **解決問題**: 標籤外露會干擾閱讀與前端呈現。
 - **影響**: WebChat 顯示更乾淨。
 
-### ⭐ Discord：HTTP proxy 設定生效於 REST 解析 (#17958)
+### ⭐ Discord：HTTP proxy 設定生效於 REST 解析 ([#17958](https://github.com/openclaw/openclaw/pull/17958))
 - **用途**: 讓 proxy 設定被 app-id/allowlist REST resolution 正確使用。
 - **解決問題**: 企業網路下可能因無 proxy 而解析失敗。
 - **影響**: Discord 相關流程在受限網路更穩定。
 
-### ⭐ CLI/Doctor：非互動修復不再掛住 (#18502)
+### ⭐ CLI/Doctor：非互動修復不再掛住 ([#18502](https://github.com/openclaw/openclaw/pull/18502))
 - **用途**: 讓 doctor 非互動模式在完成後可正常退出。
 - **解決問題**: 自動化/CI 會因掛住而浪費資源。
 - **影響**: 一鍵修復更適合自動化情境。
 
-### ⭐ Media understanding：遵守 `agents.defaults.imageModel` (#7607)
+### ⭐ Media understanding：遵守 `agents.defaults.imageModel` ([#7607](https://github.com/openclaw/openclaw/pull/7607))
 - **用途**: 讓自動影像分析使用配置的 primary/fallback image model。
 - **解決問題**: auto-discovery 若忽略設定，會導致不一致的模型選擇。
 - **影響**: 影像理解行為更可預期、與配置一致。


### PR DESCRIPTION
Updates all markdown files in `release-notes/` so referenced PR/issue IDs like `(#12345)` become clickable links to GitHub.

Link target format:
- `([#12345](https://github.com/openclaw/openclaw/pull/12345))`
