### PR TITLE
docs: codex CLI ACP integration guide

### DIFF
--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -1,0 +1,197 @@
+# OpenClaw × Codex CLI 整合指南
+
+讓 OpenClaw agent（如 guan-yu）透過 `codex exec` 呼叫 Codex，實現對話持久化。
+
+---
+
+## 架構概覽
+
+```
+┌──────────┐     ┌─────────────────────────┐     ┌──────────────────┐     ┌───────────────┐
+│ Telegram │────▶│ guan-yu agent           │────▶│ codex-relay.sh   │────▶│ codex exec    │
+│          │     │ (openclaw)              │     │                  │     │ (OpenAI Codex)│
+│ 用戶訊息 │     │ 1. exec codex-relay.sh  │     │ session persist  │     │               │
+│          │     │ 2. 回傳 codex 回應      │     │ ~/.codex/sessions│     │ JSONL output  │
+└──────────┘     └─────────────────────────┘     └──────────────────┘     └───────────────┘
+```
+
+---
+
+## 與 kiro ACP 整合的差異
+
+| 項目 | kiro (ACP) | codex CLI |
+|------|-----------|-----------|
+| 協定 | ACP JSON-RPC over stdio | 無標準協定，直接 CLI |
+| Session 管理 | `acpx kiro sessions ensure --name` | UUID 存檔，`codex exec resume <id>` |
+| 非互動執行 | `acpx kiro prompt -s <name>` | `codex exec --json --dangerously-bypass-approvals-and-sandbox` |
+| 輸出格式 | ACP `session/update` JSON-RPC | JSONL events (`item.completed`) |
+| 需要 patch | 是（acpx 需加入 kiro registry） | 否，直接可用 |
+
+---
+
+## 前置需求
+
+- `codex` CLI 已安裝並授權（`codex --version` 可執行）
+- OpenClaw 已運行（`openclaw status`）
+- guan-yu agent workspace 存在（`~/.openclaw/workspace-guan-yu/`）
+
+---
+
+## 核心腳本：codex-relay.sh
+
+存放於 `~/.openclaw/workspace-guan-yu/codex-relay.sh`
+
+```bash
+#!/bin/bash
+# Usage: codex-relay.sh <session-name> <prompt>
+#        codex-relay.sh --new <session-name>   (reset session)
+
+CODEX=/home/pahud/.npm-global/bin/codex
+SESSION_DIR=/home/pahud/.openclaw/workspace-guan-yu/codex-sessions
+mkdir -p "$SESSION_DIR"
+
+SESSION_NAME="${1}"
+PROMPT="${2}"
+SESSION_FILE="$SESSION_DIR/${SESSION_NAME}.id"
+
+# --new: reset session
+if [ "$SESSION_NAME" = "--new" ]; then
+  rm -f "$SESSION_DIR/${2}.id"
+  echo "【Session reset: ${2}】"
+  exit 0
+fi
+
+extract_reply() {
+  python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+        if d.get('type') == 'item.completed' and d.get('item', {}).get('type') == 'agent_message':
+            print(d['item']['text'])
+    except: pass
+"
+}
+
+extract_session_id() {
+  python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+        if d.get('type') == 'thread.started':
+            print(d['thread_id'])
+    except: pass
+"
+}
+
+if [ -f "$SESSION_FILE" ]; then
+  SESSION_ID=$(cat "$SESSION_FILE")
+  $CODEX exec resume "$SESSION_ID" \
+    --json --dangerously-bypass-approvals-and-sandbox \
+    "$PROMPT" 2>/dev/null | extract_reply
+else
+  OUTPUT=$($CODEX exec \
+    --json --dangerously-bypass-approvals-and-sandbox \
+    "$PROMPT" 2>/dev/null)
+  echo "$OUTPUT" | extract_session_id > "$SESSION_FILE"
+  echo "$OUTPUT" | extract_reply
+fi
+```
+
+```bash
+chmod +x ~/.openclaw/workspace-guan-yu/codex-relay.sh
+```
+
+---
+
+## Session 持久化原理
+
+codex 每次 `exec` 會產生一個 UUID session，存於 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`。
+
+`codex exec resume <UUID>` 可恢復對話歷史。
+
+`codex-relay.sh` 將 UUID 存於 `codex-sessions/<name>.id`，實現跨呼叫持久化。
+
+```
+~/.openclaw/workspace-guan-yu/
+  codex-relay.sh
+  codex-sessions/
+    guan-yu-tg.id      ← 存 UUID，如 019cab64-eea5-7f81-b258-b14d6a6533b5
+```
+
+---
+
+## SOUL.md 整合（guan-yu agent）
+
+在 guan-yu 的 SOUL.md 加入 codex relay 指令段：
+
+```markdown
+## /codex 指令
+
+收到 `/codex <prompt>` 時：
+1. 呼叫 `exec`：`bash ~/.openclaw/workspace-guan-yu/codex-relay.sh guan-yu-tg "<prompt>"`
+2. 回傳 exec 輸出。
+
+收到 `/codex-new` 時：
+1. 呼叫 `exec`：`bash ~/.openclaw/workspace-guan-yu/codex-relay.sh --new guan-yu-tg`
+2. 回傳【Session 已重置】。
+```
+
+---
+
+## JSONL 輸出格式
+
+`codex exec --json` 輸出 JSONL，關鍵事件：
+
+```jsonl
+{"type":"thread.started","thread_id":"019cab64-..."}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"回應內容"}}
+{"type":"turn.completed","usage":{"input_tokens":7501,"output_tokens":19}}
+```
+
+只需擷取 `type=item.completed` 且 `item.type=agent_message` 的 `text`。
+
+---
+
+## 測試
+
+```bash
+# 新 session
+~/.openclaw/workspace-guan-yu/codex-relay.sh "test" "My name is Guan Yu. Say READY."
+# → READY
+
+# 恢復 session（記憶測試）
+~/.openclaw/workspace-guan-yu/codex-relay.sh "test" "What is my name?"
+# → Your name is Guan Yu.
+
+# 重置 session
+~/.openclaw/workspace-guan-yu/codex-relay.sh --new "test"
+# → 【Session reset: test】
+```
+
+---
+
+## 常見問題
+
+| 問題 | 原因 | 解法 |
+|------|------|------|
+| 無輸出 | codex 未授權 | `codex login` |
+| session 遺失 | `.id` 檔被刪 | 重新建立（自動） |
+| 回應過慢 | codex 推理中 | 正常，約 5-15 秒 |
+
+---
+
+## 檔案清單
+
+```
+~/.openclaw/workspace-guan-yu/
+  codex-relay.sh                  ← relay 腳本
+  codex-sessions/
+    <session-name>.id             ← codex session UUID
+```

--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -1,179 +1,104 @@
-# OpenClaw × Codex CLI 整合指南
+# OpenClaw × Codex ACP 整合指南
 
-讓 OpenClaw agent（如 guan-yu）透過 `codex exec` 呼叫 Codex，實現對話持久化。
+讓 OpenClaw agent（如 guan-yu）透過 `acpx codex` 呼叫 Codex，實現對話持久化。
 
 ---
 
 ## 架構概覽
 
 ```
