### PR TITLE
docs: add start + troubleshooting (ops manual track)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,11 @@
 
 - 寫作規約：[`STYLE_GUIDE.md`](./STYLE_GUIDE.md)
 
+## Start here
+
+- [`start.md`](./start.md) — 最小可行 Start / Onboarding（daemon、channel、pairing、驗證清單）
+- [`troubleshooting.md`](./troubleshooting.md) — 常見故障排除（不回覆/收不到訊息/browser/cron/SSO…）
+
 ## 快速導覽
 
 - **Bedrock**
@@ -26,18 +31,15 @@
 - **運維**
   - [`profile_rotation.md`](./profile_rotation.md) — Profile rotation（憑證/身份輪替）與操作建議
 
-## 即將補齊：核心概念 Deep Dive
+## Core 概念 Deep Dive
 
-以下主題會以「核心概念」角度補上更完整的脈絡、設計取捨與最佳實務（見 issue/PR 追蹤）：
-
-- Tooling 契約與安全邊界：#31（PR #37）
-- Session 模型與隔離（main vs isolated）：#30（PR #36）
-- Gateway 架構與生命週期：#29（PR #35）
-- 訊息路由與 channel plugins：#32（PR #38）
-- Skills 系統（封裝/版本/測試）：#33（PR #39）
-- Memory 系統（files-as-memory）策略：#34（PR #40）
-
-> 註：若要認領撰寫或提出補充，直接在對應 issue/PR 留言即可。
+- `docs/core/`
+  - `gateway-lifecycle.md`
+  - `session-isolation.md`
+  - `tooling-safety.md`
+  - `messaging-routing.md`
+  - `skills-system.md`
+  - `memory-strategy.md`
 
 ## 貢獻方式（簡要）
 

