### PR TITLE
fix: allow copilot as valid commit author

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check commit authors
         run: |
           echo "Checking all commits for 'thepagent' author..."
-          INVALID_COMMITS=$(git log --format='%an <%ae>' | grep -v "thepagent" || true)
+          INVALID_COMMITS=$(git log --format='%an <%ae>' | grep -vE "thepagent|copilot" || true)
           
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"
@@ -26,4 +26,4 @@ jobs:
             exit 1
           fi
           
-          echo "✅ All commits are by 'thepagent'"
+          echo "✅ All commits are by 'thepagent' or 'copilot'"

--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Check commit authors
         run: |
-          echo "Checking all commits for 'thepagent' author..."
-          INVALID_COMMITS=$(git log --format='%an <%ae>' | grep -vE "thepagent|copilot" || true)
+          echo "Checking PR commits for valid authors..."
+          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -vE "thepagent|copilot" || true)
           
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"


### PR DESCRIPTION
Allow `copilot` (GitHub Copilot agent) as a valid commit author in addition to `thepagent`, so PRs opened by Copilot agent pass the check-author check.