### PR TITLE
ci: auto-close issues from non-whitelisted accounts

### DIFF
--- a/.github/workflows/close-unauthorized-issue.yml
+++ b/.github/workflows/close-unauthorized-issue.yml
@@ -1,30 +1,39 @@
-name: Close Unauthorized Issues
+name: 關閉未授權 Issue
 
 on:
   issues:
     types: [opened]
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   check-author:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const WHITELIST = ['thepagent', 'pahud'];
+            const fs = require('fs');
             const author = context.payload.issue.user.login;
 
-            if (WHITELIST.includes(author)) return;
+            // 讀取信任名單
+            const trusted = fs.readFileSync('TRUSTED_AGENTS.md', 'utf8')
+              .split('\n')
+              .map(l => l.trim())
+              .filter(Boolean);
+
+            if (trusted.includes(author)) return;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `Hi @${author}, thank you for your interest!\n\nThis repository only accepts issues from authorized contributors. This issue has been automatically closed.\n\nIf you believe this is a mistake, please reach out to the maintainers.`
+              body: `嗨 @${author}，感謝您的關注！\n\n本儲存庫目前僅接受已授權的貢獻者開立 Issue。此 Issue 已自動關閉。\n\n若您希望成為信任代理人，請開立標題為 \`[signup] @${author}\` 的 Issue 申請加入。`
             });
 
             await github.rest.issues.update({

--- a/.github/workflows/close-unauthorized-issue.yml
+++ b/.github/workflows/close-unauthorized-issue.yml
@@ -1,0 +1,36 @@
+name: Close Unauthorized Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const WHITELIST = ['thepagent', 'pahud'];
+            const author = context.payload.issue.user.login;
+
+            if (WHITELIST.includes(author)) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `Hi @${author}, thank you for your interest!\n\nThis repository only accepts issues from authorized contributors. This issue has been automatically closed.\n\nIf you believe this is a mistake, please reach out to the maintainers.`
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned'
+            });

--- a/.github/workflows/handle-signup.yml
+++ b/.github/workflows/handle-signup.yml
@@ -1,0 +1,82 @@
+name: 信任代理人申請
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  handle-signup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.issue.title || '';
+            const match = title.match(/^\[signup\]\s*@?(\S+)$/i);
+            if (!match) return;
+
+            const requestedUser = match[1];
+            const issueNumber = context.payload.issue.number;
+            const { owner, repo } = context.repo;
+
+            // 確認申請人與申請帳號一致
+            const author = context.payload.issue.user.login;
+            if (author.toLowerCase() !== requestedUser.toLowerCase()) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${author} 申請帳號與開立 Issue 的帳號不符，已自動關閉。`
+              });
+              await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed', state_reason: 'not_planned' });
+              return;
+            }
+
+            // 檢查是否已在名單中
+            const { data: file } = await github.rest.repos.getContent({ owner, repo, path: 'TRUSTED_AGENTS.md' });
+            const current = Buffer.from(file.content, 'base64').toString('utf8');
+            const list = current.split('\n').map(l => l.trim()).filter(Boolean);
+
+            if (list.includes(requestedUser)) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${requestedUser} 已在信任名單中，無需重複申請。`
+              });
+              await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed', state_reason: 'not_planned' });
+              return;
+            }
+
+            // 建立分支並更新 TRUSTED_AGENTS.md
+            const branch = `signup/${requestedUser}`;
+            const { data: ref } = await github.rest.git.getRef({ owner, repo, ref: 'heads/main' });
+            await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${branch}`, sha: ref.object.sha });
+
+            const newContent = current.trimEnd() + '\n' + requestedUser + '\n';
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo,
+              path: 'TRUSTED_AGENTS.md',
+              message: `feat: 新增信任代理人 ${requestedUser}`,
+              content: Buffer.from(newContent).toString('base64'),
+              sha: file.sha,
+              branch
+            });
+
+            // 開立 PR
+            const { data: pr } = await github.rest.pulls.create({
+              owner, repo,
+              title: `feat: 新增信任代理人 @${requestedUser}`,
+              body: `關聯 Issue #${issueNumber}\n\n申請人 @${requestedUser} 請求加入信任代理人名單，請維護者審核後合併。`,
+              head: branch,
+              base: 'main'
+            });
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              body: `已自動建立 PR ${pr.html_url}，待維護者審核後即可加入信任名單。`
+            });

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 `claw-info` 是 OpenClaw 相關資訊的記錄與實作知識庫。
 
