### PR TITLE
docs: mention token consumption and LLM dependency risk in cron comparison

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -371,6 +371,8 @@ OS cron 直接執行 shell 指令，行為完全確定（deterministic）——�
 
 OpenClaw cron 本質上是**透過 prompt 驅動 agent 去做某件事**。即使 message 寫得再明確，LLM 的行為仍是非確定性的（non-deterministic）——agent 可能正確執行，也可能偏離指令、加入額外判斷、或產生非預期的副作用。這是使用 AI agent 做自動化時必須接受的根本限制。
 
+此外，OpenClaw cron 每次執行都會消耗 LLM token；當所有 LLM provider 都失敗（quota 耗盡、API 故障、憑證過期）時，cron job 也會跟著失敗——而這往往正是你最需要自動化任務正常運作的時候。
+
 > 因此，對於**不需要 AI 判斷、邏輯已固定**的任務，OS cron 的可靠性天生優於 OpenClaw cron。
 
 ### 比較表


### PR DESCRIPTION
在 OS cron vs OpenClaw cron 核心差異段落補充兩點：
- OpenClaw cron 每次執行消耗 LLM token
- 當所有 LLM provider 失敗時，OpenClaw cron 也會失敗