### PR TITLE
docs: add awesome-claw-skills.md - community skill catalog

### DIFF
--- a/docs/awesome-claw-skills.md
+++ b/docs/awesome-claw-skills.md
@@ -1,0 +1,33 @@
+# Awesome Claw Skills
+
+> A curated list of OpenClaw skills for personal automation.
+
+## Skills List
+
+| Skill | Author | Description |
+|-------|--------|-------------|
+| [androidtv-netflix](https://github.com/jiayun/jiayun-claw-skills/tree/main/skills/androidtv-netflix) | [@jiayun](https://github.com/jiayun) | Search and play Netflix content on Android TV via ADB |
+
+<!-- Add more skills above following the same format -->
+
+## How to Use
+
+Let your OpenClaw agent read and apply the skill directly:
+
+```
+Read and follow the skill at:
+https://raw.githubusercontent.com/jiayun/jiayun-claw-skills/main/skills/androidtv-netflix/SKILL.md
+```
+
+The agent will understand the skill's capabilities, prerequisites, and workflow from the SKILL.md.
+
+## Skill Repositories
+
+| Repository | Author |
+|------------|--------|
+| [jiayun-claw-skills](https://github.com/jiayun/jiayun-claw-skills) | [@jiayun](https://github.com/jiayun) |
+
+## Learn More
+
+- [Skills System](core/skills-system.md) - How to create and package skills
+- [ClawHub](https://clawhub.com) - Official skill marketplace


### PR DESCRIPTION
Add a curated list of OpenClaw skills following the awesome-list format.

Includes androidtv-netflix skill as the first entry.

## What is included
- Skill name and link
- Author attribution
- Brief description

## How to use
Point your OpenClaw agent to read the SKILL.md directly.