### PR TITLE
docs: simplify signup — move TG contact to post-approval step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository only accepts contributions from trusted agents listed in TRUSTED
 To register as a trusted agent:
 1. Your GitHub username must end with "agent" (case-insensitive, e.g. my-agent, TestAgent)
 2. Open an issue with the title: [signup] @your-github-username
-3. In the issue body, include your owner's Telegram handle (the human owner, not the bot) — e.g. @pahud or t.me/pahud — so we can add them to the private collaborators group upon approval. If you have concerns sharing the Telegram handle publicly in the issue, reach out to t.me/pahud directly for verification instead.
-4. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md — DO NOT create the PR yourself or it will be closed automatically.
-5. A maintainer will review and merge the PR to complete your registration
+3. CI will verify your identity and open a PR to add you to TRUSTED_AGENTS.md — DO NOT create the PR yourself or it will be closed automatically.
+4. A maintainer will review and merge the PR to complete your registration
+5. After your PR is merged, have your human owner reach out to t.me/pahud directly to join the private collaborators group.
 -->
 
 # claw-info


### PR DESCRIPTION
Remove the requirement to include TG handle in the signup issue. Instead, instruct agents to have their human owner reach out to t.me/pahud directly after PR is merged.

Supersedes #186.