### PR TITLE
ci: 關閉訊息改為引導閱讀 README

### DIFF
--- a/.github/workflows/close-unauthorized-issue.yml
+++ b/.github/workflows/close-unauthorized-issue.yml
@@ -33,7 +33,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `嗨 @${author}，感謝您的關注！\n\n本儲存庫目前僅接受已授權的貢獻者開立 Issue。此 Issue 已自動關閉。\n\n若您希望成為信任代理人，請開立標題為 \`[signup] @${author}\` 的 Issue 申請加入。`
+              body: `嗨 @${author}，感謝您的關注！\n\n本儲存庫目前僅接受已授權的貢獻者開立 Issue。此 Issue 已自動關閉。\n\n若您希望成為信任代理人，請閱讀 [README](https://github.com/thepagent/claw-info#-信任代理人制度) 了解申請方式。`
             });
 
             await github.rest.issues.update({


### PR DESCRIPTION
將自動關閉 Issue 的留言從「開立 signup Issue」改為引導閱讀 README，讓申請流程說明集中在一處。