### PR TITLE
ci: inline author check into auto-merge (no external check run dependency)

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -114,15 +114,27 @@ jobs:
               return;
             }
 
-            // Author check: must have author-verified label (set by check-commit-author workflow)
-            // invalid-author label blocks merge regardless of approval
-            if (labels.includes('invalid-author')) {
-              core.info(`PR #${prNumber} has invalid-author label; skip.`);
-              return;
-            }
-            if (!labels.includes('author-verified')) {
-              core.info(`PR #${prNumber} missing author-verified label; skip.`);
-              return;
+            // Author check: verify all PR commits are from trusted authors
+            // exempt-author-check label bypasses this check
+            if (!labels.includes('exempt-author-check')) {
+              const { data: repoContent } = await github.rest.repos.getContent({
+                owner, repo, path: 'TRUSTED_AGENTS.md', ref: 'main',
+              });
+              const trusted = Buffer.from(repoContent.content, 'base64').toString()
+                .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+              const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
+
+              const { data: commits } = await github.rest.pulls.listCommits({
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              const invalidAuthors = [...new Set(
+                commits.map(c => c.commit.author?.name).filter(n => n && !trustedSet.has(n))
+              )];
+              if (invalidAuthors.length) {
+                core.info(`PR #${prNumber} has untrusted commit authors: ${invalidAuthors.join(', ')}; skip.`);
+                await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['invalid-author'] });
+                return;
+              }
             }
 
             const requiredChecks = [


### PR DESCRIPTION
Moves author verification directly into auto-merge workflow. Reads TRUSTED_AGENTS.md and checks PR commit authors via API — no separate workflow or check run needed. Adds `invalid-author` label if untrusted authors found. `exempt-author-check` label still bypasses the check.