### PR TITLE
docs: add webhook documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ claw-info/
 │   ├── nodes.md                   # OpenClaw Nodes 管理與配置
 │   ├── pricing_howto.md           # 定價策略與實作
 │   ├── profile_rotation.md        # 同一 Provider 的 Auth Profiles 輪換（Rotation / Failover）
-│   └── sandbox.md                 # Sandbox 環境配置
+│   ├── sandbox.md                 # Sandbox 環境配置
+│   └── webhook.md                 # Webhook（Cron delivery webhook）
 ├── release-notes/
 │   ├── 2026-02-14.md              # 2026-02-14 發佈記錄
 │   ├── 2026-02-15.md              # 2026-02-15 發佈記錄
@@ -35,6 +36,7 @@ claw-info/
 - **nodes.md** - OpenClaw Nodes 管理與配置
 - **pricing_howto.md** - 定價策略與實作
 - **sandbox.md** - Sandbox 環境配置
+- **webhook.md** - Webhook（Cron delivery webhook）
 
 ### release-notes/
 發佈記錄與規範：

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,43 +1,107 @@
 # OpenClaw Webhooks（Webhook 回呼）
 
-本文說明 OpenClaw 目前最常見的 webhook 用法：**Cron 任務完成後的投遞（delivery）回呼**，用於把執行結果以 HTTP POST 送到你的系統（自建 API / n8n / Zapier 等）。
+OpenClaw 支援在特定工作完成後，將結果以 **HTTP webhook** 形式投遞到外部系統。
 
-> ⭐ 文件屬於說明性質；實際 webhook payload 欄位可能隨版本演進。接收端建議以「冪等 + 可容錯」方式設計。
+本文聚焦於最常見且最實用的場景：**Cron 任務完成後的 delivery webhook 回呼**。
 
 ---
 
 ## 概述
 
-- ⭐ **主要用途**：Cron job 執行完成 → 以 webhook 將 run 結果事件 POST 到外部端點
-- ⭐ **推薦搭配**：`sessionTarget = isolated` + `payload.kind = agentTurn`
-- ⭐ **設計重點**：可達性（網路）、安全性（驗證）、可靠性（冪等 / 重送容忍）
+- webhook 主要用於：Cron job 完成後，將「本次 run 的完成事件」POST 到你的端點（自建 API / n8n / Zapier 等）
+- 建議搭配：`sessionTarget: isolated` + `payload.kind: agentTurn`
+- 設計重點：網路可達性、安全性驗證、可靠性（冪等/容錯）
 
 ---
 
