### PR TITLE
Release notes: OpenClaw 2026.2.22

### DIFF
--- a/release-notes/2026-02-22.md
+++ b/release-notes/2026-02-22.md
@@ -1,0 +1,195 @@
+# OpenClaw v2026.2.22 Release Notes (2026-02-22)
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)
+
+> Note: npm 後續發佈了修正版：`openclaw@2026.2.22-1`、`openclaw@2026.2.22-2`（見本文末「npm patch deltas」）。
+
+## 概述
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ 新增 Mistral provider（含 memory embeddings 與 voice 支援）（[#23845](https://github.com/openclaw/openclaw/pull/23845)）
+- ⭐⭐⭐ 新增可選的內建自動更新機制（`update.auto.*`，預設關閉；stable 有 rollout delay+jitter、beta 每小時 cadence）（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐⭐ CLI：新增 `openclaw update --dry-run`，可預覽更新行為且不改動設定/不重啟（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐⭐ 新增 Synology Chat channel plugin（webhook ingress、DM routing、outbound send/media、per-account 設定、DM policy controls）（[#23012](https://github.com/openclaw/openclaw/pull/23012)）
+- ⭐⭐ Config UI：新增「支援 tag 的設定篩選」，並改善欄位 label/help，使設定更好找（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐ iOS/Talk：預抓 TTS segments，並抑制預期的 speech-cancellation errors，提升播放順暢度（[#22833](https://github.com/openclaw/openclaw/pull/22833)）
+- ⭐ Memory/FTS：新增西文/葡文 stop-word filtering 的 query expansion（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐ Memory/FTS：新增日文 query expansion tokenization 與 stop-word filtering（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐ Memory/FTS：新增韓文 stop-word filtering 與 particle-aware keyword extraction（[#18899](https://github.com/openclaw/openclaw/pull/18899)）
+- ⭐ Docs/Subagents：thread-bound sessions 的說明改為「以 channel 能力為主」並列出支援 thread 的 channels（[#23589](https://github.com/openclaw/openclaw/pull/23589)）
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ `openclaw config get` 會在輸出前遮蔽敏感資訊，避免 credentials 泄漏到終端機輸出/命令歷史（[#13683](https://github.com/openclaw/openclaw/pull/13683)）
+- ⭐⭐ Security/Voice Call：加固 media stream WebSocket（pre-auth idle timeout、pending/per-IP 限制、總連線上限），降低 DoS 風險（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐⭐ Security/Sessions：在 sessions history 類輸出中遮蔽敏感 token pattern，並提供 `contentRedacted` metadata（[#16928](https://github.com/openclaw/openclaw/pull/16928)）
+- ⭐ Security/Exec：增加 `tools.exec.safeBinTrustedDirs`，並以 resolved absolute path 執行 allowlisted safe-bin，降低 binary shadowing / PATH 置換風險（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐ Security/Elevated：修正 elevated 授權比對僅以 sender identity 判斷，封堵 recipient-token bypass（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Install/Discord Voice：將 `@discordjs/opus` 改為 optional dependency，避免 native build 失敗導致 `openclaw` 安裝/更新硬失敗（仍保留 `opusscript` fallback）（[#23737](https://github.com/openclaw/openclaw/pull/23737)）
+- ⭐⭐⭐ Browser/Extension Relay：大幅強化 MV3 worker 的穩定性（重連、tab state rehydrate、operation locks、timeouts、badge refresh 等）（[#15099](https://github.com/openclaw/openclaw/pull/15099)）
+- ⭐⭐ Exec/Background：不再對背景 exec 套用預設 timeout（除非明確設定），避免長工被誤殺（[#23303](https://github.com/openclaw/openclaw/pull/23303)）
+- ⭐⭐ Slack/Threading：修復 thread/session 脈絡在第一輪後失效等問題，提升 thread 內連續對話可靠性（[#23843](https://github.com/openclaw/openclaw/pull/23843)）
+- ⭐ Docker/Setup：預先建立 `$OPENCLAW_CONFIG_DIR/identity`，避免 restrictive bind mounts 下 EACCES（[#23948](https://github.com/openclaw/openclaw/pull/23948)）
+- ⭐ Webchat：多項效能與 session routing 修復，避免 sent turns render 延遲與跨 channel 誤路由（[#14928](https://github.com/openclaw/openclaw/pull/14928)）
+- ⭐ Telegram/Media：媒體下載失敗時會回覆使用者，而非靜默丟棄（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- ⭐ Gateway/Pairing：scope bundles/auto-approve/legacy 兼容等多項修復，降低 pairing-required 迴圈（[#22582](https://github.com/openclaw/openclaw/pull/22582)）
+- ⭐ Cron：修正 `cron.maxConcurrentRuns` 的計時器行為，並改善 manual run / timeout / startup catch-up 的一致性（[#11595](https://github.com/openclaw/openclaw/issues/11595)）
+- ⭐ Plugins/Install：移除 `workspace:*` devDependency 以避免 npm 發佈插件安裝時的 `EUNSUPPORTEDPROTOCOL`（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Provider/Mistral：新增 Mistral provider（[#23845](https://github.com/openclaw/openclaw/pull/23845)）
+- **用途**：可直接在 OpenClaw 設定並使用 Mistral provider，並支援 memory embeddings 與 voice 流程。
+- **解決問題**：降低接入新 provider 的整合成本，讓部署選項更完整。
+- **影響**：擴充可用模型與語音/記憶能力的供應商選擇，提升容錯與成本彈性。
+
+### ⭐⭐⭐ Update/Core：可選的內建自動更新（`update.auto.*`）（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：對 package install 提供「內建」自動更新策略（預設關閉），並支援 stable rollout delay+jitter、beta hourly cadence。
+- **解決問題**：降低人工維護成本，同時避免一上線就大量節點同時更新造成風險。
+- **影響**：更適合長期運行的 agent 部署；可逐步導入自動更新而不強迫啟用。
+
+### ⭐⭐ CLI/Update：新增 `openclaw update --dry-run`（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：預覽更新 channel/tag/target/restart 等行為，但不改動 config、不安裝、不同步 plugins、不重啟。
+- **解決問題**：降低「執行更新指令」的不確定性，讓操作更可預期。
+- **影響**：提升變更管理與維運安全性，特別適合在 CI/排程前先做檢視。
+
+### ⭐⭐ Channels/Synology Chat：新增原生 plugin（[#23012](https://github.com/openclaw/openclaw/pull/23012)）
+- **用途**：支援 Synology Chat webhook ingress、DM routing、outbound send/media、per-account 設定與 DM policy。
+- **解決問題**：讓使用者能在 Synology Chat 中使用 OpenClaw，而不需自行維護轉接層。
+- **影響**：擴大 channel 覆蓋面，讓企業/家用 NAS 環境更容易整合。
+
+### ⭐⭐ Config/UI：tag-aware settings filtering（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：在 dashboard config screen 以 tag 進行設定篩選，並改善欄位 label/help。
+- **解決問題**：設定項目多時難以搜尋/理解的痛點。
+- **影響**：降低新手上手成本，提升設定可發現性。
+
+### ⭐ iOS/Talk：TTS 預抓與錯誤抑制（[#22833](https://github.com/openclaw/openclaw/pull/22833)）
+- **用途**：預抓 TTS segments、避免預期的 cancellation errors 造成噪音。
+- **解決問題**：改善 iOS talk 播放卡頓或不必要錯誤訊息。
+- **影響**：更平滑的語音互動體驗。
+
+### ⭐ Memory/FTS：多語系 stop-word 與 query expansion（[#18899](https://github.com/openclaw/openclaw/pull/18899)；其餘見 [v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：強化 FTS-only search 模式下的 query expansion（西/葡、日、韓、阿拉伯等），減少 filler、改善 tokenization。
+- **解決問題**：非英文語系在 conversational recall 時易因停用字/分詞導致召回品質下降。
+- **影響**：提升多語系記憶檢索品質與穩定性。
+
+### ⭐ Docs/Subagents：thread-bound guidance（[#23589](https://github.com/openclaw/openclaw/pull/23589)）
+- **用途**：將 thread-bound session 的說明改為 channel-first，並列出實際支援 thread 的 channels。
+- **解決問題**：避免文件過度 Discord-specific 造成誤解。
+- **影響**：提升跨平台使用的可讀性。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Security/CLI：`openclaw config get` 敏感值遮蔽（[#13683](https://github.com/openclaw/openclaw/pull/13683)）
+- **用途**：在 CLI 輸出 config 前自動遮蔽敏感欄位。
+- **解決問題**：避免 credentials 進入 terminal scrollback、shell history、截圖或 log。
+- **影響**：降低誤洩漏風險，改善安全預設值。
+
+### ⭐⭐ Security/Voice Call：WebSocket 連線加固（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：加入 pre-auth idle timeout、pending/per-IP 限制、總連線上限。
+- **解決問題**：降低 pre-auth idle connection 的 DoS 攻擊面。
+- **影響**：強化語音通話端點的可用性與韌性。
+
+### ⭐⭐ Security/Sessions：敏感 token pattern 遮蔽（[#16928](https://github.com/openclaw/openclaw/pull/16928)）
+- **用途**：對 sessions history 類輸出進行敏感字串遮蔽並標註 redacted 狀態。
+- **解決問題**：減少在 debug/回放時不小心暴露 token 的風險。
+- **影響**：更安全的診斷與可觀測性。
+
+### ⭐ Security/Exec：safe-bin 信任目錄與絕對路徑執行（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：避免 PATH 派生目錄被誤信任；對 allowlisted safe-bin 以 resolved absolute path 執行。
+- **解決問題**：封堵 binary shadowing / PATH 置換導致的 approval/allowlist 繞過風險。
+- **影響**：提升 host exec 的安全性一致性。
+
+### ⭐ Security/Elevated：sender-only 授權比對（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：授權判斷僅以 sender identity，比對規則更嚴謹。
+- **解決問題**：封堵 recipient-token 相關 bypass。
+- **影響**：降低 elevated 權限誤授權風險。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Install/Discord Voice：`@discordjs/opus` optional dependency（[#23737](https://github.com/openclaw/openclaw/pull/23737)）
+- **用途**：安裝/更新時不再因 Opus native build 失敗而硬失敗。
+- **解決問題**：降低跨平台（尤其是無法編譯 native module 的環境）安裝阻礙。
+- **影響**：提升整體安裝成功率與升級順暢度。
+
+### ⭐⭐⭐ Browser/Extension Relay：MV3 穩定性重構（[#15099](https://github.com/openclaw/openclaw/pull/15099)）
+- **用途**：改善 relay 掉線後的自動重連、tab state 續接、operation locks、timeouts、badge refresh 等。
+- **解決問題**：降低 `target_closed`/debugger detach/worker lifecycle 等造成的不可用情況。
+- **影響**：Extension Relay 的 Live 操作更可靠，降低人工介入。
+
+### ⭐⭐ Exec/Background：背景 exec 不再套用預設 timeout（[#23303](https://github.com/openclaw/openclaw/pull/23303)）
+- **用途**：背景 job（`background: true` 或 `yieldMs`）在未明確設定 timeout 時不會被預設 timeout 終止。
+- **解決問題**：修復長工被誤殺導致的任務中斷。
+- **影響**：提升排程/長任務工具的可靠性。
+
+### ⭐⭐ Slack/Threading：thread 內 context 延續修復（[#23843](https://github.com/openclaw/openclaw/pull/23843)）
+- **用途**：修復 thread history/context injection 與 session init 的 first-turn-only gate 問題。
+- **解決問題**：避免在 Slack thread 裡第二輪開始失去脈絡。
+- **影響**：提升 thread 內連續對話可用性。
+
+### ⭐ Docker/Setup：預建 identity 目錄（[#23948](https://github.com/openclaw/openclaw/pull/23948)）
+- **用途**：在 `docker-setup.sh` 預先建立 identity 目錄。
+- **解決問題**：避免 restrictive bind mounts 下出現 `EACCES ... /identity`。
+- **影響**：改善 Docker 部署穩定性。
+
+### ⭐ Webchat：渲染/效能與 routing 修復（[#14928](https://github.com/openclaw/openclaw/pull/14928)）
+- **用途**：sent turns 立即渲染、避免不必要 full-history refresh、修復外部 session routing metadata 被覆寫。
+- **解決問題**：減少 UI 延遲與跨 channel 誤路由。
+- **影響**：提升 Webchat 使用體驗與一致性。
+
+### ⭐ Telegram/Media：下載失敗回覆（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：媒體下載失敗時提供使用者可見回覆。
+- **解決問題**：避免訊息「消失」造成誤判。
+- **影響**：提升可觀測性與可用性。
+
+### ⭐ Gateway/Pairing/Scopes：多項相容與 loop 修復（[#22582](https://github.com/openclaw/openclaw/pull/22582)）
+- **用途**：調整預設 scopes bundles，並修復 pairing-required loop 的多種情境。
+- **解決問題**：降低本機 CLI/TUI 反覆被要求 pairing 的摩擦。
+- **影響**：提升操作流暢度與可用性。
+
+### ⭐ Cron：並行與 manual run 一致性修復（[#11595](https://github.com/openclaw/openclaw/issues/11595)；其餘見 release）
+- **用途**：honor `cron.maxConcurrentRuns`、改善 forced run timeout guard、startup catch-up 等行為。
+- **解決問題**：避免 due jobs 被序列化或 manual run 導致排程狀態不一致。
+- **影響**：提升 cron 排程在重啟/強制執行下的穩定性。
+
+### ⭐ Plugins/Install：移除 `workspace:*` devDeps（[v2026.2.22](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)）
+- **用途**：避免 npm 發佈插件在 `npm install --omit=dev` 時因 `workspace:*` 造成 `EUNSUPPORTEDPROTOCOL`。
+- **解決問題**：修復插件安裝失敗。
+- **影響**：提升 plugin 生態的可用性。
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 2 | 3 | 5 | 新增 Mistral provider、可選自動更新、Synology Chat channel，並持續強化 Config/UI 與多語系記憶檢索。 |
+| 安全性 | 1 | 2 | 2 | CLI 輸出遮蔽敏感值為最重要改動，並加固 Voice Call/Sessions/Exec/Elevated 的安全預設。 |
+| 錯誤修復 | 2 | 2 | 6 | Discord voice 安裝韌性、Extension Relay 穩定性、Slack/Webchat/Telegram/Cron 等多面向可靠性提升。 |
+| **總計** | **5** | **7** | **13** | **25 items** |
+
+**發佈日期**: 2026-02-22  
+**版本**: 2026.2.22  
+**狀態**: Production Ready  
+**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.2.22
+
+---
+
+## npm patch deltas (post-release)
+
+- `2026.2.22-1`
+  - Gateway/Chat UI：sanitize untrusted wrapper markup in final payloads.
+
+- `2026.2.22-2`
+  - Cron：preserve due jobs after manual runs（[#23994](https://github.com/openclaw/openclaw/pull/23994)）
+  - Exec：維持 implicit sandbox default，並回復 baseline（未明確設定 host 時預設不彈 approval）


### PR DESCRIPTION
Closes #92.

- Add zh-TW release notes for upstream OpenClaw v2026.2.22
- Source: https://github.com/openclaw/openclaw/releases/tag/v2026.2.22