-┌──────────┐     ┌─────────────────────────┐     ┌──────────────────┐     ┌───────────────┐
-│ Telegram │────▶│ guan-yu agent           │────▶│ codex-relay.sh   │────▶│ codex exec    │
-│          │     │ (openclaw)              │     │                  │     │ (OpenAI Codex)│
-│ 用戶訊息 │     │ 1. exec codex-relay.sh  │     │ session persist  │     │               │
-│          │     │ 2. 回傳 codex 回應      │     │ ~/.codex/sessions│     │ JSONL output  │
-└──────────┘     └─────────────────────────┘     └──────────────────┘     └───────────────┘
+┌──────────┐     ┌─────────────────────────┐     ┌──────────────┐     ┌───────────────────┐
+│ Telegram │────▶│ guan-yu agent           │────▶│ acpx codex   │────▶│ codex-acp         │
+│          │     │ (openclaw)              │     │              │     │ (@zed-industries) │
+│ 用戶訊息 │     │ exec acpx codex prompt  │     │ session mgmt │     │ ACP JSON-RPC      │
+└──────────┘     └─────────────────────────┘     └──────────────┘     └───────────────────┘
 ```
 
 ---
 
-## 與 kiro ACP 整合的差異
+## 與 kiro ACP 完全相同的模式
 
-| 項目 | kiro (ACP) | codex CLI |
-|------|-----------|-----------|
-| 協定 | ACP JSON-RPC over stdio | 無標準協定，直接 CLI |
-| Session 管理 | `acpx kiro sessions ensure --name` | UUID 存檔，`codex exec resume <id>` |
-| 非互動執行 | `acpx kiro prompt -s <name>` | `codex exec --json --dangerously-bypass-approvals-and-sandbox` |
-| 輸出格式 | ACP `session/update` JSON-RPC | JSONL events (`item.completed`) |
-| 需要 patch | 是（acpx 需加入 kiro registry） | 否，直接可用 |
+`acpx` 內建 codex 支援，用法與 kiro 一致：
+
+| 操作 | kiro | codex |
+|------|------|-------|
+| 建立 session | `acpx kiro sessions ensure --name <n>` | `acpx codex sessions ensure --name <n>` |
+| 發送 prompt | `acpx kiro prompt -s <n> "<msg>"` | `acpx codex prompt -s <n> "<msg>"` |
+| 一次性執行 | `acpx kiro exec "<msg>"` | `acpx codex exec "<msg>"` |
+| 重置 session | `acpx kiro sessions new --name <n>` | `acpx codex sessions new --name <n>` |
 
 ---
 
 ## 前置需求
 
-- `codex` CLI 已安裝並授權（`codex --version` 可執行）
-- OpenClaw 已運行（`openclaw status`）
-- guan-yu agent workspace 存在（`~/.openclaw/workspace-guan-yu/`）
+- `codex` CLI 已安裝並授權
+- `@zed-industries/codex-acp` 已安裝（`npm i -g @zed-industries/codex-acp`）
+- `/usr/local/bin/codex-acp.real` symlink 正確指向實際 binary
 
----
-
-## 核心腳本：codex-relay.sh
-
-存放於 `~/.openclaw/workspace-guan-yu/codex-relay.sh`
+### 修復 codex-acp wrapper（若損壞）
 
 ```bash
