### PR TITLE
docs: remove fn main() bug note (already fixed upstream)

### DIFF
--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -281,12 +281,6 @@ cargo build --release
 cd ..
 ```
 
-> **已知問題**：PR #397 的 `cli/src/main.rs` 中 `fn main()` 缺少 `Result` 回傳型別，會導致編譯失敗。修正方式：
->
-> 1. 將 `fn main() {` 改為 `fn main() -> Result<(), Box<dyn std::error::Error>> {`
-> 2. 將函式內所有 bare `return;` 改為 `return Ok(());`
-> 3. 在函式結尾加上 `Ok(())`
-
 ### 3.3 安裝到全域
 
 ```bash


### PR DESCRIPTION
Section 3.2 的 `fn main()` 已知問題已在上游修復，移除過時的 bug note。