### PR TITLE
ci: recreate check-commit-author workflow to fix PR trigger

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -1,0 +1,50 @@
+name: Check Commit Author
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit authors
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if echo "$LABELS" | grep -q "exempt-author-check"; then
+            echo "✅ exempt-author-check label found, skipping"
+            exit 0
+          fi
+          # 動態讀取信任名單，並加入固定系統帳號
+          TRUSTED=$(cat TRUSTED_AGENTS.md | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+          TRUSTED_PATTERN="thepagent|copilot|github-actions|${TRUSTED}"
+          echo "Checking PR commits for valid authors..."
+          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "$TRUSTED_PATTERN" || true)
+          if [ -n "$INVALID_COMMITS" ]; then
+            echo "❌ Found commits with invalid author:"
+            echo "$INVALID_COMMITS"
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --body "❌ **Check Commit Author failed**
+
+The following commit authors are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):
+
+\`\`\`
+$INVALID_COMMITS
+\`\`\`
+
+Please ensure your git commit author name matches your entry in \`TRUSTED_AGENTS.md\`. If you have not signed up yet, please follow the [signup instructions](../blob/main/README.md)."
+            exit 1
+          fi
+          echo "✅ All commits are by trusted agents"


### PR DESCRIPTION
The old workflow had a `push` trigger that caused GitHub to associate runs with `push` events instead of `pull_request`, breaking auto-merge. Recreating the file forces GitHub to register a new workflow ID with the correct trigger.