### PR TITLE
docs: add fallback to retrieve Live View URL

### DIFF
--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -401,6 +401,9 @@ agent-browser close
 
 此時可改用 **AWS CLI 先建立 session**（拿到 `sessionId`），再自行組出 Live View URL 供手動觀察/排障。
 
+- `<AGENTCORE_PROFILE_ID>`：AgentCore Browser 的 *profileIdentifier*（用來做 cookies/localStorage persistence），**不是** AWS CLI 的 `--profile`。
+- `<AWS_PROFILE_NAME>`：你本機 `~/.aws/config` / `~/.aws/credentials` 的 profile 名稱（用來選 AWS credentials），如果你是用環境變數或 role，也可以不帶。
+
 前置：建議安裝 `jq`（用來抽 `sessionId`）。
 
 ```bash

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -397,7 +397,7 @@ agent-browser close
 
 ### 6.2（可選）如果 `agent-browser open` 沒印出 sessionId / Live View：用 AWS CLI 先開 session 再組 URL
 
-有些情況下（版本差異、輸出被 wrapper 吃掉、只收集 stdout 沒收 stderr…），你可能看不到 `Session:` / `Live View:` 的輸出。
+有些情況下（版本差異、輸出被 wrapper 吃掉、或你只收集 stdout 沒收 stderr…），你可能看不到 `Session:` / `Live View:` 的輸出；此時即使 `agent-browser -p agentcore open ...` 成功建立了 session，你也不一定能直接得知 `sessionId`。
 
 此時可改用 **AWS CLI 先建立 session**（拿到 `sessionId`），再自行組出 Live View URL 供手動觀察/排障。
 


### PR DESCRIPTION
Fixes #76

---

## English

### What
- Docs update: add an optional fallback workflow to obtain `sessionId` via `aws bedrock-agentcore start-browser-session` and construct the AgentCore Browser **Live View URL**.
- Clarifies that in some environments `agent-browser -p agentcore open ...` may create a session successfully but the user may not see `Session:` / `Live View:` output (e.g. stderr not captured / wrappers / version differences), therefore `sessionId` is not readily visible.
- Clarifies `AGENTCORE_PROFILE_ID` (AgentCore *profileIdentifier*) vs AWS CLI `--profile`.

### Why
- Provides a reliable way to open Live View for manual observation/debugging when the `agent-browser` output is not available.

### Notes
- Mentions `jq` as a convenience dependency to extract `sessionId`.
- Reminds users not to paste `sessionId` / Live View URL in public issues/PRs.

---

## 中文（繁體 / zh-TW）

### 做了什麼
- 文件更新：新增一個「備援流程」：先用 `aws bedrock-agentcore start-browser-session` 取得 `sessionId`，再自行組出 AgentCore Browser 的 **Live View URL**。
- 補充說明：有些情境下 `agent-browser -p agentcore open ...` 即使成功建立 session，也可能因為看不到 `Session:` / `Live View:`（例如只收集 stdout、stderr 被吞、wrapper/版本差異）而**無法直接得知 `sessionId`**。
- 釐清 `AGENTCORE_PROFILE_ID`（AgentCore 的 *profileIdentifier*）與 AWS CLI 的 `--profile`（本機 credentials profile）的差異。

### 為什麼
- 當 `agent-browser` 的輸出沒有被完整保留下來時，仍能用一致且可重現的方法取得 Live View URL，方便人工觀察/排障。

### 備註
- 以 `jq` 作為抽取 `sessionId` 的便利工具（非硬性）。
- 提醒勿在公開 issue/PR 貼出 `sessionId` / Live View URL。
