### PR TITLE
ci: fix check-commit-author trigger to unblock auto-merge

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -3,8 +3,7 @@ name: Check Commit Author
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   check-author:


### PR DESCRIPTION
## Problem

`check-commit-author` workflow never triggers on `pull_request` events, causing auto-merge to stall waiting for the `check-author` required check.

**Root cause**: The workflow had both `pull_request` and `push: branches: [main]` triggers. GitHub evaluates workflow triggers using the **base branch (main) version** of the workflow file. The `push` trigger caused GitHub to associate runs with `push` events (with empty jobs, since the branch doesn't match `main`), and the `pull_request` trigger was never fired.

## Fix

- Remove `push` trigger entirely
- Add explicit `types: [opened, reopened, synchronize, labeled]` to `pull_request`
  - `labeled` enables re-triggering via `exempt-author-check` label for trusted PRs

## Effect

After this merges to main, all subsequent PRs will correctly trigger `check-author` as a PR check, allowing auto-merge to work end-to-end without manual intervention.
