### PR TITLE
docs: mark Chromium install recommended but optional for AgentCore

### DIFF
--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -105,7 +105,9 @@ npm install
 npm run build
 npm i -g .
 
-# 2) 下載 Chromium（第一次需要）
+# 2) 下載 Chromium（建議，但可選）
+# 若你主要使用 AWS AgentCore Browser（`-p agentcore`），多數情況可先略過。
+# 只有在遇到 Playwright/Chromium 相關錯誤（例如 browser binaries not installed）時，再執行：
 agent-browser install
 
 # 3) 連 AWS Bedrock AgentCore Browser（需要 AWS credentials）
@@ -285,7 +287,14 @@ npm run build:native
 
 ---
 
-## 4. 安裝 Chromium（第一次必做）
+## 4. 安裝 Chromium（建議，但可選）
+
+若你主要使用 AWS AgentCore Browser（`agent-browser -p agentcore ...`），瀏覽器執行於雲端，**多數情況不需要**在本機安裝 Chromium。
+
+但仍建議在下列情境安裝（或排障時再補做）：
+
+- 你也會使用本機 provider（非 agentcore）
+- 你看到與 Playwright/Chromium 相關的錯誤（例如 `browser binaries not installed` / 找不到 Chromium）
 
 ```bash
 agent-browser install

--- a/docs/howto/aws-iam-minimal-botbedrockrole.md
+++ b/docs/howto/aws-iam-minimal-botbedrockrole.md
@@ -1,12 +1,5 @@
 # OpenClaw AWS IAM 最小權限配置（BotBedrockRole）
 
-```text
-Prompt to your Agent:
-請根據這份文件，直接用 AWS CLI 產生一個「AWS IAM Role（BotBedrockRole）」的建立操作指南（以 aws iam create-role / attach-role-policy / put-role-policy 為主），並引導我完成最小權限配置。
-文件：
-https://github.com/thepagent/claw-info/blob/main/docs/howto/aws-iam-minimal-botbedrockrole.md
-```
-
 本文提供一份可分享的 **OpenClaw 最小 IAM 權限配置**範例，目標是讓 OpenClaw 能：
 
 - 讀取帳單與成本資訊（唯讀）


### PR DESCRIPTION
This clarifies that `agent-browser install` is recommended but optional when using the AWS AgentCore provider (`-p agentcore`).

- TL;DR step updated
- Section 4 updated with guidance on when it’s needed (Playwright/Chromium missing binaries errors, local providers)