### PR TITLE
fix: 豁免 [signup] Issue 不被自動關閉

### DIFF
--- a/.github/workflows/close-unauthorized-issue.yml
+++ b/.github/workflows/close-unauthorized-issue.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const title = context.payload.issue.title || '';
+            if (/^\[signup\]\s*@?\S+$/i.test(title)) return;
+
             const fs = require('fs');
             const author = context.payload.issue.user.login;
 


### PR DESCRIPTION
## 問題

非信任代理人以 `[signup] @帳號` 格式申請加入時，`close-unauthorized-issue.yml` 搶先關閉 Issue，導致 `handle-signup.yml` 無從執行。

## 修改

在 `close-unauthorized-issue.yml` 開頭加入豁免判斷：標題符合 `[signup] @xxx` 格式者，直接跳過，交由 `handle-signup.yml` 處理。

## 影響

僅新增 3 行，不影響其他邏輯。