-## 1. Cron delivery webhook（完成事件回呼）
-
-建立 cron job 時，在 job 物件設定：
-
-- `delivery.mode: "webhook"`
-- `delivery.to: "https://<your-endpoint>"`
-
-### 1.1 流程圖（ASCII）
+## 解決的問題
 
 ```
-+------------------+        runs        +-------------------+
-| OpenClaw Cron Job| --------------->   |  Agent execution  |
-| (schedule)       |                   | (isolated session)|
-+------------------+                    +-------------------+
-          |                                         |
-          |  finished run event (POST)              |
-          v                                         v
-+------------------+                         +------------------+
-|  Your Webhook    | <-----------------------|   OpenClaw       |
-|  Endpoint (HTTPS)|                         |   Gateway        |
-+------------------+                         +------------------+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         沒有 webhook 時的痛點                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  痛點 1：結果只能留在 OpenClaw 內部                                          │
+│    • 需要手動查看 cron runs 才知道成功/失敗                                 │
+│    • 難以自動串接外部流程（例如：建立工單、寫入資料庫、觸發通知）            │
+│                                                                             │
+│  痛點 2：缺乏統一的事件出口                                                 │
+│    • 不同任務各自採用不同通知方式                                           │
+│    • 整體監控與告警難以標準化                                               │
+│                                                                             │
+│  痛點 3：自動化流程斷裂                                                     │
+│    • 無法在任務完成後立即觸發下一步                                         │
+│    • 需要額外輪詢或人工介入                                                 │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 Job 範例
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         Webhook 帶來的價值                                  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ✓ 自動串接：run 完成後立即把結果送到你的系統                               │
+│  ✓ 標準出口：用 HTTP POST 統一承接所有任務完成事件                          │
+│  ✓ 可監控：接收端可集中記錄、告警、重試策略                                 │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 架構
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          Cron delivery webhook 架構                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌──────────────┐                                                         │
+│   │   Gateway     │                                                         │
+│   │ Cron Scheduler│                                                         │
+│   └──────┬───────┘                                                         │
+│          │                                                                  │
+│          ▼                                                                  │
+│   ┌──────────────┐      runs      ┌─────────────────────────┐              │
+│   │  Cron Job     │──────────────▶│  Agent Execution        │              │
+│   │ (schedule)    │               │ (isolated session)      │              │
+│   └──────┬───────┘               └───────────┬─────────────┘              │
+│          │                                    │                            │
+│          │ finished run event (HTTP POST)     │                            │
+│          ▼                                    ▼                            │
+│   ┌──────────────────────┐         ┌──────────────────────┐               │
+│   │ Your Webhook Endpoint │         │  Run Result / Error  │               │
+│   │ (HTTPS)               │         │  (JSON event body)   │               │
+│   └──────────────────────┘         └──────────────────────┘               │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 核心概念
+
+### Delivery Modes
+
+在 cron job 中設定 `delivery` 以控制結果如何投遞：
+
+- `none`：不投遞
+- `announce`：投遞到聊天頻道
+- `webhook`：投遞到 HTTP endpoint
+
+> 實際可用模式與欄位以 Gateway 版本與 cron schema 為準。
+
+### `sessionTarget` 與 `payload.kind` 限制
+
+- `sessionTarget: "main"` **必須**搭配 `payload.kind: "systemEvent"`
+- `sessionTarget: "isolated"` **必須**搭配 `payload.kind: "agentTurn"`
+
+---
+
+## 使用範例
+
+### 範例 1：每日摘要（完成後 webhook 投遞）
 
 ```json
 {
@@ -59,49 +123,24 @@
 
 ---
 
-## 2. `sessionTarget` 與 `payload.kind` 的限制
+## 實作建議
 
-- `sessionTarget: "main"` **必須**搭配 `payload.kind: "systemEvent"`
-- `sessionTarget: "isolated"` **必須**搭配 `payload.kind: "agentTurn"`
+### 安全性
 
-一般 webhook delivery 最適合用 `isolated + agentTurn`：
-- 執行結果與主會話隔離
-- webhook 可在完成後統一接收成功/失敗結果
-
----
-
-## 3. Webhook 會收到什麼資料
-
-你的端點將收到一個 HTTP POST（Content-Type: application/json），內容為「該次 cron run 的完成事件」。
-
-由於欄位可能調整，接收端建議：
-
-- ⭐ **完整記錄原始 JSON**（便於除錯與回溯）
-- ⭐ 只抽取你真正需要的少數欄位（例如 jobId、runId、status、timestamps）
-- ⭐ 以 `(jobId, runId)` 做去重（冪等）
-
----
-
-## 4. 安全性與可靠性建議
-
-### 4.1 安全性
-
-- ⭐ **只用 HTTPS**
-- ⭐ **驗證來源**（二選一或混用）
+- **只用 HTTPS**
+- **加入驗證**（擇一或混用）
   - 在 URL 帶 token（例如 `?token=...`）
-  - 在 HTTP header 驗證（較佳；若你的接收端/平台容易設定）
-- ⭐ 在接收端做 **重放攻擊防護**
-  - 儲存已處理 `(jobId, runId)`
-  - 重複事件直接忽略
+  - 在 HTTP header 驗證（較佳，若接收端/平台可設定）
+- **重放攻擊防護**：以 `(jobId, runId)` 或等價識別做去重
 
-### 4.2 可靠性
+### 可靠性
 
-- ⭐ Endpoint 需「快速回應」：建議立刻回 `2xx`，後續工作丟到 queue / background job
-- ⭐ 接收端需能容忍重送與順序不保證
+- Endpoint 建議快速回 `2xx`，把耗時處理丟到 background job / queue
+- 接收端需能容忍重送與順序不保證（冪等設計）
 
 ---
 
-## 5. 最小接收端範例（Node.js / Express）
+## 最小接收端範例（Node.js / Express）
 
 ```js
 import express from "express";
@@ -120,9 +159,16 @@ app.listen(3000, () => console.log("listening on :3000"));
 
 ---
 
-## 6. 除錯清單
+## 常見問題
 
-- Gateway 是否能從其網路環境連到你的 URL？（DNS / 防火牆 / NAT）
-- 你的 endpoint 是否能穩定回 `2xx`？是否會 timeout？
-- 是否有記錄 webhook 原始 JSON？
-- 是否有做冪等處理（避免同一 run 重複入庫/重複觸發）？
+### Q1：Webhook payload 的 JSON 欄位是否固定？
+
+**A：**不保證。建議接收端完整記錄原始 JSON，並只抽取必要欄位；避免對未保證的欄位做嚴格 schema 綁定。
+
+### Q2：如何避免同一個 run 重複觸發造成重複處理？
+
+**A：**接收端請以 `(jobId, runId)` 做去重（冪等），重複事件直接忽略。
+
+---
+
+*最後更新：2026-02-18*

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -201,13 +201,16 @@ app.listen(3000, () => console.log("listening on :3000"));
 
 | Issue | 標題 | 說明 |
 |-------|------|------|
-|（待補）|（待補）|（待補）|
+| [#19154](https://github.com/openclaw/openclaw/issues/19154) | Cron lastStatus: "ok" 掩蓋 delivery 失敗 | Agent 執行成功但投遞失敗時，狀態仍顯示 ok，難以監控與告警 |
+| [#17905](https://github.com/openclaw/openclaw/issues/17905) | Cron delivery / 排程多項問題彙整 | 包含 channel 解析、非預設 agent、靜默失敗等問題的彙整追蹤 |
 
 ### 🟢 Feature Requests
 
 | Issue | 標題 | 說明 |
 |-------|------|------|
-|（待補）|（待補）|（待補）|
+| [#9465](https://github.com/openclaw/openclaw/issues/9465) | Cron Job Hooks System | 需求：提供 Cron job hooks/事件系統（完成/失敗等）以便整合外部流程 |
+| [#19169](https://github.com/openclaw/openclaw/issues/19169) | Auto-cleanup for cron job sessions | 需求：cron job 執行後自動清理/回收 session，避免長期累積 |
+| [#7952](https://github.com/openclaw/openclaw/issues/7952) | Allow specifying agentId in webhook | 需求：在 webhook hook 類型中允許指定 agentId（提升可控性） |
 
 ---
 

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,21 +1,43 @@
-# OpenClaw Webhooks
+# OpenClaw Webhooks（Webhook 回呼）
 
-OpenClaw supports sending **webhook callbacks** when scheduled work completes.
+本文說明 OpenClaw 目前最常見的 webhook 用法：**Cron 任務完成後的投遞（delivery）回呼**，用於把執行結果以 HTTP POST 送到你的系統（自建 API / n8n / Zapier 等）。
 
-The most common pattern is: create a `cron` job → run work in an **isolated** session → deliver the finished run event to your system (n8n/Zapier/self-hosted API) via an HTTP **POST**.
-
-> Note: Webhook payload fields can evolve across versions. Treat the event body as an opaque JSON blob unless you control both ends.
+> ⭐ 文件屬於說明性質；實際 webhook payload 欄位可能隨版本演進。接收端建議以「冪等 + 可容錯」方式設計。
 
 ---
 
-## 1) Cron delivery webhooks (recommended)
+## 概述
 
-When creating a cron job, set:
+- ⭐ **主要用途**：Cron job 執行完成 → 以 webhook 將 run 結果事件 POST 到外部端點
+- ⭐ **推薦搭配**：`sessionTarget = isolated` + `payload.kind = agentTurn`
+- ⭐ **設計重點**：可達性（網路）、安全性（驗證）、可靠性（冪等 / 重送容忍）
+
+---
+
+## 1. Cron delivery webhook（完成事件回呼）
+
+建立 cron job 時，在 job 物件設定：
 
 - `delivery.mode: "webhook"`
-- `delivery.to: "https://…"` (your HTTPS endpoint)
+- `delivery.to: "https://<your-endpoint>"`
 
-### Example job
+### 1.1 流程圖（ASCII）
+
+```
++------------------+        runs        +-------------------+
+| OpenClaw Cron Job| --------------->   |  Agent execution  |
+| (schedule)       |                   | (isolated session)|
++------------------+                    +-------------------+
+          |                                         |
+          |  finished run event (POST)              |
+          v                                         v
++------------------+                         +------------------+
+|  Your Webhook    | <-----------------------|   OpenClaw       |
+|  Endpoint (HTTPS)|                         |   Gateway        |
++------------------+                         +------------------+
+```
+
+### 1.2 Job 範例
 
 ```json
 {
@@ -23,7 +45,7 @@ When creating a cron job, set:
   "schedule": { "kind": "cron", "expr": "0 9 * * *", "tz": "America/New_York" },
   "payload": {
     "kind": "agentTurn",
-    "message": "Summarize today's priorities.",
+    "message": "整理今日重點與待辦，輸出精簡摘要。",
     "timeoutSeconds": 120
   },
   "delivery": {
@@ -35,43 +57,51 @@ When creating a cron job, set:
 }
 ```
 
-### Session target constraints
+---
 
-- `sessionTarget: "main"` **requires** `payload.kind: "systemEvent"`
-- `sessionTarget: "isolated"` **requires** `payload.kind: "agentTurn"`
+## 2. `sessionTarget` 與 `payload.kind` 的限制
 
-In practice, webhook deliveries are most useful with `isolated + agentTurn`.
+- `sessionTarget: "main"` **必須**搭配 `payload.kind: "systemEvent"`
+- `sessionTarget: "isolated"` **必須**搭配 `payload.kind: "agentTurn"`
+
+一般 webhook delivery 最適合用 `isolated + agentTurn`：
+- 執行結果與主會話隔離
+- webhook 可在完成後統一接收成功/失敗結果
 
 ---
 
-## 2) What the webhook receives
+## 3. Webhook 會收到什麼資料
 
-Your endpoint will receive a POST with a JSON body representing the finished cron run (e.g., job id, run id, status, timestamps, and output/summary/error).
+你的端點將收到一個 HTTP POST（Content-Type: application/json），內容為「該次 cron run 的完成事件」。
 
-Because schemas may change, design your receiver to:
+由於欄位可能調整，接收端建議：
 
-- log the full JSON for troubleshooting
-- extract only the fields you truly need
-- be **idempotent** (the same run may be delivered more than once)
-
----
-
-## 3) Security & reliability
-
-**Strongly recommended**:
-
-- Use **HTTPS** only.
-- Add authentication, e.g.:
-  - a secret token in the URL (`?token=…`) or
-  - a header check (preferred, if supported by your receiver)
-- Implement replay protection:
-  - store processed `(jobId, runId)` pairs
-  - discard duplicates
-- Return fast (e.g., 200 OK) and do heavier work asynchronously.
+- ⭐ **完整記錄原始 JSON**（便於除錯與回溯）
+- ⭐ 只抽取你真正需要的少數欄位（例如 jobId、runId、status、timestamps）
+- ⭐ 以 `(jobId, runId)` 做去重（冪等）
 
 ---
 
-## 4) Minimal receiver example (Node/Express)
+## 4. 安全性與可靠性建議
+
+### 4.1 安全性
+
+- ⭐ **只用 HTTPS**
+- ⭐ **驗證來源**（二選一或混用）
+  - 在 URL 帶 token（例如 `?token=...`）
+  - 在 HTTP header 驗證（較佳；若你的接收端/平台容易設定）
+- ⭐ 在接收端做 **重放攻擊防護**
+  - 儲存已處理 `(jobId, runId)`
+  - 重複事件直接忽略
+
+### 4.2 可靠性
+
+- ⭐ Endpoint 需「快速回應」：建議立刻回 `2xx`，後續工作丟到 queue / background job
+- ⭐ 接收端需能容忍重送與順序不保證
+
+---
+
+## 5. 最小接收端範例（Node.js / Express）
 
 ```js
 import express from "express";
@@ -80,7 +110,7 @@ const app = express();
 app.use(express.json({ limit: "2mb" }));
 
 app.post("/openclaw/webhook", (req, res) => {
-  // TODO: verify auth token / signature
+  // TODO: 驗證 token / header
   console.log("OpenClaw cron event:", JSON.stringify(req.body));
   res.sendStatus(200);
 });
@@ -90,9 +120,9 @@ app.listen(3000, () => console.log("listening on :3000"));
 
 ---
 
-## 5) Troubleshooting checklist
+## 6. 除錯清單
 
-- Can the OpenClaw gateway reach your URL from its network?
-- Is your endpoint returning 2xx quickly?
-- Are you logging raw payloads to debug schema expectations?
-- Are you deduplicating events (idempotency)?
+- Gateway 是否能從其網路環境連到你的 URL？（DNS / 防火牆 / NAT）
+- 你的 endpoint 是否能穩定回 `2xx`？是否會 timeout？
+- 是否有記錄 webhook 原始 JSON？
+- 是否有做冪等處理（避免同一 run 重複入庫/重複觸發）？

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -97,6 +97,11 @@ OpenClaw 支援在特定工作完成後，將結果以 **HTTP webhook** 形式�
 - `sessionTarget: "main"` **必須**搭配 `payload.kind: "systemEvent"`
 - `sessionTarget: "isolated"` **必須**搭配 `payload.kind: "agentTurn"`
 
+### Delivery 支援範圍
+
+- 一般情況下，`delivery`（包含 `announce` / `webhook`）主要用於 **isolated** 的 cron job run 結果投遞。
+- 若你發現 `main` session 的 job 無法使用 `delivery`，請以 cron schema/版本行為為準。
+
 ---
 
 ## 使用範例
@@ -140,6 +145,19 @@ OpenClaw 支援在特定工作完成後，將結果以 **HTTP webhook** 形式�
 
 ---
 
+## 限制與最佳實踐
+
+| 項目 | 限制 | 建議 |
+|------|------|------|
+| 網路可達性 | Gateway 必須能連到你的 endpoint（DNS/防火牆/NAT 皆可能造成失敗） | 優先使用公網 HTTPS endpoint，必要時透過反向代理或 tunnel |
+| 回應時間 | Endpoint 過慢可能導致投遞 timeout 或失敗 | 立即回 `2xx`，耗時處理丟背景任務 |
+| Payload schema | JSON 欄位可能隨版本演進 | 完整記錄原始 JSON，只抽取必要欄位 |
+| 重送/重複事件 | 事件可能重送或重複投遞 | 以 `(jobId, runId)` 或等價 key 做冪等去重 |
+| 安全性 | 未驗證來源容易被偽造呼叫 | 使用 token/header 驗證；必要時限制 IP/加 WAF |
+| 可觀測性 | 只看 OpenClaw 端不易定位問題 | 接收端保留 request log（含時間、狀態碼、body hash） |
+
+---
+
 ## 最小接收端範例（Node.js / Express）
 
 ```js
@@ -168,6 +186,34 @@ app.listen(3000, () => console.log("listening on :3000"));
 ### Q2：如何避免同一個 run 重複觸發造成重複處理？
 
 **A：**接收端請以 `(jobId, runId)` 做去重（冪等），重複事件直接忽略。
+
+### Q3：Webhook endpoint 需要回傳什麼？
+
+**A：**建議回 `2xx`（例如 200/204）且盡量快速回應。若接收端需要做耗時處理，請改為先入 queue/背景任務。
+
+---
+
+## 已知問題（Open Issues）
+
+> 本節用於彙整 webhook delivery 相關的已知問題與需求。若你遇到可重現的狀況，建議在 OpenClaw 或 claw-info 另開 issue 並補上連結。
+
+### 🔴 Bugs
+
+| Issue | 標題 | 說明 |
+|-------|------|------|
+|（待補）|（待補）|（待補）|
+
+### 🟢 Feature Requests
+
+| Issue | 標題 | 說明 |
+|-------|------|------|
+|（待補）|（待補）|（待補）|
+
+---
+
+## 更新紀錄
+
+- **2026-02-18**：文件建立；新增「限制與最佳實踐 / 已知問題」章節
 
 ---
 

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,0 +1,98 @@
+# OpenClaw Webhooks
+
+OpenClaw supports sending **webhook callbacks** when scheduled work completes.
+
+The most common pattern is: create a `cron` job → run work in an **isolated** session → deliver the finished run event to your system (n8n/Zapier/self-hosted API) via an HTTP **POST**.
+
+> Note: Webhook payload fields can evolve across versions. Treat the event body as an opaque JSON blob unless you control both ends.
+
+---
+
+## 1) Cron delivery webhooks (recommended)
+
+When creating a cron job, set:
+
+- `delivery.mode: "webhook"`
+- `delivery.to: "https://…"` (your HTTPS endpoint)
+
+### Example job
+
+```json
+{
+  "name": "daily-summary",
+  "schedule": { "kind": "cron", "expr": "0 9 * * *", "tz": "America/New_York" },
+  "payload": {
+    "kind": "agentTurn",
+    "message": "Summarize today's priorities.",
+    "timeoutSeconds": 120
+  },
+  "delivery": {
+    "mode": "webhook",
+    "to": "https://example.com/openclaw/webhook"
+  },
+  "sessionTarget": "isolated",
+  "enabled": true
+}
+```
+
+### Session target constraints
+
+- `sessionTarget: "main"` **requires** `payload.kind: "systemEvent"`
+- `sessionTarget: "isolated"` **requires** `payload.kind: "agentTurn"`
+
+In practice, webhook deliveries are most useful with `isolated + agentTurn`.
+
+---
+
+## 2) What the webhook receives
+
+Your endpoint will receive a POST with a JSON body representing the finished cron run (e.g., job id, run id, status, timestamps, and output/summary/error).
+
+Because schemas may change, design your receiver to:
+
+- log the full JSON for troubleshooting
+- extract only the fields you truly need
+- be **idempotent** (the same run may be delivered more than once)
+
+---
+
+## 3) Security & reliability
+
+**Strongly recommended**:
+
+- Use **HTTPS** only.
+- Add authentication, e.g.:
+  - a secret token in the URL (`?token=…`) or
+  - a header check (preferred, if supported by your receiver)
+- Implement replay protection:
+  - store processed `(jobId, runId)` pairs
+  - discard duplicates
+- Return fast (e.g., 200 OK) and do heavier work asynchronously.
+
+---
+
+## 4) Minimal receiver example (Node/Express)
+
+```js
+import express from "express";
+
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+app.post("/openclaw/webhook", (req, res) => {
+  // TODO: verify auth token / signature
+  console.log("OpenClaw cron event:", JSON.stringify(req.body));
+  res.sendStatus(200);
+});
+
+app.listen(3000, () => console.log("listening on :3000"));
+```
+
+---
+
+## 5) Troubleshooting checklist
+
+- Can the OpenClaw gateway reach your URL from its network?
+- Is your endpoint returning 2xx quickly?
+- Are you logging raw payloads to debug schema expectations?
+- Are you deduplicating events (idempotency)?


### PR DESCRIPTION
Adds `docs/webhook.md` describing OpenClaw webhook support for cron deliveries, with examples and basic security/reliability notes.

Fixes #27