### PR TITLE
ci: auto-merge should not depend on mergeable_state

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -47,37 +47,26 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Fetch PR details (with small retry window). GitHub can briefly report
-            // mergeable_state=unstable/unknown even when checks are green.
+            // Fetch PR details (with small retry window).
+            // Note: we intentionally DO NOT gate on `mergeable_state` because it is flaky/transient.
             const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
             let pr;
-            const maxAttempts = 12;        // ~60s total
+            const maxAttempts = 12; // ~60s total
             const backoffMs = 5000;
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
               const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
               pr = data;
 
-              core.info(`PR #${prNumber} attempt ${attempt}/${maxAttempts}: mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}`);
+              core.info(`PR #${prNumber} attempt ${attempt}/${maxAttempts}: mergeable=${pr.mergeable}`);
 
               // If mergeability isn't computed yet, wait and retry.
-              if (pr.mergeable === null || pr.mergeable_state === 'unknown') {
+              if (pr.mergeable === null && attempt < maxAttempts) {
                 await sleep(backoffMs);
                 continue;
               }
 
-              // If it's already clean, stop waiting.
-              if (pr.mergeable_state === 'clean') break;
-
-              // If checks are still running / just finished, GitHub often reports 'unstable' transiently.
-              // Give it a short window to settle.
-              if (['unstable'].includes(pr.mergeable_state) && attempt < maxAttempts) {
-                await sleep(backoffMs);
-                continue;
-              }
-
-              // For other states (dirty/blocked/behind), don't spin.
               break;
             }
 


### PR DESCRIPTION
We saw approved PRs with all required checks green still fail to auto-merge because GitHub transiently reports mergeable_state=unstable.

This change removes any reliance on mergeable_state in the auto-merge workflow. We only retry on mergeable=null, and we keep the merge gate as:
- at least 1 approval
- pr.mergeable === true
- required checks SUCCESS (check-author, check)

Fixes: #44