### PR TITLE
fix: detect fork PR in script instead of workflow_run head_repository

### DIFF
--- a/.github/workflows/auto-merge-fork.yml
+++ b/.github/workflows/auto-merge-fork.yml
@@ -1,6 +1,6 @@
 name: Auto-merge fork PRs (workflow_run)
 
-# Triggered after auto-merge-approved.yml completes on a fork PR.
+# Triggered after auto-merge-approved.yml completes.
 # workflow_run always runs in the base repo context → secrets are available.
 on:
   workflow_run:
@@ -13,11 +13,10 @@ permissions:
 
 jobs:
   auto-merge-fork:
-    # Only act when the triggering workflow failed (fork PR secret was empty)
-    # and the run came from a fork (head_repository != base repository).
-    if: |
-      (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'action_required') &&
-      github.event.workflow_run.head_repository.full_name != github.repository
+    # Trigger on failure or action_required (both happen when secrets are missing for fork PRs)
+    if: >
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'action_required'
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge fork PR if approved and checks pass
@@ -34,6 +33,11 @@ jobs:
             });
             const pr = prs.find(p => p.head.sha === headSha);
             if (!pr) { core.info('No open PR for this SHA; skip.'); return; }
+
+            // Only handle fork PRs — same-repo PRs are handled by auto-merge-approved.yml
+            if (pr.head.repo.full_name === `${owner}/${repo}`) {
+              core.info('Same-repo PR; skip (handled by auto-merge-approved.yml).'); return;
+            }
 
             if (pr.draft) { core.info('Draft PR; skip.'); return; }
 


### PR DESCRIPTION
`head_repository` in `workflow_run` context always reflects the base repo (not the fork), so the previous condition `head_repository.full_name != github.repository` was always false.

Fix: remove that condition from the job `if`, and instead detect fork PRs inside the script via `pr.head.repo.full_name`.
