### PR TITLE
docs: add OS cron vs OpenClaw cron comparison to cron.md

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -343,23 +343,23 @@ Cron 作業失敗時的行為：
 
 ### 🔴 Bugs
 
-| Issue | 標題 | 說明 |
-|-------|------|------|
-| [#18120](https://github.com/openclaw/openclaw/issues/18120) | runningAtMs 永不自動清除 | Session timeout 後 runningAtMs 未清除，導致 cron 永久停止執行 |
-| [#17979](https://github.com/openclaw/openclaw/issues/17979) | cron tool 從 main session 呼叫超時 | cron.status WS frame 無回應，但 cron job 本身正常執行 |
-| [#17599](https://github.com/openclaw/openclaw/issues/17599) | WhatsApp delivery 間歇性失敗 | ~20% 機率出現 `cron delivery target is missing` 錯誤 |
-| [#16156](https://github.com/openclaw/openclaw/issues/16156) | 週期性 cron job 不執行 | `schedule.kind: "cron"` 只更新 nextRunAtMs 但不觸發執行 |
-| [#16054](https://github.com/openclaw/openclaw/issues/16054) | 自訂 provider 靜默重命名 | provider 名稱被改寫，導致 cron job 報 "model not allowed" |
-| [#14751](https://github.com/openclaw/openclaw/issues/14751) | cron list Gateway 超時 | `cron list` 回傳 60s+ 超時，但 job 正常執行 |
-| [#12440](https://github.com/openclaw/openclaw/issues/12440) | cron list 導致排程被跳過 | 呼叫 `cron list` 後 recomputeNextRuns() 跳過未執行的 job |
+| Issue | 標題 | 說明 | 狀態 |
+|-------|------|------|------|
+| [#18120](https://github.com/openclaw/openclaw/issues/18120) | runningAtMs 永不自動清除 | Session timeout 後 runningAtMs 未清除，導致 cron 永久停止執行 | ✅ 已修復 (2026-02-22) |
+| [#17979](https://github.com/openclaw/openclaw/issues/17979) | cron tool 從 main session 呼叫超時 | cron.status WS frame 無回應，但 cron job 本身正常執行 | ✅ 已修復 (2026-02-22) |
+| [#17599](https://github.com/openclaw/openclaw/issues/17599) | WhatsApp delivery 間歇性失敗 | ~20% 機率出現 `cron delivery target is missing` 錯誤 | ✅ 已關閉 (stale, 2026-02-23) |
+| [#16156](https://github.com/openclaw/openclaw/issues/16156) | 週期性 cron job 不執行 | `schedule.kind: "cron"` 只更新 nextRunAtMs 但不觸發執行 | ✅ 已修復 (2026-02-20) |
+| [#16054](https://github.com/openclaw/openclaw/issues/16054) | 自訂 provider 靜默重命名 | provider 名稱被改寫，導致 cron job 報 "model not allowed" | ✅ 已關閉 (stale, 2026-02-22) |
+| [#14751](https://github.com/openclaw/openclaw/issues/14751) | cron list Gateway 超時 | `cron list` 回傳 60s+ 超時，但 job 正常執行 | ✅ 已修復 (2026-02-22) |
+| [#12440](https://github.com/openclaw/openclaw/issues/12440) | cron list 導致排程被跳過 | 呼叫 `cron list` 後 recomputeNextRuns() 跳過未執行的 job | 🔴 仍開啟 (stale) |
 
 ### 🟢 Feature Requests
 
-| Issue | 標題 | 說明 |
-|-------|------|------|
-| [#13900](https://github.com/openclaw/openclaw/issues/13900) | Ephemeral Cron Sessions | 請求 cron session 執行後自動清除，避免 token 累積 |
-| [#13598](https://github.com/openclaw/openclaw/issues/13598) | Cron 故障排除手冊 | 請求新增 cron troubleshooting playbook 文件 |
-| [#12736](https://github.com/openclaw/openclaw/issues/12736) | tools.cron.tools.deny 設定 | 請求 cron job 層級的工具限制設定 |
+| Issue | 標題 | 說明 | 狀態 |
+|-------|------|------|------|
+| [#13900](https://github.com/openclaw/openclaw/issues/13900) | Ephemeral Cron Sessions | 請求 cron session 執行後自動清除，避免 token 累積 | 🟡 開啟中 |
+| [#13598](https://github.com/openclaw/openclaw/issues/13598) | Cron 故障排除手冊 | 請求新增 cron troubleshooting playbook 文件 | 🟡 開啟中 |
+| [#12736](https://github.com/openclaw/openclaw/issues/12736) | tools.cron.tools.deny 設定 | 請求 cron job 層級的工具限制設定 | 🟡 開啟中 |
 
 ---
 

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -365,6 +365,14 @@ Cron 作業失敗時的行為：
 
 ## OS cron 與 OpenClaw cron 比較
 
+### 核心差異
+
+OS cron 直接執行 shell 指令，行為完全確定（deterministic）——腳本寫什麼就跑什麼，不受任何外部因素影響。
+
+OpenClaw cron 本質上是**透過 prompt 驅動 agent 去做某件事**。即使 message 寫得再明確，LLM 的行為仍是非確定性的（non-deterministic）——agent 可能正確執行，也可能偏離指令、加入額外判斷、或產生非預期的副作用。這是使用 AI agent 做自動化時必須接受的根本限制。
+
+> 因此，對於**不需要 AI 判斷、邏輯已固定**的任務，OS cron 的可靠性天生優於 OpenClaw cron。
+
 ### 比較表
 
 | 項目 | OS cron | OpenClaw cron |


### PR DESCRIPTION
Closes #94

新增 OS cron 與 OpenClaw cron 比較章節，包含：
- 比較表（含說明，非單純 ✅/❌）
- 何時用哪個的建議
- 邏輯全在 shell script 時的強制執行模式