### PR TITLE
fix: replace python3 inline script with jq to fix YAML syntax error

### DIFF
--- a/.github/workflows/check-openclaw-release.yml
+++ b/.github/workflows/check-openclaw-release.yml
@@ -46,27 +46,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${{ steps.latest.outputs.version }}"
+          cat > /tmp/issue-body.md << ENDOFBODY
+          Generate release notes markdown for OpenClaw **$version** following our release notes guidelines.
+
+          Upstream GitHub Release:
+
+          - https://github.com/openclaw/openclaw/releases/tag/v$version
+
+          Guidelines:
+
+          - \`release-notes/GUIDELINES.md\` (in this repo)
+
+          Tasks:
+
+          - Pull changes/changelog from upstream OpenClaw release/tag v$version
+          - Draft a \`release-notes/\` markdown file in zh-TW
+          - Follow guidelines (分類：功能更新/安全性提升/錯誤修復；每項標註⭐；含用途/解決問題/影響)
+          - Include link(s) to the upstream GitHub Release
+
+          Acceptance:
+
+          - New md file committed in claw-info under \`release-notes/\`
+          - Issue closed via PR
+          ENDOFBODY
+
           gh issue create \
             --repo ${{ github.repository }} \
             --title "Release notes: OpenClaw $version" \
-            --body "Generate release notes markdown for OpenClaw **$version** following our release notes guidelines.
-
-Upstream GitHub Release:
-
-- https://github.com/openclaw/openclaw/releases/tag/v$version
-
-Guidelines:
-
-- \`release-notes/GUIDELINES.md\` (in this repo)
-
-Tasks:
-
-- Pull changes/changelog from upstream OpenClaw release/tag v$version
-- Draft a \`release-notes/\` markdown file in zh-TW
-- Follow guidelines (分類：功能更新/安全性提升/錯誤修復；每項標註⭐；含用途/解決問題/影響)
-- Include link(s) to the upstream GitHub Release
-
-Acceptance:
-
-- New md file committed in claw-info under \`release-notes/\`
-- Issue closed via PR"
+            --body-file /tmp/issue-body.md

--- a/.github/workflows/check-openclaw-release.yml
+++ b/.github/workflows/check-openclaw-release.yml
@@ -32,13 +32,9 @@ jobs:
             --repo ${{ github.repository }} \
             --state all \
             --search "$title" \
-            --json title,url \
-            | python3 -c "
-import json,sys
-issues=json.load(sys.stdin)
-match=[i for i in issues if i['title']=='$title']
-print(match[0]['url'] if match else '')
-")
+            --json title \
+            --jq ".[] | select(.title == \"$title\") | .title" \
+            | head -1)
           echo "existing=$existing" >> "$GITHUB_OUTPUT"
           if [ -n "$existing" ]; then
             echo "Issue already exists: $existing"


### PR DESCRIPTION
Fixes YAML syntax error on line 37 caused by python3 inline script with unescaped quotes.

Replaced with `--jq` filter which is cleaner and avoids YAML quoting issues.