### PR TITLE
ci: add workflow_run auto-merge for fork PRs

### DIFF
--- a/.github/workflows/auto-merge-fork.yml
+++ b/.github/workflows/auto-merge-fork.yml
@@ -1,0 +1,74 @@
+name: Auto-merge fork PRs (workflow_run)
+
+# Triggered after auto-merge-approved.yml completes on a fork PR.
+# workflow_run always runs in the base repo context → secrets are available.
+on:
+  workflow_run:
+    workflows: ["Auto-merge approved PRs"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge-fork:
+    # Only act when the triggering workflow failed (fork PR secret was empty)
+    # and the run came from a fork (head_repository != base repository).
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge fork PR if approved and checks pass
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            // Find the open PR for this SHA
+            const { data: prs } = await github.rest.pulls.list({
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const pr = prs.find(p => p.head.sha === headSha);
+            if (!pr) { core.info('No open PR for this SHA; skip.'); return; }
+
+            if (pr.draft) { core.info('Draft PR; skip.'); return; }
+
+            const labels = pr.labels.map(l => l.name);
+            if (labels.includes('do-not-merge')) { core.info('do-not-merge label; skip.'); return; }
+
+            // Check approvals
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const latest = new Map();
+            for (const r of reviews) {
+              if (r.user?.login) latest.set(r.user.login, r.state);
+            }
+            const approvals = [...latest.values()].filter(s => s === 'APPROVED').length;
+            if (approvals < 1) { core.info(`approvals=${approvals}; skip.`); return; }
+
+            // Check mergeability
+            const { data: prDetail } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+            if (prDetail.mergeable !== true) { core.info(`mergeable=${prDetail.mergeable}; skip.`); return; }
+
+            // Check required checks
+            const requiredChecks = ['check-author', 'check'];
+            const { data: checkData } = await github.rest.checks.listForRef({
+              owner, repo, ref: headSha, per_page: 100,
+            });
+            const byName = new Map(checkData.check_runs.map(cr => [cr.name, cr]));
+            const notPassed = requiredChecks.filter(n => byName.get(n)?.conclusion !== 'success');
+            if (notPassed.length) { core.info(`Checks not success: ${notPassed}; skip.`); return; }
+
+            core.info(`Merging fork PR #${pr.number}`);
+            core.exportVariable('PR_NUMBER', String(pr.number));
+
+      - name: Merge as thepagent
+        if: env.PR_NUMBER != ''
+        env:
+          GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
+        run: gh pr merge ${{ env.PR_NUMBER }} --squash --repo ${{ github.repository }}


### PR DESCRIPTION
## Problem

Fork PRs fail auto-merge because GitHub blocks `secrets` in `pull_request` workflows from forks — `THEPAGENT_PAT` resolves to empty string.

## Fix

Add `auto-merge-fork.yml` using `workflow_run` trigger (runs in base repo context where secrets are available).