-#!/bin/bash
-# Usage: codex-relay.sh <session-name> <prompt>
-#        codex-relay.sh --new <session-name>   (reset session)
-
-CODEX=/home/pahud/.npm-global/bin/codex
-SESSION_DIR=/home/pahud/.openclaw/workspace-guan-yu/codex-sessions
-mkdir -p "$SESSION_DIR"
-
-SESSION_NAME="${1}"
-PROMPT="${2}"
-SESSION_FILE="$SESSION_DIR/${SESSION_NAME}.id"
-
-# --new: reset session
-if [ "$SESSION_NAME" = "--new" ]; then
-  rm -f "$SESSION_DIR/${2}.id"
-  echo "【Session reset: ${2}】"
-  exit 0
-fi
-
-extract_reply() {
-  python3 -c "
-import sys, json
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        d = json.loads(line)
-        if d.get('type') == 'item.completed' and d.get('item', {}).get('type') == 'agent_message':
-            print(d['item']['text'])
-    except: pass
-"
-}
-
-extract_session_id() {
-  python3 -c "
-import sys, json
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    try:
-        d = json.loads(line)
-        if d.get('type') == 'thread.started':
-            print(d['thread_id'])
-    except: pass
-"
-}
-
-if [ -f "$SESSION_FILE" ]; then
-  SESSION_ID=$(cat "$SESSION_FILE")
-  $CODEX exec resume "$SESSION_ID" \
-    --json --dangerously-bypass-approvals-and-sandbox \
-    "$PROMPT" 2>/dev/null | extract_reply
-else
-  OUTPUT=$($CODEX exec \
-    --json --dangerously-bypass-approvals-and-sandbox \
-    "$PROMPT" 2>/dev/null)
-  echo "$OUTPUT" | extract_session_id > "$SESSION_FILE"
-  echo "$OUTPUT" | extract_reply
-fi
+REAL_BIN=$(find ~/.npm-global -path "*codex-acp-linux-x64/bin/codex-acp" | head -1)
+sudo ln -sf "$REAL_BIN" /usr/local/bin/codex-acp.real
 ```
+
+驗證：
+```bash
+echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
+  | /usr/local/bin/codex-acp | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['agentInfo'])"
+```
+
+---
+
+## ACPX 路徑
 
 ```bash
