### PR TITLE
docs: fix relay.sh sessions ensure cwd mismatch (acp_*.md)

### DIFF
--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -152,7 +152,7 @@ DO NOT use sessions_spawn. DO NOT answer yourself. ONLY call the tools above.
 ```bash
 #!/bin/bash
 ACPX=<ACPX_PATH>
-$ACPX codex sessions ensure --name my-tg >/dev/null 2>&1
+cd $HOME && $ACPX codex sessions ensure --name my-tg >/dev/null 2>&1
 $ACPX --format json codex prompt -s my-tg "$1" 2>/dev/null \
   | python3 -c "
 import sys, json

--- a/docs/acp_gemini.md
+++ b/docs/acp_gemini.md
@@ -149,7 +149,7 @@ DO NOT use sessions_spawn. DO NOT answer yourself. ONLY call the tools above.
 ```bash
 #!/bin/bash
 ACPX=<ACPX_PATH>
-$ACPX --agent "gemini --experimental-acp" sessions ensure --name my-tg >/dev/null 2>&1
+cd $HOME && $ACPX --agent "gemini --experimental-acp" sessions ensure --name my-tg >/dev/null 2>&1
 $ACPX --agent "gemini --experimental-acp" --format json prompt -s my-tg "$1" 2>/dev/null \
   | python3 -c "
 import sys, json

--- a/docs/acp_kiro.md
+++ b/docs/acp_kiro.md
@@ -166,9 +166,11 @@ DO NOT use sessions_spawn. DO NOT answer yourself. ONLY call the tools above.
 ```bash
 #!/bin/bash
 ACPX=<ACPX_PATH>
-$ACPX kiro sessions ensure --name my-tg 2>/dev/null
+cd $HOME && $ACPX kiro sessions ensure --name my-tg 2>/dev/null
 $ACPX kiro prompt -s my-tg "$1" 2>/dev/null | grep -v '^\[' | grep -v '^$' | head -50
 ```
+
+> **重要**：`cd $HOME` 確保 `sessions ensure` 的 cwd 與 session 建立時一致。若 relay agent 的 workspace 目錄與 session cwd 不符，acpx 會回傳 `RUNTIME: Internal error`，導致 relay 損壞。
 
 ```bash
 chmod +x ~/.openclaw/workspace-my-relay/relay.sh


### PR DESCRIPTION
Fix `RUNTIME: Internal error` caused by cwd mismatch in `sessions ensure`.

## Root Cause

`acpx sessions ensure` matches sessions by **current working directory**. If the relay agent's workspace differs from the cwd used when the session was created, acpx cannot load the session and returns `RUNTIME: Internal error`.

When relay.sh produces no output, the relay LLM fills in a JSON response itself. OpenClaw then executes that JSON as a shell command, causing:

```
/bin/bash: line 1: json: command not found
/bin/bash: line 3: timestamp:: command not found
```

## Fix

Add `cd $HOME` before `sessions ensure` in all three relay scripts:

```bash
cd $HOME && $ACPX kiro sessions ensure --name my-tg 2>/dev/null
```

## Files Changed

- `docs/acp_kiro.md` — also added explanation note
- `docs/acp_codex.md`
- `docs/acp_gemini.md`
