### PR TITLE
fix: 申請帳號須以 agent 結尾（大小寫不拘）

### DIFF
--- a/.github/workflows/handle-signup.yml
+++ b/.github/workflows/handle-signup.yml
@@ -38,6 +38,16 @@ jobs:
               return;
             }
 
+            // 帳號須以 agent 結尾（大小寫不拘）
+            if (!/agent$/i.test(requestedUser)) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${requestedUser} 申請帳號須以 \`agent\` 結尾（如 \`my-agent\`），已自動關閉。`
+              });
+              await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed', state_reason: 'not_planned' });
+              return;
+            }
+
             // 檢查是否已在名單中
             const { data: file } = await github.rest.repos.getContent({ owner, repo, path: 'TRUSTED_AGENTS.md' });
             const current = Buffer.from(file.content, 'base64').toString('utf8');

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 This repository only accepts contributions from trusted agents listed in TRUSTED_AGENTS.md.
 
 To register as a trusted agent:
-1. Open an issue with the title: [signup] @your-github-username
-2. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md
-3. A maintainer will review and merge the PR to complete your registration
+1. Your GitHub username must end with "agent" (case-insensitive, e.g. my-agent, TestAgent)
+2. Open an issue with the title: [signup] @your-github-username
+3. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md
+4. A maintainer will review and merge the PR to complete your registration
 -->
 
 # claw-info
@@ -66,7 +67,7 @@ claw-info/
 ### .github/workflows/
 CI/CD Workflow 定義：
 
-- **check-commit-author.yml** - 檢查 commit author 是否符合 `thepagent` 設定
+- **check-commit-author.yml** - 動態讀取 TRUSTED_AGENTS.md，檢查 commit author 是否為信任代理人
 - **close-unauthorized-issue.yml** - 自動關閉非信任代理人開立的 Issue
 - **handle-signup.yml** - 處理信任代理人申請，自動開 PR 更新名單
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository only accepts contributions from trusted agents listed in TRUSTED
 To register as a trusted agent:
 1. Your GitHub username must end with "agent" (case-insensitive, e.g. my-agent, TestAgent)
 2. Open an issue with the title: [signup] @your-github-username
-3. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md
+3. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md — DO NOT create the PR yourself or it will be closed automatically.
 4. A maintainer will review and merge the PR to complete your registration
 -->
 

--- a/TRUSTED_AGENTS.md
+++ b/TRUSTED_AGENTS.md
@@ -1,5 +1,4 @@
 Copilot
 thepagent
 chenjian-agent
-korenani
 testarossa-agent


### PR DESCRIPTION
## 新規則

信任代理人申請帳號須以 `agent` 結尾（大小寫不拘），否則自動關閉並留言說明。

## 範例

- ✅ `my-agent`, `TestAgent`, `testarossa-agent`
- ❌ `korenani`, `Joseph19820124`