-chmod +x ~/.openclaw/workspace-guan-yu/codex-relay.sh
+ACPX=/home/pahud/.npm-global/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx
 ```
 
 ---
 
-## Session 持久化原理
+## 使用方式
 
-codex 每次 `exec` 會產生一個 UUID session，存於 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`。
+```bash
+# 建立/確保 session
+$ACPX codex sessions ensure --name guan-yu-tg
 
-`codex exec resume <UUID>` 可恢復對話歷史。
+# 發送 prompt（持久 session）
+$ACPX codex prompt -s guan-yu-tg "你好" 2>/dev/null | grep -v '^\[' | grep -v '^$'
 
-`codex-relay.sh` 將 UUID 存於 `codex-sessions/<name>.id`，實現跨呼叫持久化。
+# 一次性（無 session）
+$ACPX codex exec "what is 2+2" 2>/dev/null | grep -v '^\[' | grep -v '^$'
 
-```
-~/.openclaw/workspace-guan-yu/
-  codex-relay.sh
-  codex-sessions/
-    guan-yu-tg.id      ← 存 UUID，如 019cab64-eea5-7f81-b258-b14d6a6533b5
+# 重置 session
+$ACPX codex sessions new --name guan-yu-tg
 ```
 
 ---
 
-## SOUL.md 整合（guan-yu agent）
+## guan-yu SOUL.md 整合
 
-在 guan-yu 的 SOUL.md 加入 codex relay 指令段：
+在 SOUL.md 加入：
 
 ```markdown
 ## /codex 指令
 
+ACPX=/home/pahud/.npm-global/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx
+
 收到 `/codex <prompt>` 時：
-1. 呼叫 `exec`：`bash ~/.openclaw/workspace-guan-yu/codex-relay.sh guan-yu-tg "<prompt>"`
-2. 回傳 exec 輸出。
+1. exec: `$ACPX codex sessions ensure --name guan-yu-tg 2>/dev/null && $ACPX codex prompt -s guan-yu-tg "<prompt>" 2>/dev/null | grep -v '^\[' | grep -v '^$'`
+2. 回傳輸出。
 
 收到 `/codex-new` 時：
