### PR TITLE
Release notes: OpenClaw 2026.2.24

### DIFF
--- a/release-notes/2026-02-24.md
+++ b/release-notes/2026-02-24.md
@@ -73,6 +73,38 @@ Heartbeat delivery 決策流程（v2026.2.24）
 - **解決問題**：namespace join 模式可能擴大隔離面與攻擊半徑
 - **影響**：sandbox 隔離預設更嚴格；需 break-glass 才能恢復舊行為
 
+```text
+Sandbox Docker network namespace-join gate（v2026.2.24）
+┌───────────────────────────────┐
+│ 啟動 sandbox / sandbox-browser │
+└───────────────┬───────────────┘
+                │
+                ▼
+┌───────────────────────────────┐
+│ 檢查 Docker network 設定       │
+│ 是否為 network: container:<id> │
+└───────────────┬───────────────┘
+                │
+        ┌───────┴─────────┐
+        │否               │是
+        ▼                 ▼
+┌───────────────────┐   ┌───────────────────────────────┐
+│ 正常啟動 sandbox    │   │ 預設封鎖（default deny）       │
+│（一般 network 模式）│   │ 以降低 namespace join 風險     │
+└───────────────────┘   └───────────────┬───────────────┘
+                                        │
+                                        ▼
+                          ┌───────────────────────────────┐
+                          │ break-glass：若明確設定        │
+                          │ dangerouslyAllowContainer...=true│
+                          └───────────────┬───────────────┘
+                                          │
+                                          ▼
+                          ┌───────────────────────────────┐
+                          │ 允許 namespace join（例外放行）│
+                          └───────────────────────────────┘
+```
+
 ### ⭐⭐⭐ 個人助理信任模型：新增 multi-user heuristic 與多用戶部署 hardening 指引 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
 - **用途**：新增 `security.trust_model.multi_user_heuristic` 用於偵測可能的 shared-user ingress，並補充多用戶情境 hardening 建議（如 `sandbox.mode="all"`、workspace-scoped FS、縮小 tool surface、避免共享 runtime 使用個人/私密 identity）
 - **解決問題**：在多用戶/共用環境中，若仍以單人助理假設運行，容易產生越權與資料外洩風險

--- a/release-notes/2026-02-24.md
+++ b/release-notes/2026-02-24.md
@@ -41,6 +41,33 @@
 - **解決問題**：Heartbeat 容易在錯誤的 DM/直聊目標造成訊息外洩或 spam
 - **影響**：預設更安全、降低誤送風險；但既有依賴 DM heartbeat 外送的配置需要調整（breaking 行為）
 
+```text
+Heartbeat delivery 決策流程（v2026.2.24）
+┌───────────────────────┐
+│ Cron/Heartbeat 觸發   │
+└───────────┬───────────┘
+            │
+            ▼
+┌───────────────────────┐
+│ 解析 delivery target   │
+│ - explicit target?     │
+│ - implicit: last→none  │
+└───────────┬───────────┘
+            │
+            ▼
+┌───────────────────────┐
+│ destination parsing    │
+│ 判斷是否為 DM/直聊     │
+└───────┬─────────┬─────┘
+        │是 DM     │否（群組/頻道）
+        ▼          ▼
+┌───────────────────────┐    ┌───────────────────────┐
+│ 外送封鎖（skip delivery）│    │ 允許外送（announce等）│
+│ - run 仍照常執行        │    │ - 依設定送到目標        │
+│ - 僅跳過 outbound send  │    │ - 避免誤送到 DM         │
+└───────────────────────┘    └───────────────────────┘
+```
+
 ### ⭐⭐⭐ Sandbox/Network：預設封鎖 Docker `network: "container:<id>"` namespace-join（Breaking） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
 - **用途**：對 sandbox 與 sandbox-browser containers 預設禁用 container namespace join；若需保留必須明確設定 `agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin: true`
 - **解決問題**：namespace join 模式可能擴大隔離面與攻擊半徑

--- a/release-notes/2026-02-24.md
+++ b/release-notes/2026-02-24.md
@@ -122,6 +122,40 @@ Heartbeat delivery 決策流程（v2026.2.24）
 - **解決問題**：在 shared sessions 下可能出現 webchat/control-ui context 劫持 Discord 回覆
 - **影響**：避免回覆投錯目標，提升隔離與正確性
 