--- a/docs/start.md
+++ b/docs/start.md
@@ -1,0 +1,115 @@
+# Start / Onboarding（最小可行）
+
+> 目標：讓你在 **15–30 分鐘內**把 OpenClaw 跑起來（daemon 常駐、能收訊息、能跑工具）。
+>
+> 本文件偏「操作手冊」，不是完整產品文件。
+
+---
+
+## 0) 你需要準備什麼
+
+- 一台會常開的機器（本機或 VPS）
+- 一個模型供應商（例如 Bedrock / OpenAI / Gemini / MiniMax…依你的配置）
+- 至少一個 channel（最常見：Telegram bot token）
+
+> 建議：先只接 **一個 channel + 一個模型**。跑順再加第二個。
+
+---
+
+## 1) 安裝與啟動 Gateway（daemon）
+
+> 以下以 macOS/Linux 為主；Windows 請依官方 docs。
+
+1. 安裝 OpenClaw
+
+```bash
+npm i -g openclaw
+```
+
+2. 進入 onboarding（並安裝 daemon）
+
+```bash
+openclaw onboard --install-daemon
+```
+
+3. 驗證 daemon 是否正常
+
+```bash
+openclaw gateway status
+```
+
+常見輸出：running / stopped。
+
+---
+
+## 2) 連接模型（Provider）
+
+在 onboarding 過程中依提示選擇 provider、填入 API key。
+
+### Bedrock 使用者（常見）
+
+- 如果遇到 **SSO token expired**：先跑
+
+```bash
+aws sso login
+```
+
+- 或使用你環境中的 refresh 腳本（若有）
+
+> 建議把「SSO refresh」放到 cron（每小時一次），避免半夜過期。
+
+---
+
+## 3) 連接 Channel（以 Telegram 為例）
+
+1. 到 @BotFather 建立 bot，取得 token。
+2. 在 onboarding 選 Telegram，貼上 token。
+3. 跟你的 bot 開始對話，確認能收發。
+
+> 若你看到 bot 沒回：先看 `docs/troubleshooting.md` 的「收不到訊息」段。
+
+---
+
+## 4) Pairing（把手機/節點配上）
+
+若你要使用 nodes（例如手機截圖、錄影、定位、遠端執行），在 TUI/CLI 會看到 pairing key。
+
+流程（概念）：
+
+- 取得 pairing key（像 `123456:ABCDEFG...`）
+- 把 pairing key 貼到你配置的 channel（通常是 Telegram 的 bot 對話）
+- Gateway 會把該裝置加入 paired nodes
+
+驗證：
+
+```bash
+openclaw nodes status
+```
+
+---
+
+## 5) 快速驗證清單（Checklist）
+
+到這一步，下面 5 個都應該成立：
+
+1. `openclaw gateway status` 顯示 running
+2. Telegram bot 能收到你訊息
+3. agent 能回覆（不一定要很聰明，先能動就好）
+4. `exec` 可在 sandbox 跑簡單指令（例如 `pwd`）
+5. cron 能被建立並觸發（測一個 1 分鐘後提醒）
+
+---
+
+## 6) 下一步建議
+
+- 先建立 1–2 個最常用 workflows：
+  - cron reminder
+  - issue triage / PR review
+  - 每日摘要
+- 先把安全邊界設好：
+  - `message` / `exec` / `nodes` 要求更高門檻
+
+參考：
+- `docs/core/tooling-safety.md`
+- `docs/cron.md`
+- `docs/nodes.md`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,145 @@
+# Troubleshooting（常見故障排除）
+
+> 這份文件假設你「已經跑起來一次」，但開始遇到：不回覆、收不到訊息、browser 接不上、cron 不跑、SSO 過期…
+
+---
+
+## 0) 先做三件事（80% 的問題在這裡）
+
+1) 看 Gateway 是否活著
+
+```bash
+openclaw gateway status
+```
+
+2) 如果不是 running：重啟
+
+```bash
+openclaw gateway restart
+```
+
+3) 看最近 log（如果你有集中 logging）
+
+- 先找「有沒有收到 inbound event」
+- 再找「tool call 有沒有被 policy 拒絕」
+
+---
+
+## 1) Telegram/Channel 收不到訊息
+
+症狀：你對 bot 說話，但 OpenClaw 沒任何反應。
+
+檢查順序：
+
+- bot token 是否正確（onboard 時貼的那個）
+- Gateway 是否 running
+- 有無被平台封鎖/限流（尤其是新 bot）
+
+建議動作：
+
+- 先重啟 gateway：`openclaw gateway restart`
+- 若依然不行，重新 onboard channel（最小變動：只改 channel，不動模型）
+
+---
+
+## 2) 能收到訊息但不回覆
+
+常見原因：
+
+- 模型 provider 掛了 / key 無效 / 額度用完
+- tool call 卡住（例如 browser relay 沒 attach tab）
+- 被安全 policy 擋掉
+
+快速診斷：
+
+- 先用一個最簡單的 prompt 測：例如「回覆 1」
+- 若仍不回，多半是 provider/權限。
+
+---
+
+## 3) Browser tool / Browser Relay 接不上
+
+常見錯誤：
+
+- 「Chrome extension relay is running, but no tab is connected」
+
+處理：
+
+1. 在 Chrome 打開你要自動化的頁面
+2. 點 OpenClaw Browser Relay 擴充套件圖示，把該 tab attach（badge ON）
+3. 再回到 OpenClaw 重試 browser snapshot/act
+
+---
+
+## 4) Cron 沒觸發 / 沒發提醒
+
+檢查：
+
+- cron scheduler 是否 running（gateway 要活著）
+- job 是否 enabled
+- delivery mode 是否正確（announce/webhook/none）
+
+建議：
+
+- 用 `cron list` 看 job 是否存在
+- 手動 `cron run` 觸發一次，排除排程問題
+
+---
+
+## 5) AWS SSO / Bedrock Token expired
+
+症狀：呼叫 Bedrock 的模型時失敗，提示 token expired。
+
+修復：
+
+```bash
+aws sso login
+```
+
+（若你有 profile）
+
+```bash
+aws sso login --profile <name>
+```
+
+預防：
+
+- 用 cron 每小時跑一次 refresh 腳本（如果你有，例如 `sso-refresh.sh`）
+
+---
+
+## 6) Auto-merge 沒動（PR 已 approved 但沒合）
+
+常見原因：
+
+- required checks 還沒綠
+- GitHub 的 mergeability 狀態短暫飄忽（workflow 觸發當下不一致）
+
+建議：
+
+- 先看 PR checks 是否全綠
+- 看 auto-merge workflow run log 末段原因
+- 若卡住且你很確定可合：用 `gh pr merge <num> --squash --delete-branch` 手動合（作為保險絲）
+
+---
+
+## 7) 工具被拒絕（policy 阻擋）
+
+症狀：agent 想用 `exec`/`message`/`nodes` 但被拒。
+
+處理：
+
+- 回到你的 tooling 安全規範：`docs/core/tooling-safety.md`
+- 確認是否需要 explicit user confirmation
+- 把工作拆成：先乾跑（plan / preview）→ 再確認 → 再執行
+
+---
+
+## 8) 要回報 bug
+
+請提供：
+
+- 問題發生時間
+- 你做了什麼（最小可重現步驟）
+- 相關 log（去除 token/個資）
+- 你期望的行為 vs 實際結果


### PR DESCRIPTION
Adds two top-level ops-manual docs and links them from docs/README:

- docs/start.md (minimal onboarding checklist)
- docs/troubleshooting.md (common failure modes)

Fixes: #47