### PR TITLE
docs: add background for agent-browser + AgentCore Browser how-to

### DIFF
--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -24,6 +24,29 @@ Amazon Bedrock AgentCore Browser 提供「雲端可控的遠端瀏覽器 session
 
 ### 3) 串在一起後，你會得到什麼？
 
+#### Architecture / Data Flow（元件串接圖）
+
+```text
+User / Agent
+   |
+   | (commands: open/click/type/snapshot/eval/close)
+   v
+agent-browser CLI (provider: agentcore)
+   |
+   | 1) REST (SigV4): StartBrowserSession
+   |    - profileIdentifier=<AGENTCORE_PROFILE_ID>
+   v
+Amazon Bedrock AgentCore Browser
+   |\
+   | \ 2a) WebSocket (SigV4 headers): Automation Stream (CDP)
+   |  \
+   |   \ 2b) Live View Stream (Console)
+   |
+   | 3) (optional) SaveBrowserSessionProfile
+   v
+Profile persistence (cookies/localStorage)
+```
+
 本文件會帶你走完一條建議的落地路徑：
 
 1) 先用 **AWS CLI** 驗證 AgentCore Browser 的 session/profile 機制可用

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -26,6 +26,8 @@ Amazon Bedrock AgentCore Browser 提供「雲端可控的遠端瀏覽器 session
 
 #### Architecture / Data Flow（元件串接圖）
 
+一句話記：**REST 管 session/profile（建立/關閉/保存），CDP（WebSocket）管瀏覽器操作（open/click/type/eval…）**。
+
 ```text
 User / Agent
    |


### PR DESCRIPTION
Adds an introductory background section explaining why browser automation matters in OpenClaw, what agent-browser is, what Amazon Bedrock AgentCore Browser is, and an ASCII diagram of the recommended end-to-end flow (AWS CLI preflight → agent-browser verification → skillization → new agent session validation).