### PR TITLE
Release notes: OpenClaw v2026.2.21 (2026-02-21)

### DIFF
--- a/release-notes/2026-02-21.md
+++ b/release-notes/2026-02-21.md
@@ -1,0 +1,204 @@
+# OpenClaw v2026.2.21 Release Notes (2026-02-21)
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.21)
+
+## 概述
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ 新增 Volcano Engine（Doubao）與 BytePlus provider/model，並完善 onboarding 流程（[#7967](https://github.com/openclaw/openclaw/pull/7967)）
+- ⭐⭐⭐ Discord：支援 thread-bound subagent sessions（thread 綁定的子代理）（[#21805](https://github.com/openclaw/openclaw/pull/21805)）
+- ⭐⭐ Telegram：簡化 streaming 預覽設定與相容舊 `streamMode`（[#22012](https://github.com/openclaw/openclaw/pull/22012)）
+- ⭐⭐ iOS：改善 Chat UI 顯示、輸入與 tool output 摘要（[#22122](https://github.com/openclaw/openclaw/pull/22122)）
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Gateway lock 與 tool-call synthetic IDs：雜湊基礎由 SHA-1 改為 SHA-256（[#7343](https://github.com/openclaw/openclaw/pull/7343)）
+- ⭐⭐⭐ ACP：對 `resource_link` metadata 進行跳脫，降低 prompt injection 風險（[#19009](https://github.com/openclaw/openclaw/pull/19009)）
+- ⭐⭐⭐ Gateway hooks：阻擋 `__proto__`/`constructor`/`prototype` traversal，避免原型鏈資料外洩（[#22213](https://github.com/openclaw/openclaw/pull/22213)）
+- ⭐⭐⭐ Browser：阻擋 upload path 的 symlink escape（[#21972](https://github.com/openclaw/openclaw/pull/21972)）
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐ Models/Kimi-Coding：補齊 `kimi-coding` implicit provider template，修復使用時 403（[#22409](https://github.com/openclaw/openclaw/pull/22409)）
+- ⭐⭐ Auto-reply/Tools：傳遞 `senderIsOwner` 參數，確保 owner-only tools 正確可用（[#22296](https://github.com/openclaw/openclaw/pull/22296)）
+- ⭐⭐ Providers/Copilot：移除 Claude 的 persisted `thinking` blocks，修復 follow-up 失敗（[#19459](https://github.com/openclaw/openclaw/pull/19459)）
+- ⭐ TUI/Input：抑制同 burst 的重複 backspace 事件（[#19318](https://github.com/openclaw/openclaw/pull/19318)）
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Providers/Onboarding：新增 Volcano Engine（Doubao）與 BytePlus provider/model（[#7967](https://github.com/openclaw/openclaw/pull/7967)）
+- **用途**：支援新的雲端 LLM 供應商與模型（含 coding variants），並在 onboarding 提供互動/非互動認證選項。
+- **解決問題**：降低新增 provider 的整合成本，讓使用者可更快完成設定。
+- **影響**：擴充可用模型版圖，提升部署彈性與可選擇性。
+
+### ⭐⭐⭐ Channels/CLI：新增 per-account/channel `defaultTo` 路由 fallback（[#16985](https://github.com/openclaw/openclaw/pull/16985)）
+- **用途**：讓 `openclaw agent --deliver` 在未指定 `--reply-to` 時，能依預設目標投遞。
+- **解決問題**：避免因缺少目標參數導致投遞失敗或需手動補參。
+- **影響**：提升 CLI 自動化/排程投遞的穩定性。
+
+### ⭐⭐⭐ Discord/Subagents：支援 thread-bound subagent sessions（[#21805](https://github.com/openclaw/openclaw/pull/21805)）
+- **用途**：在 Discord thread 內生成並綁定 subagent session，提供 per-thread focus/list 控制與路由延續。
+- **解決問題**：降低跨 thread/跨 session 的脈絡混淆，避免子任務回覆跑錯地方。
+- **影響**：強化 Discord 上的多任務協作體驗。
+
+### ⭐⭐ Telegram/Streaming：簡化 streaming 預覽設定並相容舊值（[#22012](https://github.com/openclaw/openclaw/pull/22012)）
+- **用途**：以 `channels.telegram.streaming` 布林值簡化設定，並自動對映 legacy `streamMode`。
+- **解決問題**：減少設定分歧與相容性困擾。
+- **影響**：降低升級成本，提升 streaming 行為一致性。
+
+### ⭐⭐ Discord：可設定 slash-command 回覆 ephemeral 預設值（[#16563](https://github.com/openclaw/openclaw/pull/16563)）
+- **用途**：針對 Discord slash command 回覆提供可配置的 ephemeral 預設。
+- **解決問題**：避免每次回覆都需手動選擇是否公開/隱藏。
+- **影響**：改善管理與互動體驗，降低誤發公開訊息的機率。
+
+### ⭐⭐ Discord：支援更新 forum channel 的 `available_tags`（[#12070](https://github.com/openclaw/openclaw/pull/12070)）
+- **用途**：透過 channel edit actions 管理 forum tags。
+- **解決問題**：減少需手動進入 Discord UI 調整 tag 的成本。
+- **影響**：提升社群/討論區治理效率。
+
+### ⭐⭐ iOS/Chat：清理 UI 雜訊並強化輸入/顯示（[#22122](https://github.com/openclaw/openclaw/pull/22122)）
+- **用途**：去除 inbound untrusted metadata/timestamp 前綴、精簡 tool outputs 呈現、輸入時 compact composer、支援點擊收起鍵盤。
+- **解決問題**：改善閱讀性與輸入體驗，降低 chat 內容被雜訊淹沒。
+- **影響**：提升 iOS 客戶端可用性與日常互動效率。
+
+### ⭐⭐ iOS/Watch：將 watch prompt actions 轉接到 iOS quick-reply（[#22123](https://github.com/openclaw/openclaw/pull/22123)）
+- **用途**：支援 watch 端通知操作轉接與 queued action handoff。
+- **解決問題**：避免 watch 操作與 iOS app 初始化不同步造成的回覆失敗。
+- **影響**：提升穿戴裝置互動可靠度。
+
+### ⭐⭐ Auto-reply/UI：增加 model fallback 的可視性與 /status 背景資訊（[#20704](https://github.com/openclaw/openclaw/pull/20704)）
+- **用途**：在 verbose logs 與 /status 顯示 active-model 與 fallback reason。
+- **解決問題**：排查「為何不是用預期模型」的疑難更容易。
+- **影響**：提升可觀測性與除錯效率。
+
+### ⭐ Agents/Subagents：調整預設 spawn depth 的一致性（[#22223](https://github.com/openclaw/openclaw/pull/22223)）
+- **用途**：預設 `maxSpawnDepth=2`，使 depth-1 orchestrator spawning 預設可用。
+- **解決問題**：減少 spawn depth 規則不一致導致的行為落差。
+- **影響**：讓子代理編排更穩定可預期。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Security/Agents：owner-ID obfuscation 改用專用 HMAC secret（[#7343](https://github.com/openclaw/openclaw/pull/7343)）
+- **用途**：以 `ownerDisplaySecret` 控制 owner 顯示混淆。
+- **解決問題**：將 owner obfuscation 與 gateway token handling 解耦，降低誤用/耦合風險。
+- **影響**：提升識別資訊處理的可控性與一致性。
+
+### ⭐⭐⭐ Security/Infra：gateway lock 與 synthetic IDs 的雜湊基礎改為 SHA-256（[#7343](https://github.com/openclaw/openclaw/pull/7343)）
+- **用途**：以 SHA-256 取代 SHA-1（保持截斷長度與 deterministic 行為）。
+- **解決問題**：強化雜湊基礎，降低 SHA-1 相關風險。
+- **影響**：提升整體基礎設施安全性。
+
+### ⭐⭐⭐ Security/Browser：阻擋 upload path symlink escapes（[#21972](https://github.com/openclaw/openclaw/pull/21972)）
+- **用途**：避免 browser upload 來源透過 symlink 逃逸至允許範圍外。
+- **解決問題**：降低被利用讀取不該讀取檔案的風險。
+- **影響**：強化 browser 工具的本地檔案邊界。
+
+### ⭐⭐⭐ Security/Gateway/Hooks：阻擋 prototype-chain traversal（[#22213](https://github.com/openclaw/openclaw/pull/22213)）
+- **用途**：在 webhook template path resolution 中阻擋 `__proto__`/`constructor`/`prototype`。
+- **解決問題**：避免原型鏈資料外洩或異常解析。
+- **影響**：降低 webhook 相關攻擊面。
+
+### ⭐⭐⭐ Security/OpenClawKit/UI：避免 inbound user context metadata blocks 泄漏至 UI（[#22142](https://github.com/openclaw/openclaw/pull/22142)）
+- **用途**：在 TUI/webchat/macOS 顯示邊界剝離 untrusted metadata 前綴。
+- **解決問題**：避免使用者訊息被注入偽造 metadata 造成誤導。
+- **影響**：提升前端顯示安全與一致性。
+
+### ⭐⭐⭐ Security/OpenClawKit/UI：TUI 渲染時剝離 inbound metadata blocks（[#22345](https://github.com/openclaw/openclaw/pull/22345)）
+- **用途**：保留使用者內容、移除 metadata 前綴。
+- **解決問題**：避免 metadata 片段污染對話記錄。
+- **影響**：減少 prompt injection 相關 UI 落點。
+
+### ⭐⭐⭐ Security/OpenClawKit/UI：移除 reply-tag streaming artifacts 與 metadata leaks（[#22346](https://github.com/openclaw/openclaw/pull/22346)）
+- **用途**：修正 TUI 於 streaming 情境下的顯示邊界。
+- **解決問題**：降低 reply tags/metadata 破碎造成的誤判。
+- **影響**：提升互動安全與可讀性。
+
+### ⭐⭐⭐ Security/Net：跨 origin redirect 時剝離敏感 header（[#20313](https://github.com/openclaw/openclaw/pull/20313)）
+- **用途**：在 `fetchWithSsrFGuard` 的 cross-origin redirects 移除 `Authorization`/`Cookie` 等 header。
+- **解決問題**：避免憑證被轉送到非預期 origin。
+- **影響**：降低 SSRF/redirect 造成的憑證外洩風險。
+
+### ⭐⭐⭐ Gateway/Security：Control UI auth hardened 行為對齊（[#20684](https://github.com/openclaw/openclaw/pull/20684)）
+- **用途**：即使設定 `gateway.controlUi.allowInsecureAuth`，仍要求 secure context 與 paired-device checks。
+- **解決問題**：避免錯誤設定導致不安全的 control UI auth 行為。
+- **影響**：提升 control UI 的預設安全基線。
+
+### ⭐⭐⭐ Shared/Security：拒絕非 loopback 的不安全 `ws://` deep links（[#21970](https://github.com/openclaw/openclaw/pull/21970)）
+- **用途**：防止使用 `ws://`（非 loopback）設定遠端 gateway。
+- **解決問題**：避免明文 websocket 帶來的竊聽/中間人風險。
+- **影響**：提升跨裝置設定流程的傳輸安全。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐ Models/Kimi-Coding：補齊 implicit provider template，修復 403（[#22409](https://github.com/openclaw/openclaw/pull/22409)）
+- **用途**：加入 `kimi-coding` 正確的 provider template（`anthropic-messages` API type 與 base URL）。
+- **解決問題**：修復 Kimi for Coding 使用時 403。
+- **影響**：提升 Kimi-Coding 可用性與相容性。
+
+### ⭐⭐ Auto-reply/Tools：傳遞 `senderIsOwner` 參數（[#22296](https://github.com/openclaw/openclaw/pull/22296)）
+- **用途**：在 embedded queued/followup runner params 轉遞 `senderIsOwner`。
+- **解決問題**：避免 owner-only tools 對授權 sender 變成不可用。
+- **影響**：權限判斷更一致，降低功能誤鎖。
+
+### ⭐⭐ Discord：修復 model picker 缺 provider 時的返回導航（[#21458](https://github.com/openclaw/openclaw/pull/21458)）
+- **用途**：恢復 picker back navigation 並補足流程文件。
+- **解決問題**：避免使用者在缺 provider 時卡住。
+- **影響**：提升 Discord 端設定/選模流暢度。
+
+### ⭐⭐ Providers/Copilot：移除 Claude persisted `thinking` blocks（[#19459](https://github.com/openclaw/openclaw/pull/19459)）
+- **用途**：保留 turn 結構/tool blocks，但移除導致錯誤的 persisted `thinking`。
+- **解決問題**：修復 follow-up request 因 `thinkingSignature` payload 無效而失敗。
+- **影響**：提升 Copilot + Claude 的穩定性。
+
+### ⭐ Auto-reply/WebChat：避免 runtime channel label 誤預設（[#21534](https://github.com/openclaw/openclaw/pull/21534)）
+- **用途**：避免 webchat session 的 channel label 被預設成無關 provider（例如 whatsapp）。
+- **解決問題**：避免 channel-specific 格式化建議錯置。
+- **影響**：提升 webchat 使用體驗與指引準確度。
+
+### ⭐ Heartbeat/Active hours：限制 `24` sentinel 解析為 `24:00`（[#21410](https://github.com/openclaw/openclaw/pull/21410)）
+- **用途**：時間驗證時拒絕如 `24:30` 的無效值。
+- **解決問題**：避免不合法設定造成行為不可預期。
+- **影響**：提升設定驗證嚴謹度。
+
+### ⭐ Heartbeat：同 start/end 視為 zero-width window（[#21408](https://github.com/openclaw/openclaw/pull/21408)）
+- **用途**：將 `activeHours` start==end 視為永遠不在 window 內。
+- **解決問題**：避免被誤判為 always-active。
+- **影響**：排程/heartbeat 行為更符合直覺。
+
+### ⭐ CLI/Pairing：pairing list/approve 預設採用唯一可用 channel（[#21527](https://github.com/openclaw/openclaw/pull/21527)）
+- **用途**：省略 channel 參數時自動選用唯一 channel。
+- **解決問題**：避免 TUI-only 環境在 `pairing required` 時需猜參數。
+- **影響**：提升新裝/故障復原體驗。
+
+### ⭐ TUI/Pairing：提供 pairing-required 復原指引（[#21841](https://github.com/openclaw/openclaw/pull/21841)）
+- **用途**：gateway disconnect 回 `pairing required` 時顯示明確修復步驟。
+- **解決問題**：避免使用者不知如何解除阻塞。
+- **影響**：提升 quickstart 與故障自救能力。
+
+### ⭐ TUI/Input：抑制重複 backspace 事件（[#19318](https://github.com/openclaw/openclaw/pull/19318)）
+- **用途**：在同 burst window 內抑制 duplicate backspace。
+- **解決問題**：修復 SSH composer 每按一次 backspace 可能刪兩字。
+- **影響**：提升終端互動穩定性。
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 6 | 1 | 擴充 providers、提升 Discord/iOS/Telegram 體驗與可觀測性 |
+| 安全性 | 10 | 0 | 0 | 強化雜湊基礎、UI/網路邊界、hook/browser 安全性 |
+| 錯誤修復 | 0 | 4 | 6 | 修復 Kimi-Coding、Copilot/Claude、webchat、heartbeat、pairing、TUI 輸入等問題 |
+| **總計** | 13 | 10 | 7 | 30 項重點更新 |
+
+**發佈日期**: 2026-02-21  
+**版本**: 2026.2.21  
+**狀態**: Production Ready  
+**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.2.21

--- a/release-notes/2026-02-21.md
+++ b/release-notes/2026-02-21.md
@@ -34,6 +34,43 @@
 - **解決問題**：降低新增 provider 的整合成本，讓使用者可更快完成設定。
 - **影響**：擴充可用模型版圖，提升部署彈性與可選擇性。
 
+```text
++----------------------+
+|        User          |
++----------+-----------+
+           |
+           |  choose provider + enter API key
+           v
++----------------------+
+|  Onboarding (UI/CLI) |
++----------+-----------+
+           |
+           |  save credentials + select default model
+           v
++----------------------+
+|   Config / Secrets   |
++----------+-----------+
+           |
+           |  load provider catalog
+           v
++----------------------+
+|     Model Picker     |
++----------+-----------+
+           |
+           |  run with chosen provider/model
+           v
++----------------------+
+| Provider Adapter     |
+| (OpenAI-compatible)  |
++----------+-----------+
+           |
+           v
++----------------------+
+| Volcengine / BytePlus|
+|   API Endpoint(s)    |
++----------------------+
+```
+
 ### ⭐⭐⭐ Channels/CLI：新增 per-account/channel `defaultTo` 路由 fallback（[#16985](https://github.com/openclaw/openclaw/pull/16985)）
 - **用途**：讓 `openclaw agent --deliver` 在未指定 `--reply-to` 時，能依預設目標投遞。
 - **解決問題**：避免因缺少目標參數導致投遞失敗或需手動補參。
@@ -44,10 +81,52 @@
 - **解決問題**：降低跨 thread/跨 session 的脈絡混淆，避免子任務回覆跑錯地方。
 - **影響**：強化 Discord 上的多任務協作體驗。
 
+```text
++----------------------+
+| Main Channel / DM    |
++----------+-----------+
+           |
+           | sessions_spawn(thread=true)
+           v
++----------------------+
+| Discord Thread       |
+| (task workspace)     |
++----+-------------+---+
+     |             ^
+     | user msgs   | subagent replies
+     v             |
++----------------------+
+| Subagent Session     |
+| (isolated context)   |
++----------------------+
+```
+
 ### ⭐⭐ Telegram/Streaming：簡化 streaming 預覽設定並相容舊值（[#22012](https://github.com/openclaw/openclaw/pull/22012)）
 - **用途**：以 `channels.telegram.streaming` 布林值簡化設定，並自動對映 legacy `streamMode`。
 - **解決問題**：減少設定分歧與相容性困擾。
 - **影響**：降低升級成本，提升 streaming 行為一致性。
+
+```text
++----------------------+
+| User Config          |
+| - streaming?         |
+| - (legacy) streamMode|
++----------+-----------+
+           |
+           v
++-------------------------------+
+| Config Normalizer             |
+| - streaming=true/false        |
+| - map legacy streamMode ->    |
+|   streaming boolean           |
++----------+--------------------+
+           |
+           v
++----------------------+
+| Telegram Preview     |
+| Streaming (one path) |
++----------------------+
+```
 
 ### ⭐⭐ Discord：可設定 slash-command 回覆 ephemeral 預設值（[#16563](https://github.com/openclaw/openclaw/pull/16563)）
 - **用途**：針對 Discord slash command 回覆提供可配置的 ephemeral 預設。


### PR DESCRIPTION
Fixes #84

- Added release notes: release-notes/2026-02-21.md
- Source: https://github.com/openclaw/openclaw/releases/tag/v2026.2.21
- Followed release-notes/GUIDELINES.md (overview + detailed sections + summary table; all items include PR links).