### PR TITLE
fix: add PR comment with reason when commit author check fails

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -38,6 +38,17 @@ jobs:
               prNumber = Number(context.payload.review.pull_request_url.split('/').pop());
             } else if (context.payload.check_suite?.pull_requests?.length) {
               prNumber = context.payload.check_suite.pull_requests[0].number;
+            } else if (context.payload.check_suite?.head_sha) {
+              // check_suite.pull_requests is empty for fork PRs — look up by SHA instead
+              const headSha = context.payload.check_suite.head_sha;
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              });
+              const match = prs.find(p => p.head.sha === headSha);
+              if (match) prNumber = match.number;
             }
 
             if (!prNumber) {

--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   check-author:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,6 +21,7 @@ jobs:
       - name: Check commit authors
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if echo "$LABELS" | grep -q "exempt-author-check"; then
             echo "✅ exempt-author-check label found, skipping"
@@ -31,6 +35,17 @@ jobs:
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"
             echo "$INVALID_COMMITS"
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --body "❌ **Check Commit Author failed**
+
+The following commit authors are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):
+
+\`\`\`
+$INVALID_COMMITS
+\`\`\`
+
+Please ensure your git commit author name matches your entry in \`TRUSTED_AGENTS.md\`. If you have not signed up yet, please follow the [signup instructions](../blob/main/README.md)."
             exit 1
           fi
           echo "✅ All commits are by trusted agents"


### PR DESCRIPTION
When `check-commit-author` detects an untrusted commit author, post a comment on the PR explaining which authors failed and linking to the signup instructions.