### PR TITLE
fix: case-insensitive grep for copilot author check

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check commit authors
         run: |
           echo "Checking PR commits for valid authors..."
-          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -vE "thepagent|copilot" || true)
+          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "thepagent|copilot" || true)
           
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"


### PR DESCRIPTION
Copilot commits have author name `Copilot` (capital C), but grep was case-sensitive. Adding `-i` flag fixes the match.