### PR TITLE
fix: 支援 exempt-author-check label 豁免 commit author 檢查

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -16,7 +16,13 @@ jobs:
           fetch-depth: 0
 
       - name: Check commit authors
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
+          if echo "$LABELS" | grep -q "exempt-author-check"; then
+            echo "✅ exempt-author-check label found, skipping"
+            exit 0
+          fi
           echo "Checking PR commits for valid authors..."
           INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "thepagent|copilot|chenjian-agent" || true)
           


### PR DESCRIPTION
## 問題

`signup/*` 分支由 `handle-signup` workflow 自動建立，commit author 為申請人本人，導致 `check-commit-author` 檢查失敗，PR 被擋。

## 修改

PR 若帶有 `exempt-author-check` label，則跳過 commit author 檢查。

## 使用方式

為 signup PR 加上 `exempt-author-check` label 即可通過檢查。