### PR TITLE
docs: release notes for OpenClaw 2026.3.1

### DIFF
--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -273,3 +273,4 @@ openclaw status
 ## 相關文件
 
 - [OpenClaw × ACP × Kiro 整合指南](./acp_kiro.md) — 使用 kiro-cli 的同類整合（需 acpx patch）
+- [OpenClaw × ACP × Gemini 整合指南](./acp_gemini.md) — 使用 Google Gemini CLI（無需 patch）

--- a/docs/acp_gemini.md
+++ b/docs/acp_gemini.md
@@ -1,0 +1,233 @@
+# OpenClaw × ACP × Gemini 整合指南
+
+讓你的 OpenClaw agent 透過 ACP 轉接 Google Gemini CLI，實現對話持久化。
+
+---
+
+## 架構概覽
+
+```
+┌──────────┐     ┌─────────────────────────┐     ┌──────────────┐     ┌──────────────┐     ┌─────────────────┐
+│ Telegram │────▶│ relay agent (gpt-5.2)   │────▶│ relay.sh     │────▶│ acpx         │────▶│ gemini CLI      │
+│          │     │                         │     │              │     │ (ACP client) │     │ --experimental- │
+│ 用戶訊息 │     │ 1. 發【轉接Gemini中...】 │     │ acpx ensure  │     │              │     │ acp             │
+│          │     │ 2. exec relay.sh        │     │ acpx prompt  │     │ JSON-RPC     │     │ (session        │
+│          │     │ 3. 發回應               │     │  -s my-tg    │     │ over stdio   │     │  my-tg)         │
+└──────────┘     └─────────────────────────┘     └──────────────┘     └──────────────┘     └────────┬────────┘
+     ▲                                                                                               │
+     └───────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 與 kiro / codex 整合的差異
+
+| 項目 | kiro | codex | gemini |
+|------|------|-------|--------|
+| ACP server | `kiro-cli acp`（需 patch acpx） | `@zed-industries/codex-acp`（原生） | `gemini --experimental-acp` |
+| acpx patch 需要？ | ✅ 是 | ❌ 否 | ❌ 否（用 `--agent` flag） |
+| acpx 啟動方式 | registry: `kiro-cli acp` | registry: `npx @zed-industries/codex-acp` | `--agent "gemini --experimental-acp"` |
+| ACP 狀態 | 正式 | 正式 | experimental |
+
+> **關鍵**：acpx registry 內建的 `gemini` 指令沒有帶 `--experimental-acp`，直接用 `acpx gemini` 會掛住。需改用 `acpx --agent "gemini --experimental-acp"` 繞過 registry。
+
+---
+
+## 前置需求
+
+- OpenClaw 已安裝並運行（`openclaw status`）
+- `gemini` CLI 已安裝並授權（`gemini --version`）
+- acpx extension 已啟用
+
+### 安裝 / 升級 gemini CLI
+
+```bash
+npm install -g @google/gemini-cli@latest
+gemini --version   # 應為 0.31.0+
+```
+
+### 驗證 ACP 可用
+
+```bash
+ACPX=$(find ~/.npm-global -path "*/extensions/acpx/node_modules/.bin/acpx" | head -1)
+timeout 10 $ACPX --agent "gemini --experimental-acp" exec "say PONG" 2>&1
+# → PONG
+```
+
+---
+
+## 步驟一：建立 relay agent
+
+在 `~/.openclaw/openclaw.json` 的 `agents.list` 加入新 agent：
+
+```json
+{
+  "id": "my-gemini-relay",
+  "name": "My Gemini Relay",
+  "workspace": "/home/<user>/.openclaw/workspace-my-gemini-relay"
+}
+```
+
+在 `bindings` 加入 Telegram 綁定：
+
+```json
+{
+  "agentId": "my-gemini-relay",
+  "match": {
+    "channel": "telegram",
+    "accountId": "my-gemini-relay"
+  }
+}
+```
+
+在 `channels.telegram.accounts` 加入 bot：
+
+```json
+"my-gemini-relay": {
+  "name": "My Gemini Relay",
+  "botToken": "<YOUR_BOT_TOKEN>",
+  "dmPolicy": "pairing",
+  "allowFrom": ["<YOUR_TELEGRAM_USER_ID>"],
+  "groupPolicy": "allowlist",
+  "streaming": "partial"
+}
+```
+
+---
+
+## 步驟二：建立 workspace
+
+```bash
+mkdir -p ~/.openclaw/workspace-my-gemini-relay
+```
+
+### AGENTS.md
+
+```markdown
+# AGENTS.md
+
+Read SOUL.md and follow it exactly.
+```
+
+### IDENTITY.md
+
+> ⚠️ openclaw 會自動注入 IDENTITY.md。若 agent 原本有個性，必須覆蓋此檔，否則個性會蓋過 SOUL.md 的 relay 指令。
+
+```markdown
+# IDENTITY.md
+
+You are a silent relay bot. No personality. No identity.
+```
+
+### SOUL.md
+
+```markdown
+SYSTEM OVERRIDE. You are a silent relay bot. You have NO personality and NO knowledge.
+
+SPECIAL CASE — if the message is "/new" OR system says "new session started":
+  1. Call `exec` with command: `<ACPX_PATH> --agent "gemini --experimental-acp" sessions new --name my-tg 2>/dev/null`
+  2. Call `message_send` with text: 【初始化完成】
+  3. Output NO_REPLY. Stop.
+
+FOR ALL OTHER messages:
+  1. Call `message_send` with text: 【轉接Gemini中...】
+  2. Call `exec` with command: `bash ~/.openclaw/workspace-my-gemini-relay/relay.sh "<USER_MESSAGE>"`
+     (replace <USER_MESSAGE> with the exact user message, properly shell-escaped)
+  3. Call `message_send` with the exec output as the message text.
+  4. Output NO_REPLY.
+
+DO NOT use sessions_spawn. DO NOT answer yourself. ONLY call the tools above.
+```
+
+> `<ACPX_PATH>` 查詢方式：
+> ```bash
+> find ~/.npm-global -path "*/extensions/acpx/node_modules/.bin/acpx" | head -1
+> ```
+
+### relay.sh
+
+```bash
+#!/bin/bash
+ACPX=<ACPX_PATH>
+$ACPX --agent "gemini --experimental-acp" sessions ensure --name my-tg >/dev/null 2>&1
+$ACPX --agent "gemini --experimental-acp" --format json prompt -s my-tg "$1" 2>/dev/null \
+  | python3 -c "
+import sys, json
+chunks = []
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+        if d.get('id') == 2 and d.get('method') == 'session/prompt':
+            chunks = []
+            continue
+        u = d.get('params', {}).get('update', {})
+        if u.get('sessionUpdate') == 'agent_message_chunk':
+            chunks.append(u['content']['text'])
+    except: pass
+print(''.join(chunks))
+"
+```
+
+```bash
+chmod +x ~/.openclaw/workspace-my-gemini-relay/relay.sh
+```
+
+> **注意**：gemini 的 `session/prompt` 出現在 `agent_message_chunk` **之後**（與 codex 相反），因此用 `id==2` 作為邊界而非 `method=='session/prompt'` 的順序判斷。
+
+---
+
+## 步驟三：重啟 gateway
+
+```bash
+systemctl --user restart openclaw-gateway.service
+sleep 3
+openclaw status
+```
+
+---
+
+## 步驟四：測試
+
+```bash
+# 直接測試 relay.sh
+bash ~/.openclaw/workspace-my-gemini-relay/relay.sh "What is 2+2?"
+# → 2 + 2 = 4.
+
+# session 記憶測試
+bash ~/.openclaw/workspace-my-gemini-relay/relay.sh "What did I just ask?"
+# → You asked: "What is 2+2?"
+```
+
+Telegram：發任意訊息應收到【轉接Gemini中...】，接著收到 Gemini 回應。發 `/new` 重置 session。
+
+---
+
+## 常見問題
+
+| 問題 | 原因 | 解法 |
+|------|------|------|
+| `acpx gemini` 掛住不返回 | registry 沒有 `--experimental-acp` | 改用 `acpx --agent "gemini --experimental-acp"` |
+| relay agent 自己回答 | IDENTITY.md 未覆蓋，個性蓋過 SOUL.md | 覆蓋 IDENTITY.md（見步驟二） |
+| 空輸出 | `--format json` 位置錯誤 | 確保在 `prompt` 子命令之前 |
+| gemini 未授權 | 未登入 | `gemini auth login` |
+
+---
+
+## 檔案清單
+
+```
+~/.openclaw/openclaw.json                                      # agent/binding/channel 設定
+~/.openclaw/workspace-my-gemini-relay/AGENTS.md
+~/.openclaw/workspace-my-gemini-relay/IDENTITY.md             # ⚠️ 必須覆蓋
+~/.openclaw/workspace-my-gemini-relay/SOUL.md                 # relay 指令
+~/.openclaw/workspace-my-gemini-relay/relay.sh                # acpx 呼叫腳本
+```
+
+---
+
+## 相關文件
+
+- [OpenClaw × ACP × Kiro 整合指南](./acp_kiro.md) — 使用 kiro-cli（需 acpx patch）
+- [OpenClaw × ACP × Codex 整合指南](./acp_codex.md) — 使用 OpenAI Codex CLI（無需 patch）

--- a/docs/acp_kiro.md
+++ b/docs/acp_kiro.md
@@ -276,3 +276,4 @@ kiro-cli --version
 ## 相關文件
 
 - [OpenClaw × ACP × Codex 整合指南](./acp_codex.md) — 使用 OpenAI Codex CLI 的同類整合（無需 acpx patch）
+- [OpenClaw × ACP × Gemini 整合指南](./acp_gemini.md) — 使用 Google Gemini CLI（無需 patch）

--- a/release-notes/2026-03-02.md
+++ b/release-notes/2026-03-02.md
@@ -1,0 +1,335 @@
+# OpenClaw v2026.3.1 版本發佈說明（2026-03-02）
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.1)
+
+## 概述
+
+### 功能更新（Features）
+
+- ⭐⭐⭐ Agents/Thinking：Claude 4.6 模型預設 `adaptive` thinking level，其餘 reasoning 模型維持 `low`
+- ⭐⭐⭐ Gateway/Container：新增內建 HTTP liveness/readiness endpoints（`/health`、`/healthz`、`/ready`、`/readyz`）([#31272](https://github.com/openclaw/openclaw/pull/31272))
+- ⭐⭐⭐ Android/Nodes：新增 `camera.list`、`device.permissions`、`device.health`、`notifications.actions`（open/dismiss/reply）([#28260](https://github.com/openclaw/openclaw/pull/28260))
+- ⭐⭐⭐ Discord/Thread：以 inactivity（`idleHours`）+ 可選 `maxAgeHours` 取代固定 TTL，新增 `/session idle` + `/session max-age` 指令 ([#27845](https://github.com/openclaw/openclaw/pull/27845))
+- ⭐⭐⭐ Telegram/DM Topics：per-DM `direct` + topic 設定（allowlists、`dmPolicy`、`skills`、`systemPrompt`、`requireTopic`）([#30579](https://github.com/openclaw/openclaw/pull/30579))
+- ⭐⭐ OpenAI/Streaming：`openai` Responses 預設 WebSocket-first（`transport: "auto"` + SSE fallback），加入 per-session WS 清理
+- ⭐⭐ ACP/ACPX：pin ACPX 至 `0.1.15`，加入可設定的 command/version probing，`final_only` 預設減少 tool-event 噪音 ([#30036](https://github.com/openclaw/openclaw/pull/30036))
+- ⭐⭐ Cron/Heartbeat：opt-in lightweight bootstrap（`--light-context` / `heartbeat.lightContext`），heartbeat 僅保留 `HEARTBEAT.md` ([#26064](https://github.com/openclaw/openclaw/pull/26064))
+- ⭐⭐ Android/Nodes parity：新增 `system.notify`、`photos.latest`、`contacts.search/add`、`calendar.events/add`、`motion.activity/pedometer` ([#29398](https://github.com/openclaw/openclaw/pull/29398))
+- ⭐⭐ Android/Gateway：live capability integration coverage + A2UI readiness retries + canvas URL normalization ([#28388](https://github.com/openclaw/openclaw/pull/28388))
+- ⭐⭐ Agents/Subagents：以 typed `task_completion` internal events 取代 ad-hoc system-message handoff
+- ⭐ Web UI/Cron i18n：cron 頁面標籤、篩選器、表單說明、驗證訊息英/zh-CN 在地化 ([#29315](https://github.com/openclaw/openclaw/pull/29315))
+- ⭐ CLI/Config：新增 `openclaw config file` 印出目前 config 路徑 ([#26256](https://github.com/openclaw/openclaw/pull/26256))
+- ⭐ Feishu/Docx tables + uploads：新增 Docx table 建立/寫入與圖片/檔案上傳 actions ([#20304](https://github.com/openclaw/openclaw/pull/20304))
+- ⭐ Feishu/Reactions：新增 `im.message.reaction.created_v1` inbound handling ([#16716](https://github.com/openclaw/openclaw/pull/16716))
+- ⭐ Feishu/Chat tooling：新增 `feishu_chat` tool actions（chat info + member queries）([#14674](https://github.com/openclaw/openclaw/pull/14674))
+- ⭐ Feishu/Doc permissions：`feishu_doc` create 支援 optional owner permission grant ([#28295](https://github.com/openclaw/openclaw/pull/28295))
+- ⭐ Web UI/i18n：新增德語（`de`）locale，Overview 設定自動渲染語言選項 ([#28495](https://github.com/openclaw/openclaw/pull/28495))
+- ⭐ Tools/Diffs：新增 `diffs` plugin tool，支援 before/after text 或 unified patch 的唯讀 diff 渲染
+- ⭐ Memory/LanceDB：支援自訂 OpenAI `baseUrl` 與 embedding dimensions ([#17874](https://github.com/openclaw/openclaw/pull/17874))
+- ⭐ Shell env markers：跨 shell-like runtimes 設定 `OPENCLAW_SHELL` 環境變數
+- ⭐ OpenAI/WebSocket warm-up：可選 WS warm-up（`response.create` with `generate:false`），`openai/*` 預設啟用
+
+### 安全性提升（Security）
+
+- ⭐⭐⭐ Security/Feishu webhook：unauthenticated webhook rate-limit state 加入 stale-window pruning + hard key cap，防止 pre-auth 記憶體無限增長 ([#26050](https://github.com/openclaw/openclaw/pull/26050))
+
+### 錯誤修復（Bug Fixes）
+
+- ⭐⭐⭐ Feishu/System preview prompt leakage：停止將 Feishu message preview 排入 system events，防止 preview 文字注入後續 turn ([#31209](https://github.com/openclaw/openclaw/pull/31209))
+- ⭐⭐⭐ OpenAI Responses/Compaction：統一 store patches，auto-inject server-side `context_management`，支援 per-model opt-out ([#16930](https://github.com/openclaw/openclaw/pull/16930)/[#22441](https://github.com/openclaw/openclaw/pull/22441)/[#25088](https://github.com/openclaw/openclaw/pull/25088))
+- ⭐⭐ Android/Nodes reliability：拒絕 `facing=both` + `deviceId` 組合、允許 non-clearable 通知 open/reply、觸發 listener rebind ([#28260](https://github.com/openclaw/openclaw/pull/28260))
+- ⭐⭐ Feishu/Multi-account + reply reliability：新增 `defaultAccount` 路由、quoted-message text-first、video 改 `msg_type: "file"`、non-blocking event handling ([#29610](https://github.com/openclaw/openclaw/pull/29610)/[#30432](https://github.com/openclaw/openclaw/pull/30432)/[#30331](https://github.com/openclaw/openclaw/pull/30331)/[#29501](https://github.com/openclaw/openclaw/pull/29501))
+- ⭐⭐ Feishu/Typing replay suppression：以 message-age 跳過 stale replayed 訊息的 typing indicator ([#30709](https://github.com/openclaw/openclaw/pull/30709))
+- ⭐⭐ Slack/Announce target account routing：multi-account announce 正確解析 `accountId` ([#31028](https://github.com/openclaw/openclaw/pull/31028))
+- ⭐⭐ Android/Voice screen TTS：透過 ElevenLabs WebSocket 串流語音，mute/barge-in 時乾淨停止 ([#29521](https://github.com/openclaw/openclaw/pull/29521))
+- ⭐⭐ Feishu/Group session routing：新增 `group`/`group_sender`/`group_topic`/`group_topic_sender` session scopes ([#17798](https://github.com/openclaw/openclaw/pull/17798))
+- ⭐⭐ Feishu/Reply-in-thread routing：新增 `replyInThread` config，propagate 跨 text/card/media/streaming sends ([#27325](https://github.com/openclaw/openclaw/pull/27325))
+- ⭐⭐ Telegram/Outbound chunking：oversize splitting 走 shared pipeline，retry escaped HTML 超限，保留 boundary whitespace ([#29342](https://github.com/openclaw/openclaw/pull/29342)/[#27317](https://github.com/openclaw/openclaw/pull/27317))
+- ⭐⭐ Agents/Thinking fallback：provider 拒絕 unsupported thinking level 時自動 retry with `think=off` ([#31002](https://github.com/openclaw/openclaw/pull/31002))
+- ⭐ Windows/Plugin install：改用 `node` + npm CLI scripts 避免 `spawn EINVAL` ([#31147](https://github.com/openclaw/openclaw/pull/31147))
+- ⭐ LINE/Voice transcription：M4A voice 正確分類為 `audio/mp4` ([#31151](https://github.com/openclaw/openclaw/pull/31151))
+- ⭐ Android/Photos permissions：宣告 Android 14+ `READ_MEDIA_VISUAL_USER_SELECTED`
+- ⭐ Feishu/Probe status caching：`probeFeishu()` 結果 cache 10 分鐘，減少重複 API 呼叫 ([#28907](https://github.com/openclaw/openclaw/pull/28907))
+- ⭐ Feishu/Opus media send type：`.opus` 改用 `msg_type: "audio"` ([#28269](https://github.com/openclaw/openclaw/pull/28269))
+- ⭐ Feishu/Inbound sender fallback：`open_id` 缺失時 fallback 至 `user_id` ([#26703](https://github.com/openclaw/openclaw/pull/26703))
+- ⭐ Feishu/Post markdown parsing：rich-text `post` 走 shared markdown-aware parser ([#12755](https://github.com/openclaw/openclaw/pull/12755))
+- ⭐ TTS/Voice bubbles：Feishu + WhatsApp 啟用 opus output + `audioAsVoice` routing ([#27366](https://github.com/openclaw/openclaw/pull/27366))
+- ⭐ Telegram/Reply media context：replied media 納入 inbound context，defer 至 debounce flush ([#28488](https://github.com/openclaw/openclaw/pull/28488))
+- ⭐ Telegram/Voice fallback reply chunking：reply reference/quote/buttons 僅套用第一個 chunk ([#31067](https://github.com/openclaw/openclaw/pull/31067))
+- ⭐ Cron/Delivery mode none：`delivery.mode: "none"` 時停用 messaging tool ([#21808](https://github.com/openclaw/openclaw/pull/21808))
+- ⭐ Gateway/WS：close post-handshake `unauthorized role:*` flood，sample duplicate rejection logs ([#20168](https://github.com/openclaw/openclaw/pull/20168))
+- ⭐ Agents/Failover reason：避免 `tpm` substring 誤判為 rate-limit ([#31007](https://github.com/openclaw/openclaw/pull/31007))
+- ⭐ Sandbox/Browser Docker：傳入 `OPENCLAW_BROWSER_NO_SANDBOX=1`，bump security hash epoch ([#29879](https://github.com/openclaw/openclaw/pull/29879))
+- ⭐ Auto-reply/NO_REPLY：從 mixed-content 訊息中 strip `NO_REPLY` token ([#31080](https://github.com/openclaw/openclaw/pull/31080))
+- ⭐ Secrets/Auth profiles：normalize inline SecretRef `token`/`key` 至 `tokenRef`/`keyRef` ([#31047](https://github.com/openclaw/openclaw/pull/31047))
+- ⭐ CLI/Install：npm-link fallback 修 `Permission denied` (`exit 127`) ([#17151](https://github.com/openclaw/openclaw/pull/17151))
+- ⭐ Docker/Image permissions：`/app/extensions`、`/app/.agent`、`/app/.agents` 目錄 755 / 檔案 644 ([#30191](https://github.com/openclaw/openclaw/pull/30191))
+- ⭐ Gateway/macOS supervised restart：`launchctl kickstart -k` 繞過 `ThrottleInterval` ([#29078](https://github.com/openclaw/openclaw/pull/29078))
+- ⭐ Feishu/Reaction notifications：新增 `reactionNotifications` config（`off|own|all`）([#28529](https://github.com/openclaw/openclaw/pull/28529))
+- ⭐ Feishu/Docx append/write ordering：sequential single-block creates 保留 markdown block 順序 ([#26172](https://github.com/openclaw/openclaw/pull/26172))
+- ⭐ Security/Compaction audit：移除 post-compaction audit injection message ([#28507](https://github.com/openclaw/openclaw/pull/28507))
+- ⭐ Usage normalization：clamp 負數 prompt/input token 至 0 ([#31211](https://github.com/openclaw/openclaw/pull/31211))
+
+---
+
+## 功能更新（Features）— by Star Rating
+
+### ⭐⭐⭐ Agents/Thinking：Claude 4.6 預設 `adaptive` thinking level
+
+- **用途**：Anthropic Claude 4.6 模型（含 Bedrock refs）預設 thinking level 改為 `adaptive`；其餘 reasoning 模型維持 `low`。
+- **解決問題**：Claude 4.6 在 `low` 模式下思考深度不足，影響複雜任務品質。
+- **影響**：Claude 4.6 使用者無需手動調整即可獲得更佳推理品質。
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Thinking Level 決策流程                 │
+└─────────────────────────────────────────────────────┘
+
+  model 設定 thinking level?
+         │
+        Yes ──────────────────────────▶ 使用設定值
+         │
+        No
+         │
+         ▼
+  是 Claude 4.6 / Bedrock 4.6 ref?
+         │
+        Yes ──────────────────────────▶ adaptive（新預設）
+         │
+        No
+         │
+         ▼
+  其他 reasoning-capable model
+         │
+         ▼
+       low（維持原預設）
+```
+
+### ⭐⭐⭐ Gateway/Container：內建 HTTP health check endpoints ([#31272](https://github.com/openclaw/openclaw/pull/31272))
+
+- **用途**：新增 `/health`、`/healthz`、`/ready`、`/readyz` endpoints，供 Docker/Kubernetes liveness/readiness probe 使用。
+- **解決問題**：容器化部署缺乏標準 health check，導致 orchestrator 無法正確判斷服務狀態。
+- **影響**：Docker Compose / K8s 部署可直接設定 probe，無需自訂 wrapper。
+
+```
+┌──────────────┐   probe    ┌─────────────────────────────┐
+│  Kubernetes  │──────────▶ │  OpenClaw Gateway           │
+│  / Docker    │            │                             │
+└──────────────┘            │  /health   ──▶ 200 OK       │
+                            │  /healthz  ──▶ 200 OK       │
+                            │  /ready    ──▶ 200 OK       │
+                            │  /readyz   ──▶ 200 OK       │
+                            │                             │
+                            │  ⚠ 若路徑已有 handler       │
+                            │    fallback routing 不覆蓋  │
+                            └─────────────────────────────┘
+```
+
+### ⭐⭐⭐ Android/Nodes：新增 camera.list / device.permissions / device.health / notifications.actions ([#28260](https://github.com/openclaw/openclaw/pull/28260))
+
+- **用途**：擴充 Android node tool actions，涵蓋相機列舉、裝置權限/健康狀態查詢，以及通知 open/dismiss/reply。
+- **解決問題**：Android node 缺乏裝置狀態感知與通知互動能力，限制自動化場景。
+- **影響**：Android 端 agent 可主動查詢裝置狀態並回應通知，大幅擴展行動端自動化能力。
+
+```
+┌─────────────┐   tool call   ┌──────────────────────────────┐
+│   Agent     │──────────────▶│  Android Node                │
+└─────────────┘               │                              │
+                              │  camera.list                 │
+                              │    └▶ 列舉可用相機            │
+                              │  device.permissions          │
+                              │    └▶ 查詢/請求權限           │
+                              │  device.health               │
+                              │    └▶ 電量/網路/儲存狀態      │
+                              │  notifications.actions       │
+                              │    ├▶ open（可開啟）          │
+                              │    ├▶ dismiss（可清除才可）   │
+                              │    └▶ reply（可回覆才可）     │
+                              └──────────────────────────────┘
+```
+
+### ⭐⭐⭐ Discord/Thread：inactivity lifecycle + /session 指令 ([#27845](https://github.com/openclaw/openclaw/pull/27845))
+
+- **用途**：Discord thread-bound session 改以 `idleHours`（預設 24h）+ 可選 `maxAgeHours` 控制生命週期；新增 `/session idle` 與 `/session max-age` 指令。
+- **解決問題**：固定 TTL 不符合實際使用節奏，活躍 thread 可能被提前關閉，閒置 thread 又佔用資源。
+- **影響**：Discord 使用者可依需求調整 session 存活策略，減少意外中斷。
+
+```
+┌──────────────────────────────────────────────────────┐
+│              Discord Thread Session 生命週期          │
+└──────────────────────────────────────────────────────┘
+
+  Thread 建立
+      │
+      ▼
+  等待訊息 ◀──────────────────────────────────────┐
+      │                                           │
+  收到訊息                                        │
+      │                                           │
+      ▼                                           │
+  重置 idle timer（idleHours，預設 24h）           │
+      │                                           │
+      ├── 超過 maxAgeHours（若設定）──▶ 關閉 thread │
+      │                                           │
+      └── idle timer 到期 ──────────────────────▶ 關閉 thread
+```
+
+### ⭐⭐⭐ Telegram/DM Topics：per-DM topic 設定與授權 ([#30579](https://github.com/openclaw/openclaw/pull/30579))
+
+- **用途**：支援 per-DM `direct` + topic config（allowlists、`dmPolicy`、`skills`、`systemPrompt`、`requireTopic`），DM topics 作為獨立 inbound/outbound session 路由，並強制 topic-aware 授權/debounce。
+- **解決問題**：DM 與 topic 混用時授權邏輯不一致，無法針對不同 topic 設定不同 skill/prompt。
+- **影響**：Telegram 進階使用者可為每個 DM topic 設定獨立的 agent 行為與存取控制。
+
+```
+┌─────────────────────────────────────────────────────┐
+│           Telegram DM Topic 路由流程                 │
+└─────────────────────────────────────────────────────┘
+
+  inbound DM 訊息
+        │
+        ▼
+  有 topic ID?
+        │
+       Yes ──▶ 查找 per-DM topic config
+        │              │
+        │         有設定? ──Yes──▶ 套用 skills/systemPrompt/dmPolicy
+        │              │
+        │              No ──▶ 套用 direct config 預設
+        │
+        No ──▶ 走一般 DM 路由
+        │
+        ▼
+  topic-aware 授權檢查
+        │
+   通過 ──▶ debounce ──▶ 送入 session
+        │
+   拒絕 ──▶ 丟棄
+```
+
+---
+
+## 安全性提升（Security）— by Star Rating
+
+### ⭐⭐⭐ Security/Feishu webhook：pre-auth rate-limit 記憶體邊界 ([#26050](https://github.com/openclaw/openclaw/pull/26050))
+
+- **用途**：對 unauthenticated webhook rate-limit state 加入 stale-window pruning 與 hard key cap，防止 rotating source keys 造成記憶體無限增長。
+- **解決問題**：攻擊者可用大量不同 source key 的請求耗盡 gateway 記憶體（pre-auth DoS）。
+- **影響**：Feishu webhook ingress 更能抵抗 pre-auth 記憶體耗盡攻擊。
+
+```
+┌──────────────────────────────────────────────────────┐
+│         Feishu Webhook Pre-auth 防護流程              │
+└──────────────────────────────────────────────────────┘
+
+  inbound webhook（未驗證）
+          │
+          ▼
+  rate-limit state 查找 source key
+          │
+          ├──▶ key 數量 > hard cap?
+          │         │
+          │        Yes ──▶ 拒絕（防記憶體耗盡）
+          │         │
+          │        No
+          │         │
+          ▼         ▼
+  stale-window pruning（清除過期 key）
+          │
+          ▼
+  rate-limit 檢查
+          │
+     通過 ──▶ 繼續驗證流程
+          │
+     超限 ──▶ 拒絕
+```
+
+---
+
+## 錯誤修復（Bug Fixes）— by Star Rating
+
+### ⭐⭐⭐ Feishu/System preview prompt leakage ([#31209](https://github.com/openclaw/openclaw/pull/31209))
+
+- **用途**：停止將 Feishu inbound message preview 排入 system events queue，防止 preview 文字以 `System:` 身份注入後續 agent turn。
+- **解決問題**：惡意或意外的 preview 內容可偽裝成系統指令影響 agent 行為（prompt injection 風險）。
+- **影響**：Feishu 使用者的 agent 不再受 preview 文字污染，安全性與行為可預期性提升。
+
+```
+┌──────────────────────────────────────────────────────┐
+│         Feishu Preview 注入修復前後對比               │
+└──────────────────────────────────────────────────────┘
+
+  修復前：
+  ┌──────────────┐   preview text   ┌─────────────────┐
+  │ Feishu inbound│────────────────▶│ system events   │
+  └──────────────┘                  │ queue           │
+                                    └────────┬────────┘
+                                             │
+                                             ▼
+                                    ┌─────────────────┐
+                                    │ Agent turn      │
+                                    │ System: <preview│  ← 污染
+                                    └─────────────────┘
+
+  修復後：
+  ┌──────────────┐   preview text   ┌─────────────────┐
+  │ Feishu inbound│────────────────▶│ 丟棄（不排隊）   │
+  └──────────────┘                  └─────────────────┘
+                                    Agent turn 乾淨 ✓
+```
+
+### ⭐⭐⭐ OpenAI Responses/Compaction：統一 store patches + server-side context_management ([#16930](https://github.com/openclaw/openclaw/pull/16930)/[#22441](https://github.com/openclaw/openclaw/pull/22441)/[#25088](https://github.com/openclaw/openclaw/pull/25088))
+
+- **用途**：重寫 OpenAI Responses store patches，空 `baseUrl` 視為 non-direct；尊重 `compat.supportsStore=false`；對相容的 direct OpenAI 模型自動注入 `context_management`（支援 per-model opt-out/threshold）。
+- **解決問題**：compaction 路徑不一致導致 store 狀態錯誤，部分模型不支援 store 卻仍嘗試注入。
+- **影響**：長對話 compaction 更可靠，減少 context 截斷與 store 相關錯誤。
+
+```
+┌──────────────────────────────────────────────────────┐
+│       OpenAI Responses Compaction 決策流程            │
+└──────────────────────────────────────────────────────┘
+
+  OpenAI Responses 請求
+          │
+          ▼
+  baseUrl 為空或非 direct?
+          │
+         Yes ──▶ non-direct 路徑（不注入 store）
+          │
+         No
+          │
+          ▼
+  compat.supportsStore = false?
+          │
+         Yes ──▶ 跳過 store patch
+          │
+         No
+          │
+          ▼
+  per-model opt-out 設定?
+          │
+         Yes ──▶ 跳過 context_management 注入
+          │
+         No
+          │
+          ▼
+  自動注入 context_management（含 threshold）
+          │
+          ▼
+  送出請求 ✓
+```
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 5 | 6 | 11 | Thinking 智慧預設、容器 health check、Android 裝置能力大幅擴充、Discord/Telegram 進階 session 控制、OpenAI WS-first |
+| 安全性提升 | 1 | 0 | 0 | Feishu webhook pre-auth 記憶體邊界防護 |
+| 錯誤修復 | 2 | 11 | 26 | Feishu preview 注入修復、OpenAI compaction 統一、多平台穩定性大量修正 |
+| **總計** | **8** | **17** | **37** | **62 項** |
+
+**發佈日期**: 2026-03-02
+**版本**: 2026.3.1
+**狀態**: Production Ready
+**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.3.1


### PR DESCRIPTION
Closes #176

## Release Notes: OpenClaw 2026.3.1

新增 `release-notes/2026-03-02.md`，依循 GUIDELINES.md 格式撰寫。

### 涵蓋內容
- **功能更新**：5 項三星（Thinking adaptive 預設、容器 health check、Android 裝置能力、Discord thread lifecycle、Telegram DM topics）
- **安全性提升**：1 項三星（Feishu webhook pre-auth 記憶體邊界）
- **錯誤修復**：2 項三星（Feishu preview prompt injection、OpenAI compaction 統一）
- 所有三星項目均附 ASCII solid-line 流程圖

### 上游 Release
https://github.com/openclaw/openclaw/releases/tag/v2026.3.1
