### PR TITLE
fix: resolve PR number from head SHA for fork PRs in check_suite event

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -38,6 +38,17 @@ jobs:
               prNumber = Number(context.payload.review.pull_request_url.split('/').pop());
             } else if (context.payload.check_suite?.pull_requests?.length) {
               prNumber = context.payload.check_suite.pull_requests[0].number;
+            } else if (context.payload.check_suite?.head_sha) {
+              // check_suite.pull_requests is empty for fork PRs — look up by SHA instead
+              const headSha = context.payload.check_suite.head_sha;
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              const match = prs.find(p => p.head.sha === headSha);
+              if (match) prNumber = match.number;
             }
 
             if (!prNumber) {


### PR DESCRIPTION
## Problem

When a signup PR is opened from a fork (which is always the case for agent signups), the `check_suite` event payload has an empty `pull_requests` array. This is a known GitHub limitation — `check_suite.pull_requests` only includes PRs from the **same repo**, not forks.

As a result, when CI checks (`check-author`, `check`) complete after an approval, the auto-merge workflow fires but cannot determine the PR number and exits early:

```
No PR found in event payload; exiting.
```

This means the happy path breaks:

```
approve PR
    │
    ▼
auto-merge runs (pull_request_review trigger)
    │
    └─▶ checks not done yet → SKIP

checks complete
    │
    ▼
auto-merge runs (check_suite trigger)
    │
    └─▶ check_suite.pull_requests = [] (fork PR) → EXIT ← bug
```

The PR never merges automatically, requiring a manual close & reopen to re-trigger.

## Fix

When `check_suite.pull_requests` is empty but `head_sha` is present, fall back to listing all open PRs and match by `head.sha`:

```
checks complete
    │
    ▼
auto-merge runs (check_suite trigger)
    │
    └─▶ check_suite.pull_requests = [] → lookup open PRs by head.sha
    │
    └─▶ PR found → approved + checks green → MERGE ✓
```

## Impact

After this fix, the full flow works without manual intervention:
1. Agent opens signup PR from fork
2. Maintainer approves
3. CI checks run and pass
4. `check_suite` triggers auto-merge, PR number resolved via SHA lookup
5. PR is automatically merged
