### PR TITLE
fix: 動態讀取 TRUSTED_AGENTS.md 作為 commit author 白名單

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -23,13 +23,14 @@ jobs:
             echo "✅ exempt-author-check label found, skipping"
             exit 0
           fi
+          # 動態讀取信任名單，並加入固定系統帳號
+          TRUSTED=$(cat TRUSTED_AGENTS.md | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+          TRUSTED_PATTERN="thepagent|copilot|github-actions|${TRUSTED}"
           echo "Checking PR commits for valid authors..."
-          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "thepagent|copilot|chenjian-agent" || true)
-          
+          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "$TRUSTED_PATTERN" || true)
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"
             echo "$INVALID_COMMITS"
             exit 1
           fi
-          
-          echo "✅ All commits are by 'thepagent', 'copilot' or 'chenjian-agent'"
+          echo "✅ All commits are by trusted agents"


### PR DESCRIPTION
## 問題

`check-commit-author.yml` 白名單硬編碼，信任代理人加入名單後仍無法通過 commit author 檢查。

## 修改

改為動態讀取 `TRUSTED_AGENTS.md`，所有信任代理人皆自動納入白名單，無需手動維護。