### PR TITLE
release-notes: link issue numbers to upstream PR URLs

### DIFF
--- a/release-notes/2026-02-19.md
+++ b/release-notes/2026-02-19.md
@@ -6,16 +6,16 @@
 
 ### 功能更新（Features）
 
-- ⭐⭐⭐ iOS/Watch：Apple Watch Companion MVP（Watch inbox UI + 通知 relay）(#20054)
-- ⭐⭐ iOS/Gateway：APNs 喚醒離線 iOS Node 以提升 `nodes.invoke` 成功率 (#20332)
-- ⭐⭐ Devices：配對裝置衛生管理（`openclaw devices remove/clear`）(#20057)
-- ⭐⭐ iOS/APNs：新增 push registration 與 notification signing 設定 (#20308)
-- ⭐ iOS/APNs：新增 push-test pipeline 驗證 APNs 投遞 (#20307)
+- ⭐⭐⭐ iOS/Watch：Apple Watch Companion MVP（Watch inbox UI + 通知 relay）([#20054](https://github.com/openclaw/openclaw/pull/20054))
+- ⭐⭐ iOS/Gateway：APNs 喚醒離線 iOS Node 以提升 `nodes.invoke` 成功率 ([#20332](https://github.com/openclaw/openclaw/pull/20332))
+- ⭐⭐ Devices：配對裝置衛生管理（`openclaw devices remove/clear`）([#20057](https://github.com/openclaw/openclaw/pull/20057))
+- ⭐⭐ iOS/APNs：新增 push registration 與 notification signing 設定 ([#20308](https://github.com/openclaw/openclaw/pull/20308))
+- ⭐ iOS/APNs：新增 push-test pipeline 驗證 APNs 投遞 ([#20307](https://github.com/openclaw/openclaw/pull/20307))
 - ⭐ Skills：coding-agent skill 指南移除不安全的 shell 範例（避免不可信文字插入指令）
-- ⭐ Dev tooling：`oxfmt` 本機/CI formatting 行為對齊 (#12579)
-- ⭐ Telegram：統一 message-like inbound pipeline（message/channel_post 同等處理）(#20591)
-- ⭐ UI/Sessions：Chat UI 接受 canonical main session-key alias (#20311)
-- ⭐ Browser/Relay：relay port 已被占用時可重用既有 extension relay (#20035)
+- ⭐ Dev tooling：`oxfmt` 本機/CI formatting 行為對齊 ([#12579](https://github.com/openclaw/openclaw/pull/12579))
+- ⭐ Telegram：統一 message-like inbound pipeline（message/channel_post 同等處理）([#20591](https://github.com/openclaw/openclaw/pull/20591))
+- ⭐ UI/Sessions：Chat UI 接受 canonical main session-key alias ([#20311](https://github.com/openclaw/openclaw/pull/20311))
+- ⭐ Browser/Relay：relay port 已被占用時可重用既有 extension relay ([#20035](https://github.com/openclaw/openclaw/pull/20035))
 
 ### 安全性提升（Security）
 
@@ -24,50 +24,50 @@
 - ⭐⭐⭐ Security/Windows Daemon：加固 Scheduled Task `gateway.cmd` 生成，防 cmd injection（下個 npm 版）
 - ⭐⭐⭐ Security/Webhooks：cron webhook delivery 加上 SSRF guard（阻擋 private/metadata 目的地）
 - ⭐⭐⭐ Security/Exec：`safeBins` 僅允許可信 bin 目錄解析，避免 PATH 劫持繞過 allowlist
-- ⭐⭐ Security/Network：禁止對非 loopback 使用明文 `ws://` 連線，避免傳輸降級 (#20803)
-- ⭐⭐ Security/Config：frontmatter YAML 以 YAML 1.2 core schema 解析，避免隱性型別轉換 (#20857)
+- ⭐⭐ Security/Network：禁止對非 loopback 使用明文 `ws://` 連線，避免傳輸降級 ([#20803](https://github.com/openclaw/openclaw/pull/20803))
+- ⭐⭐ Security/Config：frontmatter YAML 以 YAML 1.2 core schema 解析，避免隱性型別轉換 ([#20857](https://github.com/openclaw/openclaw/pull/20857))
 - ⭐⭐ Security/Discord：強制可信 sender 權限檢查（timeout/kick/ban）防提權
-- ⭐ Security/Media：TTS temp file 採用 randomBytes 命名 + owner-only 權限 (#20654)
-- ⭐ Security/Headers：gateway HTTP 回應加 baseline security headers（nosniff/no-referrer）(#10526)
+- ⭐ Security/Media：TTS temp file 採用 randomBytes 命名 + owner-only 權限 ([#20654](https://github.com/openclaw/openclaw/pull/20654))
+- ⭐ Security/Headers：gateway HTTP 回應加 baseline security headers（nosniff/no-referrer）([#10526](https://github.com/openclaw/openclaw/pull/10526))
 
 ### 錯誤修復（Bug Fixes）
 
-- ⭐⭐⭐ Agents/Streaming：修 reasoning stream 下的 partial streaming、事件一致性與 retry 後 stale tool errors (#20635)
-- ⭐⭐ Telegram/Cron/Heartbeat：cron/heartbeat 尊重 topic target（`<chatId>:topic:<threadId>`）避免送到錯 thread (#19367)
-- ⭐⭐ Gateway/Daemon：轉發 `TMPDIR` 給 macOS LaunchAgent，修 SQLite `SQLITE_CANTOPEN` (#20512)
-- ⭐⭐ Agents/Billing：billing error 訊息帶出實際 model 名稱（含 failover 路徑）(#20510)
-- ⭐ iOS/Onboarding：pairing auto-resume flicker 與 reconnect 穩定性修正 (#20310/#20056)
-- ⭐ iOS/Screen：WKWebView lifecycle 管理改為 explicit attach/detach 降低 crash (#20366)
-- ⭐ Telegram/Agents：exec/bash tool-failure 警告僅在 verbose 模式顯示 (#20560)
-- ⭐ Commands/Doctor：memory.backend=qmd 時跳過 embedding-provider 警告 (#17263)
-- ⭐ Canvas/A2UI：改善 bundled-asset resolution 與 empty-state fallback (#20312)
-- ⭐ Channels/Matrix：修 formatted_body 的 mention detection（matrix.to）(#16941)
+- ⭐⭐⭐ Agents/Streaming：修 reasoning stream 下的 partial streaming、事件一致性與 retry 後 stale tool errors ([#20635](https://github.com/openclaw/openclaw/pull/20635))
+- ⭐⭐ Telegram/Cron/Heartbeat：cron/heartbeat 尊重 topic target（`<chatId>:topic:<threadId>`）避免送到錯 thread ([#19367](https://github.com/openclaw/openclaw/pull/19367))
+- ⭐⭐ Gateway/Daemon：轉發 `TMPDIR` 給 macOS LaunchAgent，修 SQLite `SQLITE_CANTOPEN` ([#20512](https://github.com/openclaw/openclaw/pull/20512))
+- ⭐⭐ Agents/Billing：billing error 訊息帶出實際 model 名稱（含 failover 路徑）([#20510](https://github.com/openclaw/openclaw/pull/20510))
+- ⭐ iOS/Onboarding：pairing auto-resume flicker 與 reconnect 穩定性修正 ([#20310](https://github.com/openclaw/openclaw/pull/20310)/[#20056](https://github.com/openclaw/openclaw/pull/20056))
+- ⭐ iOS/Screen：WKWebView lifecycle 管理改為 explicit attach/detach 降低 crash ([#20366](https://github.com/openclaw/openclaw/pull/20366))
+- ⭐ Telegram/Agents：exec/bash tool-failure 警告僅在 verbose 模式顯示 ([#20560](https://github.com/openclaw/openclaw/pull/20560))
+- ⭐ Commands/Doctor：memory.backend=qmd 時跳過 embedding-provider 警告 ([#17263](https://github.com/openclaw/openclaw/pull/17263))
+- ⭐ Canvas/A2UI：改善 bundled-asset resolution 與 empty-state fallback ([#20312](https://github.com/openclaw/openclaw/pull/20312))
+- ⭐ Channels/Matrix：修 formatted_body 的 mention detection（matrix.to）([#16941](https://github.com/openclaw/openclaw/pull/16941))
 
 ---
 
 ## 功能更新（Features）— by Star Rating
 
-### ⭐⭐⭐ Apple Watch Companion MVP（Watch inbox + 通知 relay）(#20054)
+### ⭐⭐⭐ Apple Watch Companion MVP（Watch inbox + 通知 relay）([#20054](https://github.com/openclaw/openclaw/pull/20054))
 - **用途**：新增 Apple Watch 伴生端，提供 watch inbox UI 與通知 relay，讓使用者在手錶上也能接收/處理訊息。
 - **解決問題**：降低必須打開手機才能查看 agent 訊息的摩擦；提升「隨時可回應」的可用性。
 - **影響**：iOS 生態的可達性提升，適合 24/7 團隊與提醒場景。
 
-### ⭐⭐ APNs 喚醒離線 iOS Node 以提升 `nodes.invoke` 成功率 (#20332)
+### ⭐⭐ APNs 喚醒離線 iOS Node 以提升 `nodes.invoke` 成功率 ([#20332](https://github.com/openclaw/openclaw/pull/20332))
 - **用途**：在 `nodes.invoke` 前先以 APNs 喚醒已斷線的 iOS node，並在 silent push wake 後自動重連 gateway session。
 - **解決問題**：iOS app 背景化/休眠時，invoke 失敗率高。
 - **影響**：行動端 node 的可靠性提升，降低「背景叫不醒」的失敗重試。
 
-### ⭐⭐ 配對裝置衛生管理（devices remove/clear）(#20057)
+### ⭐⭐ 配對裝置衛生管理（devices remove/clear）([#20057](https://github.com/openclaw/openclaw/pull/20057))
 - **用途**：新增 `device.pair.remove`、`openclaw devices remove`、`openclaw devices clear --yes [--pending]`。
 - **解決問題**：paired device 清理/拒絕 pending 配對缺乏標準化流程，容易留下髒資料。
 - **影響**：維運更可控，降低誤配對與歷史殘留的困擾。
 
-### ⭐⭐ iOS/APNs：push registration + notification signing 設定 (#20308)
+### ⭐⭐ iOS/APNs：push registration + notification signing 設定 ([#20308](https://github.com/openclaw/openclaw/pull/20308))
 - **用途**：加入 APNs push registration 與 notification-signing 設定以支援 node delivery。
 - **解決問題**：APNs 投遞需要完整註冊/簽章配置，缺一不可。
 - **影響**：為 iOS node 背景喚醒/投遞打底，與 gateway 端流程更一致。
 
-### ⭐ iOS/APNs：push-test pipeline（投遞驗證）(#20307)
+### ⭐ iOS/APNs：push-test pipeline（投遞驗證）([#20307](https://github.com/openclaw/openclaw/pull/20307))
 - **用途**：提供 APNs delivery validation 流程（push test）。
 - **解決問題**：APNs 配置錯誤時排查成本高、回饋慢。
 - **影響**：縮短 debug 迴圈，降低上線風險。
@@ -77,22 +77,22 @@
 - **解決問題**：降低 prompt injection → command injection 的教學性風險。
 - **影響**：Skill 文件更安全、也更符合「工具輸入不可信」的最佳實踐。
 
-### ⭐ Dev tooling：`oxfmt` 本機/CI formatting 對齊 (#12579)
+### ⭐ Dev tooling：`oxfmt` 本機/CI formatting 對齊 ([#12579](https://github.com/openclaw/openclaw/pull/12579))
 - **用途**：統一格式化工具在本機與 CI 的行為。
 - **解決問題**：避免「本機過、CI 掛」的格式漂移。
 - **影響**：貢獻者體驗改善，CI 噪音降低。
 
-### ⭐ Telegram：統一 message-like inbound pipeline（message/channel_post）(#20591)
+### ⭐ Telegram：統一 message-like inbound pipeline（message/channel_post）([#20591](https://github.com/openclaw/openclaw/pull/20591))
 - **用途**：讓 Telegram `message` 與 `channel_post` 走同一套 dedupe/access/media pipeline。
 - **解決問題**：兩種 inbound 事件行為不一致導致處理差異。
 - **影響**：行為一致性提升，減少「同訊息不同通道」的意外。
 
-### ⭐ UI/Sessions：Chat UI 接受 canonical main session-key alias (#20311)
+### ⭐ UI/Sessions：Chat UI 接受 canonical main session-key alias ([#20311](https://github.com/openclaw/openclaw/pull/20311))
 - **用途**：讓 Chat UI 支援 canonical main session-key alias。
 - **解決問題**：main-session 路由不一致會造成操作困惑。
 - **影響**：UI 與 routing 一致性提升。
 
-### ⭐ Browser/Relay：重用既有 extension relay（避免 port occupied 直接失敗）(#20035)
+### ⭐ Browser/Relay：重用既有 extension relay（避免 port occupied 直接失敗）([#20035](https://github.com/openclaw/openclaw/pull/20035))
 - **用途**：relay port 被另一個 OpenClaw process 占用時，嘗試重用已在跑的 extension relay。
 - **解決問題**：多進程/重啟時容易出現 relay port collision。
 - **影響**：browser relay 穩定性提升，但仍保留對非 relay 的 collision 失敗（避免掩蓋其他服務）。
@@ -126,12 +126,12 @@
 - **解決問題**：避免 PATH 被劫持後以 trojan binary 繞過 allowlist。
 - **影響**：加固 exec 的 allowlist 可信邊界。
 
-### ⭐⭐ Security/Network：禁止非 loopback 使用明文 `ws://` (#20803)
+### ⭐⭐ Security/Network：禁止非 loopback 使用明文 `ws://` ([#20803](https://github.com/openclaw/openclaw/pull/20803))
 - **用途**：阻擋對非 loopback host 的 plaintext websocket。
 - **解決問題**：避免傳輸降級導致 token/內容被攔截。
 - **影響**：提升遠端連線的傳輸安全。
 
-### ⭐⭐ Security/Config：frontmatter YAML 改用 YAML 1.2 core schema (#20857)
+### ⭐⭐ Security/Config：frontmatter YAML 改用 YAML 1.2 core schema ([#20857](https://github.com/openclaw/openclaw/pull/20857))
 - **用途**：避免 YAML 1.1 的隱性型別轉換（例如 `on/off` 被當 boolean）。
 - **解決問題**：配置解析的意外 coercion 可能造成安全或行為偏差。
 - **影響**：設定解析更可預期。
@@ -141,12 +141,12 @@
 - **解決問題**：避免 tool-driven flow 被注入 untrusted sender 參數造成提權。
 - **影響**：Discord 工具鏈路更安全。
 
-### ⭐ Security/Media：TTS temp file 隨機命名 + owner-only 權限 (#20654)
+### ⭐ Security/Media：TTS temp file 隨機命名 + owner-only 權限 ([#20654](https://github.com/openclaw/openclaw/pull/20654))
 - **用途**：臨時檔命名用 `crypto.randomBytes()`，並設定 owner-only 權限。
 - **解決問題**：避免可預測檔名與權限過寬造成資訊外洩。
 - **影響**：媒體處理更安全。
 
-### ⭐ Security Headers：baseline headers（nosniff/no-referrer）(#10526)
+### ⭐ Security Headers：baseline headers（nosniff/no-referrer）([#10526](https://github.com/openclaw/openclaw/pull/10526))
 - **用途**：gateway HTTP 回應加上 `X-Content-Type-Options` 與 `Referrer-Policy`。
 - **解決問題**：降低 MIME sniffing 與 referer 洩漏。
 - **影響**：預設網路面攻擊面縮小。
@@ -155,52 +155,52 @@
 
 ## 錯誤修復（Bug Fixes）— by Star Rating
 
-### ⭐⭐⭐ Agents/Streaming：reasoning stream 下的 partial streaming/事件一致性修正 (#20635)
+### ⭐⭐⭐ Agents/Streaming：reasoning stream 下的 partial streaming/事件一致性修正 ([#20635](https://github.com/openclaw/openclaw/pull/20635))
 - **用途**：保持 reasoning streams 時 assistant partial streaming；統一處理 native `thinking_*` 事件；dedupe 混合 reasoning-end signals。
 - **解決問題**：串流狀態不一致導致 UI/使用者體驗不穩、tool error 狀態殘留。
 - **影響**：串流穩定性提升，重試成功後不再留下錯誤污染。
 
-### ⭐⭐ Telegram/Cron/Heartbeat：尊重 topic target，避免排程訊息落錯 thread (#19367)
+### ⭐⭐ Telegram/Cron/Heartbeat：尊重 topic target，避免排程訊息落錯 thread ([#19367](https://github.com/openclaw/openclaw/pull/19367))
 - **用途**：cron/heartbeat delivery 支援 `<chatId>:topic:<threadId>`。
 - **解決問題**：排程送訊息可能跑到最後活躍 thread 而非指定 topic。
 - **影響**：群組 topics 使用者的可靠投遞。
 
-### ⭐⭐ Gateway/Daemon：轉發 `TMPDIR` 修 SQLite `SQLITE_CANTOPEN` (#20512)
+### ⭐⭐ Gateway/Daemon：轉發 `TMPDIR` 修 SQLite `SQLITE_CANTOPEN` ([#20512](https://github.com/openclaw/openclaw/pull/20512))
 - **用途**：把 `TMPDIR` 轉入已安裝 service 的環境。
 - **解決問題**：macOS LaunchAgent 下 SQLite temp/journal 可能無法開啟。
 - **影響**：降低 daemon 在 macOS 上的隱性啟動失敗。
 
-### ⭐⭐ Agents/Billing：錯誤訊息帶出實際 model 名稱 (#20510)
+### ⭐⭐ Agents/Billing：錯誤訊息帶出實際 model 名稱 ([#20510](https://github.com/openclaw/openclaw/pull/20510))
 - **用途**：billing error 顯示觸發錯誤的 model（含 failover/lifecycle path）。
 - **解決問題**：使用者難以定位到底哪個 key/哪個模型缺額度。
 - **影響**：排查時間縮短。
 
-### ⭐ iOS/Onboarding：pairing flicker 與 reconnect 穩定性修正 (#20310/#20056)
+### ⭐ iOS/Onboarding：pairing flicker 與 reconnect 穩定性修正 ([#20310](https://github.com/openclaw/openclaw/pull/20310)/[#20056](https://github.com/openclaw/openclaw/pull/20056))
 - **用途**：修 auto-resume flicker；重置 stale pairing request；避免 duplicate pairing loops。
 - **解決問題**：iOS onboarding 的狀態抖動與重試不穩。
 - **影響**：配對體驗更穩。
 
-### ⭐ iOS/Screen：WKWebView lifecycle ownership 修正 (#20366)
+### ⭐ iOS/Screen：WKWebView lifecycle ownership 修正 ([#20366](https://github.com/openclaw/openclaw/pull/20366))
 - **用途**：將 WKWebView lifecycle 交由 coordinator 管理並明確 attach/detach。
 - **解決問題**：降低 `__NSArrayM insertObject:atIndex:` 等 gesture/lifecycle crash 風險。
 - **影響**：iOS screen tab 更新更穩定。
 
-### ⭐ Telegram/Agents：exec/bash tool-failure 警告改為 verbose-only (#20560)
+### ⭐ Telegram/Agents：exec/bash tool-failure 警告改為 verbose-only ([#20560](https://github.com/openclaw/openclaw/pull/20560))
 - **用途**：把工具失敗警告 gate 在 verbose mode。
 - **解決問題**：預設 Telegram 回覆太吵，影響可讀性。
 - **影響**：預設對話更乾淨，仍保留 verbose 診斷能力。
 
-### ⭐ Commands/Doctor：memory.backend=qmd 跳過 embedding-provider 警告 (#17263)
+### ⭐ Commands/Doctor：memory.backend=qmd 跳過 embedding-provider 警告 ([#17263](https://github.com/openclaw/openclaw/pull/17263))
 - **用途**：當 memory backend 是 qmd，跳過不需要的 embedding provider 警告。
 - **解決問題**：誤導性的警告增加維運噪音。
 - **影響**：doctor 輸出更精準。
 
-### ⭐ Canvas/A2UI：asset resolution 與 empty-state fallback 改善 (#20312)
+### ⭐ Canvas/A2UI：asset resolution 與 empty-state fallback 改善 ([#20312](https://github.com/openclaw/openclaw/pull/20312))
 - **用途**：改善 bundled assets 解析與 empty-state handling。
 - **解決問題**：UI fallback 偶發不渲染。
 - **影響**：Canvas/A2UI 更可靠。
 
-### ⭐ Channels/Matrix：formatted_body mention detection 修正 (#16941)
+### ⭐ Channels/Matrix：formatted_body mention detection 修正 ([#16941](https://github.com/openclaw/openclaw/pull/16941))
 - **用途**：處理 matrix.to mention 格式。
 - **解決問題**：mentions 偵測不一致導致路由/通知錯誤。
 - **影響**：Matrix channel 行為更一致。


### PR DESCRIPTION
Update `release-notes/2026-02-19.md` so all (#NNNN) references are clickable links to upstream OpenClaw PRs.

No content changes, link-only.