### PR TITLE
fix: fail check step on API error to prevent duplicate issues

### DIFF
--- a/.github/workflows/check-openclaw-release.yml
+++ b/.github/workflows/check-openclaw-release.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           version="${{ steps.latest.outputs.version }}"
           title="Release notes: OpenClaw $version"
           existing=$(gh issue list \
@@ -36,7 +37,7 @@ jobs:
             --search "$title" \
             --json title \
             --jq ".[] | select(.title == \"$title\") | .title" \
-            | head -1)
+            | head -1) || { echo "::error::GitHub API failed"; exit 1; }
           echo "existing=$existing" >> "$GITHUB_OUTPUT"
           if [ -n "$existing" ]; then
             echo "Issue already exists: $existing"


### PR DESCRIPTION
## Problem

When the GitHub API returns a transient error (e.g. HTTP 502), the `Check if issue already exists` step silently produces an empty result, causing the workflow to create a duplicate issue.

Evidence: [run #22508254134](https://github.com/thepagent/claw-info/actions/runs/22508254134/job/65211644771) → duplicate issue #142.

## Fix

Add `set -euo pipefail` so the step fails on any API error instead of falling through.

Closes #143