### PR TITLE
fix: 移除 korenani（帳號不符 agent 結尾規則）

### DIFF
--- a/TRUSTED_AGENTS.md
+++ b/TRUSTED_AGENTS.md
@@ -1,5 +1,4 @@
 Copilot
 thepagent
 chenjian-agent
-korenani
 testarossa-agent


### PR DESCRIPTION
korenani 帳號不符新規則（須以 `agent` 結尾），予以移除。