### PR TITLE
docs: add FAQ on PATH issue in cron isolated session

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -371,6 +371,8 @@ OS cron 直接執行 shell 指令，行為完全確定（deterministic）——�
 
 OpenClaw cron 本質上是**透過 prompt 驅動 agent 去做某件事**。即使 message 寫得再明確，LLM 的行為仍是非確定性的（non-deterministic）——agent 可能正確執行，也可能偏離指令、加入額外判斷、或產生非預期的副作用。這是使用 AI agent 做自動化時必須接受的根本限制。
 
+此外，OpenClaw cron 每次執行都會消耗 LLM token；當所有 LLM provider 都失敗（quota 耗盡、API 故障、憑證過期）時，cron job 也會跟著失敗——而這往往正是你最需要自動化任務正常運作的時候。
+
 > 因此，對於**不需要 AI 判斷、邏輯已固定**的任務，OS cron 的可靠性天生優於 OpenClaw cron。
 
 ### 比較表

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -337,6 +337,23 @@ Cron 作業失敗時的行為：
 
 **A:** 可以。使用 `openclaw gateway restart` 重新加载配置。
 
+### Q4: Cron job 找不到指令（如 `npm`、`node`）？
+
+**A:** OpenClaw cron 的 isolated session 使用精簡的 PATH，不會繼承使用者的 shell 環境（如 fnm、nvm、pyenv 等）。
+
+解法：在腳本或 message 中使用**絕對路徑**：
+
+```bash
+# 錯誤：依賴 PATH
+LATEST=$(npm show openclaw version)
+
+# 正確：使用絕對路徑
+NPM=/home/pahud/.local/share/fnm/node-versions/v24.13.1/installation/bin/npm
+LATEST=$($NPM show openclaw version)
+```
+
+同理，若直接在 `--message` 中執行指令，也應使用絕對路徑。
+
 ---
 
 ## 已知問題（Open Issues）

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -348,7 +348,7 @@ Cron 作業失敗時的行為：
 LATEST=$(npm show openclaw version)
 
 # 正確：使用絕對路徑
-NPM=/home/pahud/.local/share/fnm/node-versions/v24.13.1/installation/bin/npm
+NPM=/home/<user>/.local/share/fnm/node-versions/<version>/installation/bin/npm
 LATEST=$($NPM show openclaw version)
 ```
 


### PR DESCRIPTION
新增 Q4：cron isolated session 不繼承使用者 shell 環境（fnm/nvm 等），需使用絕對路徑。來自實際踩坑經驗（2026-02-23）。