### PR TITLE
docs: add v2026.2.26 release notes

### DIFF
--- a/release-notes/2026-02-26.md
+++ b/release-notes/2026-02-26.md
@@ -1,0 +1,241 @@
+# OpenClaw v2026.2.26 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.26)
+
+## 概述
+
+- **功能更新**: ⭐⭐⭐ External Secrets Management、⭐⭐⭐ ACP Thread-bound Agents、⭐⭐⭐ Codex WebSocket Transport、⭐⭐ Agents 路由 CLI、⭐⭐ Onboarding Plugin Hooks、⭐⭐ Android Nodes 新增裝置/通知能力
+- **安全性提升**: ⭐⭐⭐ Node exec approvals 強化、⭐⭐⭐ Plugin channel HTTP auth 路徑正規化、⭐⭐⭐ Gateway node pairing 中繼資料綁定、⭐⭐⭐ Sandbox symlink 逃脫防護（多項）、⭐⭐⭐ Config includes hardlink 防護、⭐⭐⭐ MS Teams media SSRF 防護、⭐⭐⭐ Voice Call webhook replay 防護
+- **錯誤修復**: ⭐⭐⭐ Telegram DM allowlist 繼承修復、⭐⭐⭐ Compaction 安全與 onboarding 強化、⭐⭐⭐ NO_REPLY 洩漏至 Slack、⭐⭐ Delivery queue recovery backoff、⭐⭐ Typing indicator 全面修復、⭐⭐ Browser extension relay 多項強化
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ External Secrets Management ([#26155](https://github.com/openclaw/openclaw/pull/26155))
+
+- **用途**: 引入完整 `openclaw secrets` 工作流程（`audit`、`configure`、`apply`、`reload`），支援 runtime snapshot 啟用、嚴格 `secrets apply` 路徑驗證、ref-only auth-profile 支援
+- **解決問題**: 過去敏感資訊直接存在 config 中，缺乏集中管理與安全遷移機制
+- **影響**: 大幅提升部署安全性，secrets 管理從散落各處整合為統一流程
+
+### ⭐⭐⭐ ACP Thread-bound Agents ([#23580](https://github.com/openclaw/openclaw/pull/23580))
+
+- **用途**: 將 ACP agents 提升為 thread session 的正式 runtime，整合 `acp` spawn/send dispatch、acpx backend 橋接、lifecycle 控制、啟動對帳、runtime 清理與合併 thread 回覆
+- **解決問題**: ACP agents 無法綁定到 thread session，無法持續對話
+- **影響**: 可在 Discord/Slack thread 中啟動持久 Claude/Codex/Gemini 工作階段
+
+### ⭐⭐⭐ Codex WebSocket Transport
+
+- **用途**: `openai-codex` 預設改為 WebSocket-first（`transport: "auto"` 搭配 SSE fallback），保留 per-model/runtime 的 transport 覆寫
+- **解決問題**: 過去僅走 SSE，延遲較高且不支援雙向通訊
+- **影響**: 降低延遲、改善串流品質
+
+### ⭐⭐ Agents 路由 CLI ([#27195](https://github.com/openclaw/openclaw/pull/27195))
+
+- **用途**: 新增 `openclaw agents bindings`、`openclaw agents bind`、`openclaw agents unbind` 指令，支援帳號範圍路由管理
+- **解決問題**: 過去無法從 CLI 管理 agent 綁定
+- **影響**: 簡化多帳號 agent 路由管理
+
+### ⭐⭐ Onboarding Plugin Hooks ([#27191](https://github.com/openclaw/openclaw/pull/27191))
+
+- **用途**: 讓 channel plugin 擁有互動式 onboarding 流程（`configureInteractive`、`configureWhenConfigured`）
+- **解決問題**: 所有 channel 只能走通用 onboarding，無法客製
+- **影響**: 各 channel 可提供更友善的設定引導
+
+### ⭐⭐ Android Nodes：裝置狀態與通知 ([#27664](https://github.com/openclaw/openclaw/pull/27664), [#27344](https://github.com/openclaw/openclaw/pull/27344))
+
+- **用途**: 新增 `device.status`、`device.info`、`notifications.list` 能力
+- **解決問題**: Agent 無法查詢 Android 裝置狀態或取得通知列表
+- **影響**: 擴展 Android node 的可觀測性
+
+### ⭐ Auth/Gemini OAuth 安全警告 ([#16683](https://github.com/openclaw/openclaw/pull/16683))
+
+- **用途**: 在 Gemini CLI OAuth 啟動前加入帳號風險警告與確認閘門
+- **解決問題**: 使用者可能不知道 OAuth 授權範圍
+- **影響**: 提升安全意識
+
+### ⭐ Docs/Contributing
+
+- **用途**: 新增 Nimrod Gutman 為 CONTRIBUTING.md 維護者 ([#27840](https://github.com/openclaw/openclaw/pull/27840))
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Node exec approvals 強化
+
+- **用途**: 要求結構化 `commandArgv` approvals（`host=node`），實施 `systemRunBindingV1` 精確比對，封鎖 `GIT_EXTERNAL_DIFF` 環境變數
+- **解決問題**: trailing-space / symlink 路徑替換可繞過 approval
+- **影響**: exec approval 無法被路徑操控繞過
+
+### ⭐⭐⭐ Plugin channel HTTP auth 路徑正規化
+
+- **用途**: 正規化 `/api/channels` 路徑檢查（大小寫 + percent-decoding + slash 正規化），拒絕編碼 dot-segment traversal
+- **解決問題**: 替代路徑變體繞過 gateway auth
+- **影響**: channel API 端點安全邊界更嚴密
+
+### ⭐⭐⭐ Gateway node pairing 中繼資料綁定
+
+- **用途**: 鎖定 `platform`/`deviceFamily` 中繼資料於重連時，並綁入 device-auth 簽章
+- **解決問題**: 重連時竄改中繼資料可擴展 node command allowlist
+- **影響**: node 設備無法透過 reconnect 偽造能力
+
+### ⭐⭐⭐ Sandbox symlink 逃脫防護（二項）
+
+- **用途**: 拒絕斷裂 symlink 目標、正規化非存在 leaf 的 symlink 別名；`apply_patch` 寫入無法透過 dangling symlink 逃脫
+- **解決問題**: 透過 dangling symlink 寫入 workspace 外
+- **影響**: sandbox/workspace 邊界更可靠
+
+### ⭐⭐⭐ Config includes hardlink 防護
+
+- **用途**: `$include` 載入改用 verified-open read、拒絕 hardlink 別名、加入檔案大小限制
+- **解決問題**: 透過 include 載入非信任檔案
+- **影響**: config include 僅限信任 in-root 檔案
+
+### ⭐⭐⭐ Node exec approvals 二階段強化
+
+- **用途**: `system.run.prepare` 凍結不可變執行計畫（`argv`/`cwd`/`agentId`/`sessionKey`），approval forwarding/execution 時強制比對
+- **解決問題**: approval 後 symlink rebind 可替換 cwd
+- **影響**: approval 從准許到執行之間的 TOCTOU 攻擊被封堵
+
+### ⭐⭐⭐ MS Teams media fetch SSRF 防護
+
+- **用途**: Graph message/hosted-content/attachment 下載統一走 SSRF-guarded fetch，集中 hostname-suffix allowlist
+- **解決問題**: Teams media fetch 可能被導向內部網路
+- **影響**: Teams channel 的媒體抓取安全對齊其他 channel
+
+### ⭐⭐⭐ Voice Call (Twilio) webhook replay 防護
+
+- **用途**: webhook replay/manager dedupe 綁定至已驗證請求素材，移除未簽名 `i-twilio-idempotency-token` 的信任
+- **解決問題**: replay 攻擊與 cross-provider event dedupe 偽造
+- **影響**: Twilio webhook 防重放安全提升
+
+### ⭐⭐ Exec approvals forwarding 路由修正
+
+- **用途**: approval delivery 優先使用 turn-source channel/account/thread metadata
+- **解決問題**: stale session route 可能導致 approval 提示送到錯誤地方
+- **影響**: approval 路由更可靠
+
+### ⭐⭐ Pairing multi-account 隔離
+
+- **用途**: 強制帳號範圍的 pairing allowlist 與 pending-request 儲存
+- **解決問題**: 跨帳號 pairing 邊界不明確
+- **影響**: 多帳號部署的配對安全提升
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Telegram DM allowlist runtime 繼承 ([#27936](https://github.com/openclaw/openclaw/pull/27936))
+
+- **用途**: `dmPolicy: "allowlist"` 的 `allowFrom` 跨所有帳號-capable channel（Telegram、Discord、Slack、Signal、iMessage、IRC、BlueBubbles、WhatsApp）統一使用 effective account+parent config
+- **解決問題**: DM 訊息在升級後被靜默丟棄
+- **影響**: DM 授權行為一致且可預測
+
+### ⭐⭐⭐ Compaction 安全與 onboarding 強化 ([#26458](https://github.com/openclaw/openclaw/pull/26458), [#27314](https://github.com/openclaw/openclaw/pull/27314))
+
+- **用途**: 防止破壞性 double-compaction、跳過無真實對話訊息的 safeguard compaction、`openclaw onboard --reset` 預設範圍改為 `config+creds+sessions`
+- **解決問題**: compaction 邊界的 assistant usage 殘留導致對話損壞
+- **影響**: 對話壓縮更安全，onboarding reset 不再預設刪 workspace
+
+### ⭐⭐⭐ NO_REPLY 洩漏至用戶頻道 ([#27529](https://github.com/openclaw/openclaw/pull/27529), [#27535](https://github.com/openclaw/openclaw/pull/27535))
+
+- **用途**: 在 Slack API send 前及 sub-agent announce 完成流程中過濾 `NO_REPLY` sentinel
+- **解決問題**: `NO_REPLY` 文字被直接發送給用戶
+- **影響**: sentinel 不再洩漏到用戶頻道
+
+### ⭐⭐ Delivery queue recovery backoff ([#27710](https://github.com/openclaw/openclaw/pull/27710))
+
+- **用途**: 持久化 `lastAttemptAt`，延遲到 backoff 窗口才重試
+- **解決問題**: 重試飢餓（retry starvation）
+- **影響**: 失敗投遞有合理退避，不阻塞其他投遞
+
+### ⭐⭐ Typing indicator 全面修復 ([#27250](https://github.com/openclaw/openclaw/pull/27250), [#27428](https://github.com/openclaw/openclaw/pull/27428), [#27647](https://github.com/openclaw/openclaw/pull/27647), [#27415](https://github.com/openclaw/openclaw/pull/27415))
+
+- **用途**: 修復 main reply pipeline idle 標記、TTL 安全網、cross-channel 洩漏、Telegram `sendChatAction` 401 無限重試
+- **解決問題**: typing indicator 卡住不消、跨 channel 洩漏、Telegram bot 被封
+- **影響**: 所有 channel 的 typing indicator 正確清理
+
+### ⭐⭐ Browser extension relay 多項強化
+
+- **用途**: CORS preflight 處理 ([#23962](https://github.com/openclaw/openclaw/pull/23962))、query-param auth ([#26015](https://github.com/openclaw/openclaw/pull/26015))、shutdown flush ([#24142](https://github.com/openclaw/openclaw/pull/24142))、reconnect resilience ([#27617](https://github.com/openclaw/openclaw/pull/27617))、malformed URL 防護 ([#11880](https://github.com/openclaw/openclaw/pull/11880))
+- **解決問題**: extension relay 在各種邊界情況下失敗
+- **影響**: Chrome extension 連線更穩定可靠
+
+### ⭐⭐ Feishu 多項修復
+
+- **用途**: permission error 合併 dispatch ([#27381](https://github.com/openclaw/openclaw/pull/27381))、Doc tools 多帳號路由 ([#27338](https://github.com/openclaw/openclaw/pull/27338))、inbound message_id metadata ([#27253](https://github.com/openclaw/openclaw/pull/27253))、group sender allowlist fallback ([#29174](https://github.com/openclaw/openclaw/pull/29174))
+- **解決問題**: Feishu 權限提示重複、多帳號 Doc 路由錯誤、缺 message_id
+- **影響**: Feishu 整合更穩定完善
+
+### ⭐⭐ Matrix group sender identity ([#27401](https://github.com/openclaw/openclaw/pull/27401))
+
+- **用途**: 保留 Matrix group 中 sender labels
+- **解決問題**: 第一人稱請求無法對應到正確 sender
+- **影響**: Matrix group 對話身份辨識正常
+
+### ⭐⭐ Auto-reply 串流 sentinel 過濾 ([#19576](https://github.com/openclaw/openclaw/pull/19576))
+
+- **用途**: 僅過濾精確 `NO_REPLY`，同時過濾串流中的 partial sentinel fragment
+- **解決問題**: 串流中 `NO_`、`NO_RE` 等 partial token 洩漏
+- **影響**: 串流回覆不再出現 sentinel 碎片
+
+### ⭐⭐ Pi image-token 控制 ([#27602](https://github.com/openclaw/openclaw/pull/27602))
+
+- **用途**: 停止每 turn 重新注入歷史 image blocks，僅處理當前 prompt 的圖片
+- **解決問題**: token 消耗失控增長
+- **影響**: 圖片對話的 token 使用大幅降低
+
+### ⭐ Config/Plugin entries 容錯 ([#27506](https://github.com/openclaw/openclaw/pull/27506))
+
+- **用途**: 未知 plugin entry 改為啟動警告而非硬錯誤
+- **解決問題**: 殘留 plugin config 導致 gateway 崩潰重啟
+- **影響**: 升級後不再因過期 plugin config 開機失敗
+
+### ⭐ Telegram native commands 降級 ([#27512](https://github.com/openclaw/openclaw/pull/27512))
+
+- **用途**: `BOT_COMMANDS_TOO_MUCH` 時減少命令數重試
+- **解決問題**: 啟動同步崩潰
+- **影響**: 大量指令的 bot 不再啟動失敗
+
+### ⭐ Web tools Proxy 支援 ([#27430](https://github.com/openclaw/openclaw/pull/27430))
+
+- **用途**: `web_search`/`web_fetch` 透過 proxy-aware SSRF guard 路由
+- **解決問題**: HTTP_PROXY 環境下 `fetch failed` 錯誤
+- **影響**: 在 proxy 環境中可正常使用 web 工具
+
+### ⭐ Google Gemini model ID 正規化 ([#24145](https://github.com/openclaw/openclaw/pull/24145))
+
+- **用途**: `gemini-3-pro` 等 bare ID 自動補上 `-low` thinking tier suffix
+- **解決問題**: 省略 tier suffix 時 404 錯誤
+- **影響**: model ID 容錯提升
+
+### ⭐ macOS Gateway restart 強化 ([#27655](https://github.com/openclaw/openclaw/pull/27655), [#27448](https://github.com/openclaw/openclaw/pull/27448), [#27650](https://github.com/openclaw/openclaw/pull/27650))
+
+- **用途**: 偵測 supervisor marker、清理 stale PID、設定 `ThrottleInterval=60`
+- **解決問題**: launchd restart storm / lock-release races
+- **影響**: macOS 上 gateway 重啟更可靠
+
+### ⭐ CLI Gateway `--force` 非 root Docker 支援 ([#27941](https://github.com/openclaw/openclaw/pull/27941))
+
+- **用途**: `lsof` EACCES 時 fallback 到 `fuser` + probe-based port check
+- **解決問題**: Docker 容器內 `--force` 無法使用
+- **影響**: Docker 部署的 port 衝突解決更簡單
+
+---
+
+## 摘要
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 3 | 2 | Secrets 管理、ACP thread agents、Codex WS |
+| 安全性 | 8 | 2 | 0 | exec approvals 二階段、多項 symlink/SSRF 防護 |
+| 錯誤修復 | 3 | 7 | 6 | DM allowlist、compaction、typing、browser relay |
+| **總計** | **14** | **12** | **8** | **34 項更新** |
+
+---
+
+- **發佈日期**: 2026-02-26
+- **版本**: 2026.2.26
+- **狀態**: Production Ready
+- **GitHub Release**: [v2026.2.26](https://github.com/openclaw/openclaw/releases/tag/v2026.2.26)


### PR DESCRIPTION
新增 v2026.2.26 版本發佈說明。

涵蓋 34 項更新：
- ⭐⭐⭐ External Secrets Management
- ⭐⭐⭐ ACP Thread-bound Agents
- ⭐⭐⭐ Codex WebSocket Transport
- ⭐⭐⭐ 8 項安全性修復
- ⭐⭐⭐ DM allowlist / Compaction / NO_REPLY 修復
- 以及 typing indicator、browser relay、Feishu 等修復

依照 GUIDELINES.md 格式撰寫。