### PR TITLE
ci: reduce auto-merge flakiness from mergeable_state=unstable

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -47,8 +47,39 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Fetch PR details
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            // Fetch PR details (with small retry window). GitHub can briefly report
+            // mergeable_state=unstable/unknown even when checks are green.
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            let pr;
+            const maxAttempts = 12;        // ~60s total
+            const backoffMs = 5000;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              pr = data;
+
+              core.info(`PR #${prNumber} attempt ${attempt}/${maxAttempts}: mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}`);
+
+              // If mergeability isn't computed yet, wait and retry.
+              if (pr.mergeable === null || pr.mergeable_state === 'unknown') {
+                await sleep(backoffMs);
+                continue;
+              }
+
+              // If it's already clean, stop waiting.
+              if (pr.mergeable_state === 'clean') break;
+
+              // If checks are still running / just finished, GitHub often reports 'unstable' transiently.
+              // Give it a short window to settle.
+              if (['unstable'].includes(pr.mergeable_state) && attempt < maxAttempts) {
+                await sleep(backoffMs);
+                continue;
+              }
+
+              // For other states (dirty/blocked/behind), don't spin.
+              break;
+            }
 
             if (pr.draft) {
               core.info(`PR #${prNumber} is draft; skip.`);
@@ -74,19 +105,13 @@ jobs:
               return;
             }
 
-            // Check mergeability. Note: GitHub may return null briefly.
+            // Check mergeability.
             // mergeable_state values: clean, dirty, blocked, unstable, unknown, behind, draft...
             const mergeableState = pr.mergeable_state;
-            core.info(`PR #${prNumber} mergeable_state=${mergeableState}, mergeable=${pr.mergeable}`);
-
-            if (pr.mergeable === null || mergeableState === 'unknown') {
-              core.info('Mergeability not yet computed; try again on next event.');
-              return;
-            }
 
             // Only merge when clean (i.e., branch protection + required checks satisfied)
             if (mergeableState !== 'clean') {
-              core.info('Not clean yet (likely waiting for checks / conflicts / approvals); skip.');
+              core.info(`Not clean (mergeable_state=${mergeableState}); skip.`);
               return;
             }
 


### PR DESCRIPTION
GitHub sometimes returns mergeable_state=unstable transiently (even when checks are green), causing our auto-merge workflow to skip.

This change adds a short retry/backoff loop (~60s max) to re-fetch PR mergeability before deciding.

Fixes: #41