+```text
+Cross-channel reply routing（防 hijack / fail-closed）
+┌──────────────────────────────┐
+│ Turn 開始：來源 channel/to    │
+│（turn-source metadata）       │
+└───────────────┬──────────────┘
+                │
+                ▼
+┌──────────────────────────────┐
+│ 產生 reply plan / followup     │
+│ - 保留 queued overflow metadata│
+│ - 偏好 originating channel ctx │
+└───────────────┬──────────────┘
+                │
+                ▼
+┌──────────────────────────────┐
+│ outbound target resolution     │
+│ 綁定 turn-source（#24571）     │
+└───────────────┬──────────────┘
+                │
+        ┌───────┴────────┐
+        │                │
+        ▼                ▼
+┌───────────────────┐  ┌──────────────────────────┐
+│ resolve 成功       │  │ resolve 失敗              │
+└─────────┬─────────┘  └────────────┬─────────────┘
+          │                         │
+          ▼                         ▼
+┌───────────────────┐  ┌──────────────────────────┐
+│ 送到正確目的地     │  │ fail-closed：不回退到     │
+│（Discord/Slack/...）│  │ active dispatcher（#25864）│
+└───────────────────┘  └──────────────────────────┘
+```
+
 ### ⭐⭐⭐ Heartbeat queueing：session 仍在 active run 時丟棄 heartbeat（避免 stale followup 佇列） ([#25610](https://github.com/openclaw/openclaw/pull/25610), [#25606](https://github.com/openclaw/openclaw/pull/25606))
 - **用途**：heartbeat 模式下若 session 已有 active run，改為 drop（不 enqueue）
 - **解決問題**：queue drain 後可能產生重複 heartbeat 分支與重複回覆