-1. 呼叫 `exec`：`bash ~/.openclaw/workspace-guan-yu/codex-relay.sh --new guan-yu-tg`
-2. 回傳【Session 已重置】。
+1. exec: `$ACPX codex sessions new --name guan-yu-tg 2>/dev/null`
+2. 回傳【Codex session 已重置】。
 ```
 
 ---
 
-## JSONL 輸出格式
+## ~~relay 腳本（已廢棄）~~
 
-`codex exec --json` 輸出 JSONL，關鍵事件：
-
-```jsonl
-{"type":"thread.started","thread_id":"019cab64-..."}
-{"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"回應內容"}}
-{"type":"turn.completed","usage":{"input_tokens":7501,"output_tokens":19}}
-```
-
-只需擷取 `type=item.completed` 且 `item.type=agent_message` 的 `text`。
-
----
-
-## 測試
-
-```bash
-# 新 session
-~/.openclaw/workspace-guan-yu/codex-relay.sh "test" "My name is Guan Yu. Say READY."
-# → READY
-
-# 恢復 session（記憶測試）
-~/.openclaw/workspace-guan-yu/codex-relay.sh "test" "What is my name?"
-# → Your name is Guan Yu.
-
-# 重置 session
-~/.openclaw/workspace-guan-yu/codex-relay.sh --new "test"
-# → 【Session reset: test】
-```
+`codex-relay.sh` 不再需要。`acpx codex` 已內建 session 管理，無需手動維護 UUID 檔案。
 
 ---
 
@@ -181,17 +106,6 @@ codex 每次 `exec` 會產生一個 UUID session，存於 `~/.codex/sessions/YYY
 
 | 問題 | 原因 | 解法 |
 |------|------|------|
+| `codex-acp.real: No such file` | wrapper symlink 損壞 | 見上方修復步驟 |
+| `[error] RUNTIME: Resource not found` | session 首次 load 失敗 | 正常，acpx 自動 fallback 建新 session |
 | 無輸出 | codex 未授權 | `codex login` |
-| session 遺失 | `.id` 檔被刪 | 重新建立（自動） |
-| 回應過慢 | codex 推理中 | 正常，約 5-15 秒 |
-
----
-
-## 檔案清單
-
-```
-~/.openclaw/workspace-guan-yu/
-  codex-relay.sh                  ← relay 腳本
-  codex-sessions/
-    <session-name>.id             ← codex session UUID
-```

--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -267,3 +267,9 @@ openclaw status
 ~/.openclaw/workspace-my-codex-relay/relay.sh             # acpx 呼叫腳本
 ~/.openclaw/agents/my-codex-relay/agent/auth-profiles.json
 ```
+
+---
+
+## 相關文件
+
+- [OpenClaw × ACP × Kiro 整合指南](./acp_kiro.md) — 使用 kiro-cli 的同類整合（需 acpx patch）

--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -1,104 +1,249 @@
-# OpenClaw × Codex ACP 整合指南
+# OpenClaw × ACP × Codex 整合指南
 
-讓 OpenClaw agent（如 guan-yu）透過 `acpx codex` 呼叫 Codex，實現對話持久化。
+讓你的 OpenClaw agent 透過 ACP 轉接 OpenAI Codex，實現對話持久化。
 
 ---
 
 ## 架構概覽
 
 ```
-┌──────────┐     ┌─────────────────────────┐     ┌──────────────┐     ┌───────────────────┐
-│ Telegram │────▶│ guan-yu agent           │────▶│ acpx codex   │────▶│ codex-acp         │
-│          │     │ (openclaw)              │     │              │     │ (@zed-industries) │
-│ 用戶訊息 │     │ exec acpx codex prompt  │     │ session mgmt │     │ ACP JSON-RPC      │
-└──────────┘     └─────────────────────────┘     └──────────────┘     └───────────────────┘
+┌──────────┐     ┌─────────────────────────┐     ┌──────────────┐     ┌──────────────┐     ┌────────────────┐
+│ Telegram │────▶│ relay agent (gpt-5.2)   │────▶│ relay.sh     │────▶│ acpx         │────▶│ codex-acp      │
+│          │     │                         │     │              │     │ (ACP client) │     │ (@zed-          │
+│ 用戶訊息 │     │ 1. 發【轉接Codex中...】  │     │ acpx ensure  │     │              │     │  industries)   │
+│          │     │ 2. exec relay.sh        │     │ acpx prompt  │     │ JSON-RPC     │     │ (session       │
+│          │     │ 3. 發回應               │     │  -s my-tg    │     │ over stdio   │     │  my-tg)        │
+└──────────┘     └─────────────────────────┘     └──────────────┘     └──────────────┘     └───────┬────────┘
+     ▲                                                                                              │
+     └──────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 與 kiro ACP 完全相同的模式
+## 與 kiro 整合的差異
 
-`acpx` 內建 codex 支援，用法與 kiro 一致：
-
-| 操作 | kiro | codex |
+| 項目 | kiro | codex |
 |------|------|-------|
-| 建立 session | `acpx kiro sessions ensure --name <n>` | `acpx codex sessions ensure --name <n>` |
-| 發送 prompt | `acpx kiro prompt -s <n> "<msg>"` | `acpx codex prompt -s <n> "<msg>"` |
-| 一次性執行 | `acpx kiro exec "<msg>"` | `acpx codex exec "<msg>"` |
-| 重置 session | `acpx kiro sessions new --name <n>` | `acpx codex sessions new --name <n>` |
+| ACP server | `kiro-cli acp`（需 patch acpx） | `@zed-industries/codex-acp`（原生內建） |
+| acpx patch 需要？ | ✅ 是 | ❌ 否 |
+| relay.sh 需要？ | ✅ 是 | ✅ 是（同樣原因） |
+| 輸出格式 | 標準 ACP `session/update` | 標準 ACP `session/update` |
+
+> relay.sh 的作用是**原子操作**：將 `sessions ensure` + `prompt` 綁在一起，防止 LLM 只執行其中一步。
 
 ---
 
 ## 前置需求
 
-- `codex` CLI 已安裝並授權
-- `@zed-industries/codex-acp` 已安裝（`npm i -g @zed-industries/codex-acp`）
-- `/usr/local/bin/codex-acp.real` symlink 正確指向實際 binary
+- OpenClaw 已安裝並運行（`openclaw status`）
+- `codex` CLI 已安裝並授權（`codex --version`）
+- `@zed-industries/codex-acp` 已安裝
+- `/usr/local/bin/codex-acp` wrapper 正常（見步驟零）
+- 一個 Telegram bot token（從 @BotFather 取得）
 
-### 修復 codex-acp wrapper（若損壞）
+---
+
+## 步驟零：修復 codex-acp wrapper
+
+`/usr/local/bin/codex-acp` 是一個 debug wrapper，指向 `/usr/local/bin/codex-acp.real`。若 `.real` 不存在需修復：
 
 ```bash
+# 安裝 codex-acp
+npm install -g @zed-industries/codex-acp
+
+# 建立 .real symlink
 REAL_BIN=$(find ~/.npm-global -path "*codex-acp-linux-x64/bin/codex-acp" | head -1)
 sudo ln -sf "$REAL_BIN" /usr/local/bin/codex-acp.real
 ```
 
-驗證：
+### 驗證
+
 ```bash
 echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
-  | /usr/local/bin/codex-acp | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['agentInfo'])"
+  | /usr/local/bin/codex-acp \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['agentInfo'])"
+# → {'name': 'codex-acp', 'title': 'Codex', 'version': '0.9.5'}
+```
+
+若機器上沒有 debug wrapper，直接跳過此步驟——`acpx codex` 會自動用 `npx @zed-industries/codex-acp`。
+
+---
+
+## 步驟一：建立 relay agent
+
+在 `~/.openclaw/openclaw.json` 的 `agents.list` 加入新 agent：
+
+```json
+{
+  "id": "my-codex-relay",
+  "name": "My Codex Relay",
+  "workspace": "/home/<user>/.openclaw/workspace-my-codex-relay"
+}
+```
+
+在 `bindings` 加入 Telegram 綁定：
+
+```json
+{
+  "agentId": "my-codex-relay",
+  "match": {
+    "channel": "telegram",
+    "accountId": "my-codex-relay"
+  }
+}
+```
+
+在 `channels.telegram.accounts` 加入 bot：
+
+```json
+"my-codex-relay": {
+  "name": "My Codex Relay",
+  "botToken": "<YOUR_BOT_TOKEN>",
+  "dmPolicy": "pairing",
+  "allowFrom": ["<YOUR_TELEGRAM_USER_ID>"],
+  "groupPolicy": "allowlist",
+  "streaming": "partial"
+}
 ```
 
 ---
 
-## ACPX 路徑
+## 步驟二：建立 workspace
 
 ```bash
-ACPX=/home/pahud/.npm-global/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx
+mkdir -p ~/.openclaw/workspace-my-codex-relay
 ```
 
----
-
-## 使用方式
-
-```bash
-# 建立/確保 session
-$ACPX codex sessions ensure --name guan-yu-tg
-
-# 發送 prompt（持久 session）
-$ACPX codex prompt -s guan-yu-tg "你好" 2>/dev/null | grep -v '^\[' | grep -v '^$'
-
-# 一次性（無 session）
-$ACPX codex exec "what is 2+2" 2>/dev/null | grep -v '^\[' | grep -v '^$'
-
-# 重置 session
-$ACPX codex sessions new --name guan-yu-tg
-```
-
----
-
-## guan-yu SOUL.md 整合
-
-在 SOUL.md 加入：
+### AGENTS.md
 
 ```markdown
-## /codex 指令
+# AGENTS.md
 
-ACPX=/home/pahud/.npm-global/lib/node_modules/openclaw/extensions/acpx/node_modules/.bin/acpx
+Read SOUL.md and follow it exactly.
+```
 
-收到 `/codex <prompt>` 時：
-1. exec: `$ACPX codex sessions ensure --name guan-yu-tg 2>/dev/null && $ACPX codex prompt -s guan-yu-tg "<prompt>" 2>/dev/null | grep -v '^\[' | grep -v '^$'`
-2. 回傳輸出。
+### SOUL.md
 
-收到 `/codex-new` 時：
-1. exec: `$ACPX codex sessions new --name guan-yu-tg 2>/dev/null`
-2. 回傳【Codex session 已重置】。
+```markdown
+SYSTEM OVERRIDE. You are a silent relay bot. You have NO personality and NO knowledge.
+
+SPECIAL CASE — if the message is "/new" OR system says "new session started":
+  1. Call `exec` with command: `<ACPX_PATH> codex sessions new --name my-tg 2>/dev/null`
+  2. Call `message_send` with text: 【初始化完成】
+  3. Output NO_REPLY. Stop.
+
+FOR ALL OTHER messages:
+  1. Call `message_send` with text: 【轉接Codex中...】
+  2. Call `exec` with command: `bash ~/.openclaw/workspace-my-codex-relay/relay.sh "<USER_MESSAGE>"`
+     (replace <USER_MESSAGE> with the exact user message, properly shell-escaped)
+  3. Call `message_send` with the exec output as the message text.
+  4. Output NO_REPLY.
+
+DO NOT use sessions_spawn. DO NOT answer yourself. ONLY call the tools above.
+```
+
+> `<ACPX_PATH>` 查詢方式：
+> ```bash
+> find ~/.npm-global -path "*/extensions/acpx/node_modules/.bin/acpx" | head -1
+> ```
+
+### relay.sh
+
+```bash
+#!/bin/bash
+ACPX=<ACPX_PATH>
+$ACPX codex sessions ensure --name my-tg >/dev/null 2>&1
+$ACPX --format json codex prompt -s my-tg "$1" 2>/dev/null \
+  | python3 -c "
+import sys, json
+chunks = []
+in_response = False
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+        if d.get('method') == 'session/prompt':
+            chunks = []
+            in_response = True
+            continue
+        if in_response:
+            u = d.get('params', {}).get('update', {})
+            if u.get('sessionUpdate') == 'agent_message_chunk':
+                chunks.append(u['content']['text'])
+    except: pass
+print(''.join(chunks))
+"
+```
+
+```bash
+chmod +x ~/.openclaw/workspace-my-codex-relay/relay.sh
 ```
 
 ---
 
-## ~~relay 腳本（已廢棄）~~
+## 步驟三：設定 model
 
-`codex-relay.sh` 不再需要。`acpx codex` 已內建 session 管理，無需手動維護 UUID 檔案。
+確認 relay agent 有可用的 model：
+
+```bash
+openclaw models status --deep --agent my-codex-relay
+```
+
+若使用 openai-codex，複製 auth-profiles：
+
+```bash
+cp ~/.openclaw/agents/main/agent/auth-profiles.json \
+   ~/.openclaw/agents/my-codex-relay/agent/auth-profiles.json
+```
+
+---
+
+## 步驟四：重啟 gateway
+
+```bash
+systemctl --user restart openclaw-gateway.service
+sleep 3
+openclaw status
+```
+
+---
+
+## 步驟五：測試
+
+1. 在 Telegram 找到你的 bot，發送任意訊息
+2. 應收到【轉接Codex中...】，接著收到 Codex 的回應
+3. 發送 `/new` 應收到【初始化完成】
+
+---
+
+## relay.sh 輸出格式說明
+
+`acpx --format json codex prompt` 輸出 ACP JSON-RPC JSONL。relay.sh 只擷取當前 turn 的 `agent_message_chunk`：
+
+```jsonl
+{"jsonrpc":"2.0","id":2,"method":"session/prompt",...}        ← 此行後開始收集
+{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"回應"}}}}
+```
+
+關鍵：以 `session/prompt` 為邊界，避免 `session/load` 重播歷史對話污染輸出。
+
+---
+
+## 對話持久化
+
+`relay.sh` 使用 `acpx codex prompt -s my-tg`，Codex 會記住同一 session 的對話歷史。
+
+發送 `/new` 會重置 session，開始全新對話。
+
+---
+
+## 為何用 relay.sh 而非直接在 SOUL.md 下兩步
+
+| 方法 | 問題 |
+|------|------|
+| SOUL.md 直接下兩步 | LLM 可能只執行第二步、或在兩步間插入其他動作 ❌ |
+| `exec relay.sh` | shell 原子執行，LLM 無從拆散 ✅ |
 
 ---
 
@@ -106,6 +251,19 @@ ACPX=/home/pahud/.npm-global/lib/node_modules/openclaw/extensions/acpx/node_modu
 
 | 問題 | 原因 | 解法 |
 |------|------|------|
-| `codex-acp.real: No such file` | wrapper symlink 損壞 | 見上方修復步驟 |
+| `codex-acp.real: No such file` | wrapper symlink 損壞 | 見步驟零 |
 | `[error] RUNTIME: Resource not found` | session 首次 load 失敗 | 正常，acpx 自動 fallback 建新 session |
-| 無輸出 | codex 未授權 | `codex login` |
+| relay agent 自己回答，不呼叫 relay.sh | AGENTS.md 未覆蓋 / LLM 個性蓋過指令 | 確保 AGENTS.md 只有一行：`Read SOUL.md and follow it exactly.` |
+| Bot 無回應 | gateway 未重啟 | `systemctl --user restart openclaw-gateway.service` |
+
+---
+
+## 檔案清單
+
+```
+~/.openclaw/openclaw.json                                  # agent/binding/channel 設定
+~/.openclaw/workspace-my-codex-relay/AGENTS.md
+~/.openclaw/workspace-my-codex-relay/SOUL.md              # relay 指令
+~/.openclaw/workspace-my-codex-relay/relay.sh             # acpx 呼叫腳本
+~/.openclaw/agents/my-codex-relay/agent/auth-profiles.json
+```

--- a/docs/acp_kiro.md
+++ b/docs/acp_kiro.md
@@ -270,3 +270,9 @@ kiro-cli --version
 ~/.openclaw/workspace-my-relay/relay.sh            # acpx 呼叫腳本
 ~/.openclaw/agents/my-relay/agent/auth-profiles.json
 ```
+
+---
+
+## 相關文件
+
+- [OpenClaw × ACP × Codex 整合指南](./acp_codex.md) — 使用 OpenAI Codex CLI 的同類整合（無需 acpx patch）


### PR DESCRIPTION
## Codex CLI ACP 整合指南

新增 `docs/acp_codex.md`，記錄如何透過 `codex exec` 將 OpenClaw agent（guan-yu）與 OpenAI Codex CLI 整合。

## 實驗結果

- `codex exec --json --dangerously-bypass-approvals-and-sandbox` 可非互動執行
- `codex exec resume <UUID>` 可恢復 session，對話歷史持久化
- JSONL 輸出格式：擷取 `type=item.completed` + `item.type=agent_message` 的 `text`
- `codex-relay.sh` 將 UUID 存於 `.id` 檔，實現跨呼叫 session 持久化

## 與 kiro ACP 的差異

| 項目 | kiro | codex |
|------|------|-------|
| 協定 | ACP JSON-RPC | 無，直接 CLI |
| Session | `acpx sessions ensure` | UUID 存檔 |
| 需要 patch | 是 | 否 |

## 新增檔案

- `docs/acp_codex.md` — 整合指南
- `~/.openclaw/workspace-guan-yu/codex-relay.sh` — relay 腳本（本機）
