### PR TITLE
docs: add install + CLI quick reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@
 
 ## Start here
 
+- [`install.md`](./install.md) — 安裝（macOS/Linux，常見安裝坑）
 - [`start.md`](./start.md) — 最小可行 Start / Onboarding（daemon、channel、pairing、驗證清單）
+- [`cli.md`](./cli.md) — CLI 指令速查
 - [`troubleshooting.md`](./troubleshooting.md) — 常見故障排除（不回覆/收不到訊息/browser/cron/SSO…）
 
 ## 快速導覽

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,95 @@
+# CLI Quick Reference（指令速查）
+
+> 目標：把最常用的 OpenClaw 指令整理成「抄得到就能用」的速查表。
+
+---
+
+## 0) 基本
+
+```bash
+openclaw --version
+openclaw help
+```
+
+---
+
+## 1) Gateway（daemon）
+
+```bash
+openclaw gateway status
+openclaw gateway restart
+openclaw gateway start
+openclaw gateway stop
+```
+
+---
+
+## 2) Onboarding
+
+```bash
+openclaw onboard
+openclaw onboard --install-daemon
+```
+
+---
+
+## 3) Sessions / Subagents
+
+（以下命令視你的版本可能略有差異；以實際 help 為準）
+
+- 列出 sessions
+- 查某個 session 歷史
+- 對某個 session 發訊息
+
+> 在 chat 介面中，多數情境你會直接用 agent 的內建工具 `sessions_list / sessions_history / sessions_send`。
+
+---
+
+## 4) Cron（排程）
+
+> 你也可以直接在 chat 用 `cron` tool 建立/管理。
+
+概念：
+- list：看有哪些 job
+- add：新增 job
+- run：立即觸發
+- runs：看執行紀錄
+
+---
+
+## 5) Nodes
+
+```bash
+openclaw nodes status
+```
+
+（配對流程與能力請看 `docs/nodes.md`）
+
+---
+
+## 6) 常用除錯
+
+```bash
+openclaw status
+openclaw gateway status
+```
+
+---
+
+## 7) 常見工作流（例）
+
+### 7.1 「我想確認 bot 還活著」
+
+```bash
+openclaw gateway status
+```
+
+### 7.2 「我想重啟所有東西」
+
+```bash
+openclaw gateway restart
+```
+
+---
+
+更多排錯見：`docs/troubleshooting.md`

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,136 @@
+# Install（安裝）
+
+> 目標：用最少步驟把 OpenClaw 安裝好，並避免常見的 PATH / 權限 / Node 版本坑。
+>
+> 本文件偏「可操作」，不是全平台完整指南。
+
+---
+
+## TL;DR
+
+```bash
+# 1) 安裝 Node.js（建議用 nvm 或 Volta 管）
+node -v
+npm -v
+
+# 2) 安裝 OpenClaw CLI
+npm i -g openclaw
+
+# 3) 啟動 onboarding + 安裝 daemon
+openclaw onboard --install-daemon
+
+# 4) 驗證
+openclaw gateway status
+```
+
+---
+
+## 1) 先決條件
+
+- Node.js LTS（建議 >= 20）
+- npm
+- 可連外下載套件（公司網路可能要 proxy）
+
+### 建議：不要用系統自帶 node
+
+系統自帶 node 常常太舊，或權限/路徑容易混亂。
+
+---
+
+## 2) macOS 安裝
+
+### 2.1 安裝 Node.js
+
+（擇一）
+
+- 用 Homebrew：
+
+```bash
+brew install node
+```
+
+- 或用 nvm（更好管理多版本）：
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+nvm install --lts
+nvm use --lts
+```
+
+### 2.2 安裝 OpenClaw
+
+```bash
+npm i -g openclaw
+openclaw --version
+```
+
+### 2.3 Onboard + daemon
+
+```bash
+openclaw onboard --install-daemon
+openclaw gateway status
+```
+
+---
+
+## 3) Linux 安裝
+
+步驟同 macOS：先裝 Node.js，再 `npm i -g openclaw`。
+
+若是 VPS/Headless 環境：
+
+- 建議把 `openclaw gateway` 設成 systemd/daemon（onboard 的 `--install-daemon` 通常會處理）
+- 防火牆先不要開外網入口（避免暴露管理介面）
+
+---
+
+## 4) 升級 / 釘版本
+
+### 4.1 升級 CLI
+
+```bash
+npm i -g openclaw@latest
+openclaw --version
+```
+
+### 4.2 釘版本（避免大改動）
+
+```bash
+npm i -g openclaw@<version>
+```
+
+---
+
+## 5) 移除（Uninstall）
+
+```bash
+npm rm -g openclaw
+```
+
+daemon/service 如何移除取決於你的安裝方式（systemd/launchd）。
+
+---
+
+## 6) 常見安裝問題
+
+### 6.1 `openclaw: command not found`
+
+- 確認 `npm bin -g` 是否在 PATH
+- 重新開新 shell
+
+### 6.2 權限錯誤（EACCES）
+
+- 不建議用 `sudo npm -g ...`
+- 用 nvm/Volta 解決全域 npm 權限
+
+### 6.3 Node 版本衝突
+
+- `which node` / `node -v` 確認目前實際使用版本
+- 若你用 nvm，確保 shell 有載入 nvm
+
+---
+
+## 下一步
+
+- `docs/start.md`
+- `docs/troubleshooting.md`


### PR DESCRIPTION
Adds ops-manual docs:

- docs/install.md (macOS/Linux install + common pitfalls)
- docs/cli.md (quick reference)
- link them from docs/README.md

Fixes: #49