### PR TITLE
docs: auto-update exec troubleshooting (pathPrepend, approvals)

### DIFF
--- a/docs/openclaw-auto-update.md
+++ b/docs/openclaw-auto-update.md
@@ -93,3 +93,53 @@ openclaw message send ... "🎉 已更新至 $NEW_VERSION"
 - **`--ignore-scripts`** — 避免 node v24 上 `@discordjs/opus` 原生編譯失敗
 - **輪詢等待** — gateway 重啟後最多等待 60 秒，確認就緒後才發送 TG 確認訊息
 - **獨立 cron session** — 版本檢查在獨立 context 執行，不污染 main session
+
+## 常見問題排除
+
+### Agent 抱怨「工具壞了」或找不到 openclaw
+
+Isolated session 使用精簡 PATH，找不到 `~/.npm-global/bin/openclaw`。
+
+**解法**：設定 `tools.exec.pathPrepend`：
+
+```bash
+openclaw config set tools.exec.pathPrepend \
+  '["~/.npm-global/bin", "~/.local/share/fnm/node-versions/v24.13.1/installation/bin"]' \
+  --strict-json
+systemctl --user restart openclaw-gateway.service
+```
+
+### UPDATE CLAW 一直要求人工核准
+
+`host=gateway` 時 exec 預設需要批准。需要同時設定兩處：
+
+**1. `openclaw.json`（全域）**：
+
+```bash
+openclaw config set tools.exec.ask off
+openclaw config set tools.exec.security full
+```
+
+> ⚠️ `tools.exec.*` 與 `exec-approvals.json` 取**較嚴格**者，兩處都要設。
+
+**2. `exec-approvals.json`（用 CLI，勿直接編輯）**：
+
+直接編輯 `exec-approvals.json` 會被 gateway 重啟覆寫。請用 CLI：
+
+```bash
+# 所有 agent 允許跑 scripts/
+openclaw approvals allowlist add --agent "*" "/home/<user>/.openclaw/scripts/*"
+
+# main agent 允許 kiro-cli + setsid
+openclaw approvals allowlist add --agent "main" "/home/<user>/.local/bin/kiro-cli"
+openclaw approvals allowlist add --agent "main" "/usr/bin/setsid"
+```
+
+**3. Per-agent 設定（最終保障）**：
+
+```bash
+openclaw config set agents.list[0].tools.exec.ask off
+openclaw config set agents.list[0].tools.exec.security full
+openclaw config set agents.list[0].tools.exec.host gateway
+systemctl --user restart openclaw-gateway.service
+```

--- a/docs/openclaw-auto-update.md
+++ b/docs/openclaw-auto-update.md
@@ -100,6 +100,33 @@ openclaw message send ... "🎉 已更新至 $NEW_VERSION"
 
 Isolated session 使用精簡 PATH，找不到 `~/.npm-global/bin/openclaw`。
 
+```
+isolated session exec
+        │
+        ▼
+  PATH = /usr/local/bin:/usr/bin:/bin   ← 精簡 PATH，無 ~/.npm-global/bin
+        │
+        ▼
+  openclaw --version
+        │
+        ▼
+  command not found ❌
+  agent 回報「工具壞了」
+
+  ─────────────────────────────────────
+  設定 tools.exec.pathPrepend 後：
+  ─────────────────────────────────────
+
+isolated session exec
+        │
+        ▼
+  PATH = ~/.npm-global/bin:~/.local/share/fnm/.../bin:/usr/local/bin:...
+        │
+        ▼
+  openclaw --version ✅
+  npm show openclaw version ✅
+```
+
 **解法**：設定 `tools.exec.pathPrepend`：
 
 ```bash
@@ -113,14 +140,38 @@ systemctl --user restart openclaw-gateway.service
 
 `host=gateway` 時 exec 預設需要批准。需要同時設定兩處：
 
+```
+agent exec 請求
+        │
+        ▼
+┌───────────────────────────────┐
+│  取較嚴格者                   │
+│                               │
+│  tools.exec.ask (openclaw.json)│
+│         vs                    │
+│  exec-approvals.json defaults │
+└───────────────┬───────────────┘
+                │
+        ┌───────┴────────┐
+        │                │
+   兩者皆 off         任一為 on-miss
+        │                │
+        ▼                ▼
+   直接執行 ✅      要求批准 ❌
+                         │
+                         ▼
+                   approval timeout
+                   → 拒絕執行
+```
+
+> ⚠️ `tools.exec.*` 與 `exec-approvals.json` 取**較嚴格**者，兩處都要設。
+
 **1. `openclaw.json`（全域）**：
 
 ```bash
 openclaw config set tools.exec.ask off
 openclaw config set tools.exec.security full
 ```
-
-> ⚠️ `tools.exec.*` 與 `exec-approvals.json` 取**較嚴格**者，兩處都要設。
 
 **2. `exec-approvals.json`（用 CLI，勿直接編輯）**：
 

--- a/docs/openclaw-auto-update.md
+++ b/docs/openclaw-auto-update.md
@@ -132,12 +132,15 @@ isolated session exec
         └──────────────────┘
 ```
 
-**解法**：設定 `tools.exec.pathPrepend`：
+**解法**：將常用 binary symlink 至 `~/.local/bin/`，再設定 `tools.exec.pathPrepend`：
 
 ```bash
-openclaw config set tools.exec.pathPrepend \
-  '["~/.npm-global/bin", "~/.local/share/fnm/node-versions/v24.13.1/installation/bin"]' \
-  --strict-json
+# 建立 symlink
+ln -sf ~/.npm-global/bin/openclaw ~/.local/bin/openclaw
+ln -sf ~/.local/share/fnm/node-versions/<version>/installation/bin/npm ~/.local/bin/npm
+
+# 設定 pathPrepend（只需一個路徑）
+openclaw config set tools.exec.pathPrepend '["~/.local/bin"]' --strict-json
 systemctl --user restart openclaw-gateway.service
 ```
 


### PR DESCRIPTION
補充今天實際踩到的坑：

- isolated session 找不到 openclaw binary → `tools.exec.pathPrepend`
- exec-approvals.json 直接編輯會被覆寫 → 改用 `openclaw approvals` CLI
- `tools.exec.ask` 全域設定比 exec-approvals.json 更嚴格，兩處都要設
- per-agent 設定作為最終保障