--- a/release-notes/2026-02-24.md
+++ b/release-notes/2026-02-24.md
@@ -1,0 +1,162 @@
+# OpenClaw v2026.2.24 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24)
+
+## 概述
+
+- **功能更新**：Android/App 全新原生 onboarding 與五分頁架構；Talk/Gateway provider-agnostic 設定與相容性更新；Auto-reply/Abort stop phrases 擴充（含多語系與標點支援）
+- **安全性提升**：Heartbeat DM/outbound 防外洩策略調整（預設不外送、並封鎖 DM 目標）；Sandbox/Exec 多項 fail-closed 強化（含 Docker namespace-join 預設封鎖、環境變數淨化、workspace 路徑正規化）；新增 multi-user heuristic 與多用戶部署 hardening 指引
+- **錯誤修復**：跨 channel 回覆與 session routing 隔離加固；Cron/Heartbeat/Followup 排程與去重可靠性提升；Discord/WhatsApp/Telegram/Matrix/macOS/Windows 等多平台相容性修復
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Android/App UX：原生 onboarding + 五分頁殼層（Connect/Chat/Voice/Screen/Settings） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：提供原生四步 onboarding 流程，並在完成後進入五分頁導航架構；新增完整 Connect 設定/手動模式頁面，重整 Android chat/settings 介面以配合新導航模型
+- **解決問題**：既有 onboarding/導航分散且步驟不明確，初次設定與後續操作成本偏高
+- **影響**：降低首次上手門檻，並讓連線/對話/語音/螢幕/設定入口更一致
+
+### ⭐⭐ Auto-reply/Abort stop phrases 擴充（多語系、標點、變體） ([#25103](https://github.com/openclaw/openclaw/pull/25103))
+- **用途**：擴充可獨立觸發中止的 stop phrases（如 `stop openclaw`, `please stop` 等），支援尾端標點（如 `STOP OPENCLAW!!!`），新增多語系 stop keywords（含 ES/FR/ZH/HI/AR/JP/DE/PT/RU 等），並把精確 `do not do that` 納入 stop trigger
+- **解決問題**：使用者以自然語言或非英文指令要求停止時，可能無法可靠中止
+- **影響**：提升安全停機與使用者控制的可預期性（仍維持「嚴格獨立成句」匹配原則）
+
+### ⭐⭐ Talk/Gateway config：provider-agnostic Talk 設定與相容性整理 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：加入 provider-agnostic Talk configuration（並保留 legacy 相容性），同時在 setup/status surfaces 暴露 gateway Talk ElevenLabs 設定 metadata
+- **解決問題**：Talk 設定在不同 provider/版本間差異大，導致設定與診斷不直覺
+- **影響**：統一 Talk 設定模型，改善 UI/診斷一致性並降低維護成本
+
+### ⭐ Dependencies：關鍵 runtime/tooling 依賴更新（保留 @buape/carbon pin） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：更新 Bedrock SDK、pi runtime stack、OpenAI、Google auth、oxlint/oxfmt 等依賴（刻意維持 `@buape/carbon` pinned）
+- **解決問題**：依賴過舊可能導致相容性問題、安全修補延遲或工具鏈不穩
+- **影響**：提升長期可維護性與相容性，並降低供應鏈風險
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Heartbeat DM/outbound 防外洩：封鎖 DM 目標 + 預設 delivery=none（Breaking） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：Heartbeat delivery 解析到 DM/直聊目標時一律跳過外送（仍執行檢查）；同時把 implicit heartbeat delivery target 從 `last` 改為 `none`（需明確 opt-in 才會外送）
+- **解決問題**：Heartbeat 容易在錯誤的 DM/直聊目標造成訊息外洩或 spam
+- **影響**：預設更安全、降低誤送風險；但既有依賴 DM heartbeat 外送的配置需要調整（breaking 行為）
+
+### ⭐⭐⭐ Sandbox/Network：預設封鎖 Docker `network: "container:<id>"` namespace-join（Breaking） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：對 sandbox 與 sandbox-browser containers 預設禁用 container namespace join；若需保留必須明確設定 `agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin: true`
+- **解決問題**：namespace join 模式可能擴大隔離面與攻擊半徑
+- **影響**：sandbox 隔離預設更嚴格；需 break-glass 才能恢復舊行為
+
+### ⭐⭐⭐ 個人助理信任模型：新增 multi-user heuristic 與多用戶部署 hardening 指引 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：新增 `security.trust_model.multi_user_heuristic` 用於偵測可能的 shared-user ingress，並補充多用戶情境 hardening 建議（如 `sandbox.mode="all"`、workspace-scoped FS、縮小 tool surface、避免共享 runtime 使用個人/私密 identity）
+- **解決問題**：在多用戶/共用環境中，若仍以單人助理假設運行，容易產生越權與資料外洩風險
+- **影響**：提供更清楚的部署風險提示與配置方向，降低誤用造成的安全事故
+
+### ⭐⭐⭐ Security/Routing：shared-session 跨 channel 回覆 fail-closed（綁定 turn source metadata） ([#24571](https://github.com/openclaw/openclaw/pull/24571))
+- **用途**：將 outbound target resolution 綁定到「本 turn 的來源 channel metadata」，避免使用 stale session route fallbacks；並將 turn-source 欄位一路串接到 gateway + command delivery planner
+- **解決問題**：shared-session 下可能發生跨 channel 回覆錯投或被劫持
+- **影響**：降低錯投與資料外洩風險，提升跨 channel 路由安全性
+
+### ⭐⭐ Security/Exec：host exec 環境淨化（剝除危險 env keys、PATH 處理正規化） ([#25755](https://github.com/openclaw/openclaw/pull/25755))
+- **用途**：合併前 sanitize inherited host execution environment，並移除 `LD_*`、`DYLD_*`、`SSLKEYLOGFILE` 等注入向量
+- **解決問題**：非 sandboxed exec 可能受環境變數注入影響
+- **影響**：降低環境注入/側錄風險，讓 exec 更可預期
+
+### ⭐⭐ Security/Workspace FS：`@` 前綴路徑正規化後再做 workspace boundary 檢查 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：在 workspace-only read/write/edit 與 sandbox mount guards 前，先正規化 `@`-prefixed paths
+- **解決問題**：部分 path 形式可能繞過 boundary checks，造成越界存取風險
+- **影響**：降低路徑逃逸/越權風險
+
+### ⭐⭐ Security/Telegram：DM media 下載/寫入前強制 sender 授權檢查 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：Telegram inbound media（含 media groups）在下載/寫入前先做 DM authorization，並調整 inbound activity tracking 時機
+- **解決問題**：未授權 sender 可能觸發磁碟寫入或資源消耗
+- **影響**：降低未授權觸發副作用的風險
+
+### ⭐⭐ Security/Sandbox media：tmp-path 限縮、hardlink alias 拒絕、外送 guardrails ([#25820](https://github.com/openclaw/openclaw/pull/25820))
+- **用途**：限制 sandbox media tmp-path 只信任 OpenClaw 管理的 tmp roots；拒絕 hard-link tmp media aliases（含 symlink-to-hardlink 鏈）；增加 outbound/channel guardrails
+- **解決問題**：tmp-path 允許範圍過大可能造成 out-of-sandbox inode alias 讀取
+- **影響**：強化 media 路徑安全，降低越界讀取風險
+
+### ⭐ Security/Exec approvals：fail-closed（wrapper 展開深度上限、display/argv 一致性） ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.24))
+- **用途**：透明 wrapper unwrapping 超過深度 cap 時 fail-closed；並強化 `system.run` display text 與 argv/rawCommand 一致性（含 macOS exec companion host）
+- **解決問題**：多層 `/usr/bin/env` 或 shell wrapper 可能導致顯示/核准文字與實際執行命令不一致
+- **影響**：降低「看起來安全、實際不安全」的核准繞過風險
+
+### ⭐ Security/Voice Call：Telnyx webhook replay detection + replay-key 正規化 ([#25832](https://github.com/openclaw/openclaw/pull/25832))
+- **用途**：加入 webhook replay 偵測，並將 replay-key signature encoding 正規化（Base64/Base64URL 形式去重）
+- **解決問題**：重放 webhook 可能造成重複副作用
+- **影響**：降低重放攻擊與重複觸發風險
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Routing/Session isolation：避免跨 channel 回覆回退到 active dispatcher（防止 context hijack） ([#25864](https://github.com/openclaw/openclaw/pull/25864))
+- **用途**：強化 followup routing：explicit cross-channel origin replies 失敗時不再回退到 active dispatcher；保留 queued overflow summary routing metadata；偏好 originating channel context
+- **解決問題**：在 shared sessions 下可能出現 webchat/control-ui context 劫持 Discord 回覆
+- **影響**：避免回覆投錯目標，提升隔離與正確性
+
+### ⭐⭐⭐ Heartbeat queueing：session 仍在 active run 時丟棄 heartbeat（避免 stale followup 佇列） ([#25610](https://github.com/openclaw/openclaw/pull/25610), [#25606](https://github.com/openclaw/openclaw/pull/25606))
+- **用途**：heartbeat 模式下若 session 已有 active run，改為 drop（不 enqueue）
+- **解決問題**：queue drain 後可能產生重複 heartbeat 分支與重複回覆
+- **影響**：減少重複執行與噪音，提升穩定性
+
+### ⭐⭐ Cron/Heartbeat delivery：避免繼承 cached `lastThreadId`（除非明確指定 thread/topic） ([#25730](https://github.com/openclaw/openclaw/pull/25730))
+- **用途**：heartbeat/cron announce-mode 在沒有指定 thread 時，保持 top-level destination
+- **解決問題**：訊息可能誤送到當前活躍 thread/topic
+- **影響**：降低誤投與訊息分流錯亂
+
+### ⭐⭐ Messaging tool dedupe：以 originating channel metadata 作為同目標 suppression 權威來源 ([#25835](https://github.com/openclaw/openclaw/pull/25835))
+- **用途**：針對 heartbeat/cron/exec-event 等 proactive runs，改以 originating channel metadata 判斷同目標 `message.send` 去重
+- **解決問題**：delivery-mirror transcript 可能導致 Telegram 重複發送
+- **影響**：降低重複訊息與成本
+
+### ⭐⭐ Channels/Typing keepalive：長回覆期間 refresh typing callbacks（並在 idle/cleanup 清理 timers） ([#25886](https://github.com/openclaw/openclaw/pull/25886), [#25882](https://github.com/openclaw/openclaw/pull/25882))
+- **用途**：長回覆期間定期刷新 typing keepalive，並在清理階段移除 keepalive timers
+- **解決問題**：typing indicator 可能在推理中途過期
+- **影響**：改善使用者體驗與 channel 表現一致性
+
+### ⭐⭐ Agents/Model fallback：在 fallback model 上仍繼續走 fallback chain（避免死路） ([#25922](https://github.com/openclaw/openclaw/pull/25922), [#25912](https://github.com/openclaw/openclaw/pull/25912))
+- **用途**：當 run 已在 fallback model 上時，仍依設定繼續遍歷 fallback chain
+- **解決問題**：primary cooldown 時可能直接回退到 primary-only，造成 dead-end failures
+- **影響**：提升可用性與自動復原能力
+
+### ⭐⭐ Discord/Voice reliability：恢復 DAVE 依賴、加入 join options、改善重連/解密失敗復原 ([#25861](https://github.com/openclaw/openclaw/pull/25861))
+- **用途**：恢復 `@snazzah/davey`，加入 `channels.discord.voice.daveEncryption` / `decryptionFailureTolerance`，並在連續 decrypt failure 後觸發 controlled rejoin recovery
+- **解決問題**：DAVE receive errors 下 STT 可靠性下降
+- **影響**：提升 Discord 語音輸入穩定性
+
+### ⭐ Telegram/Replies：markdown render 為空時 fallback plain text（並在雙空 payload 時 fail loud） ([#25096](https://github.com/openclaw/openclaw/pull/25096), [#25091](https://github.com/openclaw/openclaw/pull/25091))
+- **用途**：threaded replies 中若格式化輸出為空 HTML，改用純文字重送；若兩者皆空則明確報錯
+- **解決問題**：Telegram 可能出現「看似送出但實際空訊息」的假成功狀態
+- **影響**：提高可觀測性並降低漏送
+
+### ⭐ WhatsApp/Web reconnect：將 close status `440` 視為非 retryable，停止無限重連並提示 relink ([#25858](https://github.com/openclaw/openclaw/pull/25858))
+- **用途**：把 440（含字串型）視為不可重試，立即停止 loop，並輸出操作指引
+- **解決問題**：session conflict 時可能陷入重連風暴
+- **影響**：減少資源消耗與運維困擾
+
+### ⭐ Matrix/Read receipts：在 handler pipeline 前即送出 read receipts ([#25841](https://github.com/openclaw/openclaw/pull/25841), [#25840](https://github.com/openclaw/openclaw/pull/25840))
+- **用途**：Matrix 訊息一到達就回 read receipt（先於後續處理）
+- **解決問題**：client 可能長時間顯示未讀/已送出狀態
+- **影響**：改善體驗與一致性
+
+### ⭐ Windows/Exec shell selection：優先發現 PowerShell 7（pwsh），修復 `&&` chaining 失效 ([#25684](https://github.com/openclaw/openclaw/pull/25684), [#25638](https://github.com/openclaw/openclaw/pull/25638))
+- **用途**：優先以多路徑探測 `pwsh`（Program Files/ProgramW6432/PATH）再回退到 Windows PowerShell 5.1
+- **解決問題**：在裝了 PS7 的 Windows 上 `&&` command chaining 可能失效
+- **影響**：提升跨平台 exec 一致性
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 1 | 2 | 1 | Android onboarding/導航改版、stop phrases 多語系擴充、Talk 設定模型整理 |
+| 安全性 | 4 | 4 | 2 | Heartbeat DM 外送封鎖與預設不外送、sandbox/exec/workspace 多處 fail-closed 強化 |
+| 錯誤修復 | 2 | 6 | 5 | 路由隔離、Heartbeat/Cron 去重與投遞修復、多平台相容性改善 |
+| **總計** | **7** | **12** | **8** | **27** |
+
+**發佈日期**: 2026-02-24  
+**版本**: 2026.2.24  
+**狀態**: Production Ready  
+**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.2.24


### PR DESCRIPTION
Adds zh-TW release notes for OpenClaw v2026.2.24.

Closes #106.

Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.2.24