+> ⚠️ **本儲存庫僅限信任代理人（Trusted Agents）開立 Issue 與貢獻內容。**
+> 若您希望參與，請參閱下方「如何申請成為信任代理人」。
+
 ## 📁 目錄結構
 
 ```
 claw-info/
 ├── .github/workflows/
-│   └── check-commit-author.yml    # 檢查 commit author 的 workflow
+│   ├── check-commit-author.yml        # 檢查 commit author 的 workflow
+│   ├── close-unauthorized-issue.yml   # 自動關閉非信任代理人開立的 Issue
+│   └── handle-signup.yml              # 處理信任代理人申請
 ├── docs/
 │   ├── core/
 │   │   └── gateway-lifecycle.md   # Gateway 架構與生命週期（重啟/更新/排障）
@@ -25,6 +30,7 @@ claw-info/
 │   ├── 2026-02-15.md              # 2026-02-15 發佈記錄
 │   ├── 2026-02-16.md              # 2026-02-16 發佈記錄
 │   └── GUIDELINES.md              # Release Notes 製作規範
+├── TRUSTED_AGENTS.md              # 信任代理人名單
 └── README.md
 ```
 
@@ -52,27 +58,55 @@ claw-info/
 CI/CD Workflow 定義：
 
 - **check-commit-author.yml** - 檢查 commit author 是否符合 `thepagent` 設定
+- **close-unauthorized-issue.yml** - 自動關閉非信任代理人開立的 Issue
+- **handle-signup.yml** - 處理信任代理人申請，自動開 PR 更新名單
 
-## 🛠️ 使用情境
+## 🤖 信任代理人制度
 
-- **開發者**：查閱技術規格與實作細節
-- **維護者**：Reference Release Notes 了解變更歷史
-- **研究者**：學習 OpenClaw 架構與設計決策
+本儲存庫採用信任代理人制度，僅允許 [`TRUSTED_AGENTS.md`](./TRUSTED_AGENTS.md) 中列出的帳號開立 Issue。
+
+### 如何申請成為信任代理人
+
+1. 開立一個新 Issue，標題格式為：
+
+   ```
+   [signup] @你的GitHub帳號
+   ```
+
+2. CI 會自動驗證申請並開立 PR，將您加入 `TRUSTED_AGENTS.md`。
+
+3. 維護者審核後合併 PR，即完成授權。
+
+```
+開立 [signup] @username Issue
+              │
+              ▼
+┌─────────────────────────────────┐
+│  CI 驗證申請人身份               │
+└─────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────┐
+│  自動開 PR 更新 TRUSTED_AGENTS  │
+└─────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────┐
+│  維護者審核並合併 PR             │
+└─────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────┐
+│  授權完成，可開立 Issue          │
+└─────────────────────────────────┘
+```
 
 ## 📂 相關連結
 
 - [OpenClaw 官方倉庫](https://github.com/openclaw/openclaw)
 - [OpenClaw 文件](https://docs.openclaw.ai)
 
-## 📝 如何貢獻
-
-### 問題回報 (Issues)
-
-若有任何問題、建議或發現錯誤，歡迎建立 Issue：
-
-1. 檢查是否已有類似問題
-2. 提供詳細描述、再現步驟與預期結果
-3. 若適用，附上相關日誌或截圖
+## 📝 貢獻規範（信任代理人）
 
 ### 程式碼貢獻 (Pull Requests)
 

--- a/TRUSTED_AGENTS.md
+++ b/TRUSTED_AGENTS.md
@@ -1,0 +1,2 @@
+thepagent
+pahud


### PR DESCRIPTION
Closes #134 (by auto-closing it once this workflow is live)

## 變更內容

### `TRUSTED_AGENTS.md`
信任代理人名單（每行一個帳號），由 workflow 讀取。

### `close-unauthorized-issue.yml`
- 改從 `TRUSTED_AGENTS.md` 讀取白名單（不再硬編碼）
- 回覆訊息改為繁體中文，並告知如何申請加入

### `handle-signup.yml`
信任代理人申請流程：

```
使用者開立 [signup] @username 的 Issue
              │
              ▼
┌─────────────────────────────────┐
│  申請人 == Issue 作者？          │
└─────────────────────────────────┘
       │               │
      是               否
       │               │
       ▼               ▼
┌────────────┐   ┌───────────────┐
│ 已在名單？  │   │ 關閉 Issue    │
└────────────┘   └───────────────┘
   │       │
  是       否
   │       │
   ▼       ▼
關閉    建立 PR 更新
Issue   TRUSTED_AGENTS.md
        ＋ 回覆 PR 連結
              │
              ▼
┌─────────────────────────────────┐
│  維護者審核並合併 PR             │
└─────────────────────────────────┘
              │
              ▼
┌─────────────────────────────────┐
│  使用者加入信任名單，可開立 Issue │
└─────────────────────────────────┘
```
