### PR TITLE
fix: handle action_required in auto-merge-fork workflow

### DIFF
--- a/.github/workflows/auto-merge-fork.yml
+++ b/.github/workflows/auto-merge-fork.yml
@@ -16,7 +16,7 @@ jobs:
     # Only act when the triggering workflow failed (fork PR secret was empty)
     # and the run came from a fork (head_repository != base repository).
     if: |
-      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'action_required') &&
       github.event.workflow_run.head_repository.full_name != github.repository
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fork PR `auto-merge-approved` runs conclude as `action_required` (not `failure`) when secrets are missing. Update the `if` condition to handle both.
