### PR TITLE
fix: merge as thepagent via PAT so Closes #N auto-closes issues

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge if approved and not blocked
+        id: check
         uses: actions/github-script@v7
         with:
           script: |
@@ -131,16 +132,11 @@ jobs:
               return;
             }
 
-            // Merge
-            try {
-              await github.rest.pulls.merge({
-                owner,
-                repo,
-                pull_number: prNumber,
-                merge_method: 'squash',
-              });
-              core.info(`Merged PR #${prNumber}.`);
-            } catch (e) {
-              core.warning(`Failed to merge PR #${prNumber}: ${e.message}`);
-              throw e;
-            }
+            // Signal to next step to merge
+            core.setOutput('pr_number', String(prNumber));
+
+      - name: Merge as thepagent
+        if: steps.check.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
+        run: gh pr merge ${{ steps.check.outputs.pr_number }} --squash --repo ${{ github.repository }}


### PR DESCRIPTION
Use `THEPAGENT_PAT` in a dedicated merge step so PRs are merged as `thepagent` instead of `github-actions[bot]`, enabling GitHub's auto-close mechanism for linked issues.