### PR TITLE
docs: add awesome-claw-skills.md - community skill catalog

### DIFF
--- a/docs/awesome-claw-skills.md
+++ b/docs/awesome-claw-skills.md
@@ -1,0 +1,32 @@
+# Awesome Claw Skills
+
+> A curated list of OpenClaw skills for personal automation.
+
+## Skills List
+
+| Skill | Author | Description |
+|-------|--------|-------------|
+| [androidtv-netflix](https://github.com/jiayun/jiayun-claw-skills/tree/main/skills/androidtv-netflix) | [@jiayun](https://github.com/jiayun) | Search and play Netflix content on Android TV via ADB |
+
+<!-- Add more skills above following the same format -->
+
+## How to Use
+
+Clone or copy the skill into your workspace's `skills/` directory:
+
+```bash
+# Example: Using androidtv-netflix skill
+git clone https://github.com/jiayun/jiayun-claw-skills.git
+cp -r jiayun-claw-skills/skills/androidtv-netflix /path/to/your/workspace/skills/
+```
+
+## Skill Repositories
+
+| Repository | Author |
+|------------|--------|
+| [jiayun-claw-skills](https://github.com/jiayun/jiayun-claw-skills) | [@jiayun](https://github.com/jiayun) |
+
+## Learn More
+
+- [Skills System](core/skills-system.md) - How to create and package skills
+- [ClawHub](https://clawhub.com) - Official skill marketplace


### PR DESCRIPTION
Add a curated list of OpenClaw skills following the awesome-list format.

Includes androidtv-netflix skill as the first entry.

Co-authored-by: testarossa-agent <jiayun+testarossa@gmail.com>