### PR TITLE
docs: release notes for OpenClaw v2026.3.2

### DIFF
--- a/release-notes/2026-03-03.md
+++ b/release-notes/2026-03-03.md
@@ -1,0 +1,470 @@
+# OpenClaw v2026.3.2 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.2)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Secrets/SecretRef 全面覆蓋**：擴展 SecretRef 支援至 64 個目標，未解析的 ref 在活躍介面快速失敗 ([#29580](https://github.com/openclaw/openclaw/pull/29580))
+- ⭐⭐⭐ **PDF 工具**：新增原生 `pdf` 工具，支援 Anthropic/Google PDF provider，含 fallback 萃取 ([#31319](https://github.com/openclaw/openclaw/pull/31319))
+- ⭐⭐⭐ **Sessions/Attachments**：`sessions_spawn` 支援 inline 檔案附件（base64/utf8），含生命週期清理 ([#16761](https://github.com/openclaw/openclaw/pull/16761))
+- ⭐⭐ **MiniMax-M2.5-highspeed**：新增 MiniMax-M2.5-highspeed 支援，保留舊版 Lightning 相容性
+- ⭐⭐ **Telegram Streaming 預設**：`channels.telegram.streaming` 預設改為 `partial`，新設定即享串流預覽
+- ⭐⭐ **Memory/Ollama embeddings**：新增 `memorySearch.provider = "ollama"` 支援 ([#26349](https://github.com/openclaw/openclaw/pull/26349))
+- ⭐⭐ **Outbound adapters/plugins**：跨 Discord/Slack/WhatsApp/Zalo 新增 `sendPayload` 支援 ([#30144](https://github.com/openclaw/openclaw/pull/30144))
+- ⭐ **CLI/Config validation**：新增 `openclaw config validate` 指令，含 `--json` 輸出 ([#31220](https://github.com/openclaw/openclaw/pull/31220))
+- ⭐ **Tools/Diffs PDF 輸出**：diff 工具支援 PDF 輸出及品質控制參數 ([#31342](https://github.com/openclaw/openclaw/pull/31342))
+- ⭐ **Plugin SDK/channel extensibility**：暴露 `channelRuntime` 供外部 channel plugin 使用 ([#25462](https://github.com/openclaw/openclaw/pull/25462))
+- ⭐ **Plugin runtime/STT**：新增 `api.runtime.stt.transcribeAudioFile(...)` ([#22402](https://github.com/openclaw/openclaw/pull/22402))
+- ⭐ **Media/audio echo**：新增 `tools.media.audio.echoTranscript` 轉錄確認訊息 ([#32150](https://github.com/openclaw/openclaw/pull/32150))
+- ⭐ **CLI/Banner taglines**：新增 `cli.banner.taglineMode` 控制啟動標語行為
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Gateway/Security hardening**：綁定 loopback-origin 至實際本地 socket，強化 safe-regex 偵測，限制大型 regex 輸入
+- ⭐⭐⭐ **Security/ACP sandbox inheritance**：`sessions_spawn` 拒絕沙箱 session 發起 ACP spawn，防止沙箱邊界繞過 ([#32254](https://github.com/openclaw/openclaw/pull/32254))
+- ⭐⭐⭐ **Security/Web tools SSRF guard**：設定 proxy 時保持 DNS pinning，防止 proxy 繞過 pinned dispatch
+- ⭐⭐⭐ **Security/Prompt spoofing hardening**：停止將 runtime events 注入 user-role，中和 `[System Message]` 等偽造標記 ([#30448](https://github.com/openclaw/openclaw/pull/30448))
+- ⭐⭐ **Gateway/Plugin HTTP hardening**：plugin route 需明確 `auth`，集中 path matching/auth 邏輯
+- ⭐⭐ **Security/Webhook request hardening**：BlueBubbles/Google Chat 強制 auth-before-body，防止 slow-body DoS
+- ⭐⭐ **Gateway/WS security**：`ws://` 預設僅限 loopback，需明確 opt-in 才可開放私有網路 ([#28670](https://github.com/openclaw/openclaw/pull/28670))
+- ⭐⭐ **Config/backups hardening**：備份檔強制 `0600` 權限，清理過期 `.bak.*` 檔案 ([#31718](https://github.com/openclaw/openclaw/pull/31718))
+- ⭐⭐ **Security/Node exec approvals**：執行前重新驗證 `cwd` 身份，防止 cwd 漂移
+- ⭐⭐ **Security/Skills archive extraction**：統一 tar.gz/tar.bz2 安全檢查，強制壓縮大小限制
+- ⭐ **Security/fs-safe write hardening**：使用同目錄 temp write + atomic rename，加入 inode 重新驗證
+- ⭐ **Security audit/skills workspace hardening**：新增 `skills.workspace.symlink_escape` 警告
+- ⭐ **Sandbox/Bootstrap context boundary hardening**：拒絕解析至 workspace 外的 symlink/hardlink seed 檔案
+- ⭐ **Security/Nodes camera URL downloads**：綁定 camera snap/clip 下載至 node host，防止 off-node fetch
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Gateway/Subagent TLS pairing**：允許本地 gateway-client 跳過 device pairing，修復 TLS 環境下 `sessions_spawn` ([#30740](https://github.com/openclaw/openclaw/issues/30740))
+- ⭐⭐⭐ **Sessions/Lock recovery**：偵測 Linux PID 回收，立即回收過期 lock 檔案 ([#26443](https://github.com/openclaw/openclaw/pull/26443))
+- ⭐⭐ **OpenAI Codex OAuth/TLS prerequisites**：新增 OAuth TLS cert-chain preflight，提供可操作的修復指引 ([#32051](https://github.com/openclaw/openclaw/pull/32051))
+- ⭐⭐ **Slack/Bolt startup compatibility**：移除無效 `message.channels`/`message.groups` 事件，修復 Bolt 4.6+ 啟動崩潰 ([#32033](https://github.com/openclaw/openclaw/pull/32033))
+- ⭐⭐ **Voice-call/runtime lifecycle**：防止 `EADDRINUSE` 迴圈，使 webhook `start()` 冪等 ([#32395](https://github.com/openclaw/openclaw/pull/32395))
+- ⭐⭐ **Webchat/silent token leak**：過濾 `NO_REPLY` transcript 條目，防止內部 token 顯示為聊天泡泡 ([#32015](https://github.com/openclaw/openclaw/issues/32015))
+- ⭐⭐ **Feishu/multi-app mention routing**：驗證 mention display name 防止誤觸發 self-mention ([#30315](https://github.com/openclaw/openclaw/pull/30315))
+- ⭐ **Telegram/inbound media filenames**：保留原始 `file_name` metadata ([#31837](https://github.com/openclaw/openclaw/pull/31837))
+- ⭐ **Exec approvals/allowlist matching**：跳脫 regex metacharacters，修復 `/usr/bin/g++` 等路徑匹配 ([#32162](https://github.com/openclaw/openclaw/pull/32162))
+- ⭐ **Models/Codex usage labels**：正確推斷每週次要使用窗口，修復 `models status` 誤標 ([#31938](https://github.com/openclaw/openclaw/pull/31938))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Secrets/SecretRef 全面覆蓋 ([#29580](https://github.com/openclaw/openclaw/pull/29580))
+- **用途**: 將 SecretRef 支援擴展至 64 個使用者憑證目標，涵蓋 runtime collectors、`openclaw secrets` planning/apply/audit 流程及 onboarding SecretInput UX
+- **解決問題**: 未解析的 SecretRef 在活躍介面靜默失敗，難以診斷憑證問題
+- **影響**: 活躍介面的未解析 ref 快速失敗並報錯；非活躍介面回報非阻塞診斷，大幅提升憑證管理可靠性
+
+```text
+┌─────────────────────┐
+│  SecretRef 輸入      │
+└─────────────────────┘
+          │
+          ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│  活躍介面？          │─Yes─►│  解析失敗 → 快速失敗  │
+└─────────────────────┘     └──────────────────────┘
+          │ No
+          ▼
+┌─────────────────────┐
+│  非活躍介面          │
+│  → 非阻塞診斷警告    │
+└─────────────────────┘
+```
+
+### ⭐⭐⭐ PDF 工具 ([#31319](https://github.com/openclaw/openclaw/pull/31319))
+- **用途**: 新增原生 `pdf` 工具，支援 Anthropic 與 Google 的 PDF provider，非原生 model 使用萃取 fallback；可設定 `agents.defaults.pdfModel`、`pdfMaxBytesMb`、`pdfMaxPages`
+- **解決問題**: 過去無法直接在 agent 工具鏈中處理 PDF 文件
+- **影響**: agent 可直接分析 PDF，自動路由至最適合的 provider，非支援 model 亦可透過萃取 fallback 使用
+
+```text
+┌──────────────┐
+│  PDF 輸入    │
+└──────────────┘
+       │
+       ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  原生 provider？      │─Yes─►│  Anthropic/Google    │
+│  (Anthropic/Google)  │     │  原生 PDF 處理        │
+└──────────────────────┘     └──────────────────────┘
+       │ No
+       ▼
+┌──────────────────────┐
+│  萃取 fallback        │
+│  (文字擷取後送 LLM)   │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Sessions/Attachments for sessions_spawn ([#16761](https://github.com/openclaw/openclaw/pull/16761))
+- **用途**: `sessions_spawn`（subagent runtime）支援 inline 檔案附件，base64/utf8 編碼，含 transcript 內容遮蔽、生命週期清理及可設定限制 `tools.sessions_spawn.attachments`
+- **解決問題**: subagent 無法接收檔案附件，限制了多 agent 協作場景
+- **影響**: subagent 可接收並處理檔案，敏感內容自動遮蔽於 transcript，session 結束後自動清理
+
+```text
+┌──────────────────┐
+│  Parent Agent    │
+│  sessions_spawn  │
+│  + attachments   │
+└──────────────────┘
+         │ base64/utf8
+         ▼
+┌──────────────────┐     ┌──────────────────┐
+│  Subagent        │────►│  Transcript      │
+│  (ACP runtime)   │     │  (內容遮蔽)       │
+└──────────────────┘     └──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Session 結束    │
+│  → 自動清理附件  │
+└──────────────────┘
+```
+
+### ⭐⭐ MiniMax-M2.5-highspeed 支援
+- **用途**: 新增 `MiniMax-M2.5-highspeed` 至內建 provider catalog、onboarding 流程及 MiniMax OAuth plugin 預設
+- **解決問題**: 無法使用 MiniMax 最新高速模型
+- **影響**: 可直接在 config 選用高速版本，舊版 `MiniMax-M2.5-Lightning` 設定仍相容
+
+### ⭐⭐ Telegram Streaming 預設改為 partial
+- **用途**: `channels.telegram.streaming` 預設值從 `off` 改為 `partial`，新 Telegram 設定即享串流預覽；不支援 native drafts 時自動 fallback 至 message-edit preview
+- **解決問題**: 新設定需手動啟用串流，體驗不佳
+- **影響**: 所有新 Telegram bot 設定自動獲得串流預覽，無需額外配置
+
+### ⭐⭐ Memory/Ollama embeddings ([#26349](https://github.com/openclaw/openclaw/pull/26349))
+- **用途**: 新增 `memorySearch.provider = "ollama"` 及 `fallback = "ollama"`，使用 `models.providers.ollama` 設定進行 memory embedding
+- **解決問題**: 無法使用本地 Ollama 模型進行 memory embedding，必須依賴雲端 provider
+- **影響**: 可完全離線運行 memory 功能，降低雲端 API 成本
+
+### ⭐⭐ Outbound adapters/plugins sendPayload ([#30144](https://github.com/openclaw/openclaw/pull/30144))
+- **用途**: 跨 direct-text-media、Discord、Slack、WhatsApp、Zalo、Zalouser 新增共享 `sendPayload` 支援，含 multi-media iteration 及 chunk-aware text fallback
+- **解決問題**: 各 channel 的 outbound adapter 缺乏統一的 payload 發送介面
+- **影響**: plugin 開發者可使用統一 API 跨 channel 發送媒體，減少重複實作
+
+### ⭐ CLI/Config validation ([#31220](https://github.com/openclaw/openclaw/pull/31220))
+- **用途**: 新增 `openclaw config validate`（含 `--json`）在 gateway 啟動前驗證設定檔，啟動時的無效設定錯誤包含詳細的無效 key 路徑
+- **解決問題**: 設定錯誤只在 gateway 啟動後才被發現，難以快速定位問題
+- **影響**: 可在部署前預先驗證設定，加速問題排查
+
+### ⭐ Tools/Diffs PDF 輸出 ([#31342](https://github.com/openclaw/openclaw/pull/31342))
+- **用途**: diff 工具新增 PDF 檔案輸出及渲染品質控制（`fileQuality`、`fileScale`、`fileMaxWidth`）
+- **解決問題**: messaging channel 壓縮圖片導致 diff 難以閱讀
+- **影響**: 可輸出高品質 PDF diff，避免圖片壓縮問題
+
+### ⭐ Plugin SDK/channel extensibility ([#25462](https://github.com/openclaw/openclaw/pull/25462))
+- **用途**: 在 `ChannelGatewayContext` 上暴露 `channelRuntime`，讓外部 channel plugin 存取共享 runtime helpers
+- **解決問題**: 外部 plugin 需要 internal imports 才能使用 runtime helpers
+- **影響**: plugin 開發更簡潔，無需依賴內部模組
+
+### ⭐ Plugin runtime/STT ([#22402](https://github.com/openclaw/openclaw/pull/22402))
+- **用途**: 新增 `api.runtime.stt.transcribeAudioFile(...)` 讓 extension 可透過 OpenClaw 設定的 audio provider 轉錄本地音訊
+- **解決問題**: plugin 無法直接使用 OpenClaw 的 STT 功能
+- **影響**: plugin 可整合語音轉錄，無需自行管理 provider 設定
+
+### ⭐ Media/audio echo transcript ([#32150](https://github.com/openclaw/openclaw/pull/32150))
+- **用途**: 新增 `tools.media.audio.echoTranscript` + `echoFormat`，在 agent 處理前發送轉錄確認訊息至原始聊天，預設關閉
+- **解決問題**: 使用者無法確認語音訊息是否被正確轉錄
+- **影響**: 可選擇性地讓使用者看到轉錄結果，提升透明度
+
+### ⭐ CLI/Banner taglines
+- **用途**: 新增 `cli.banner.taglineMode`（`random` | `default` | `off`）控制啟動輸出中的趣味標語行為
+- **解決問題**: 無法關閉或自訂啟動標語
+- **影響**: 可依偏好調整啟動輸出，`off` 適合自動化腳本環境
+
+---
+
+## 重大變更 (Breaking Changes)
+
+### ⭐⭐⭐ Onboarding 預設 tools.profile 改為 messaging
+- **用途**: 新本地安裝（互動式與非互動式）預設 `tools.profile = "messaging"`
+- **解決問題**: 新安裝預設開放過多 coding/system 工具，不符合一般使用情境
+- **影響**: **新安裝不再預設包含 coding/system 工具**，需明確設定才能啟用
+
+### ⭐⭐⭐ ACP dispatch 預設啟用
+- **用途**: ACP dispatch 預設啟用，需明確設定 `acp.dispatch.enabled=false` 才能停用
+- **解決問題**: 過去需手動啟用 ACP dispatch
+- **影響**: **現有設定若需暫停 ACP turn routing，需明確設定 `acp.dispatch.enabled=false`**；文件：https://docs.openclaw.ai/tools/acp-agents
+
+### ⭐⭐ Plugin SDK 移除 api.registerHttpHandler
+- **用途**: Plugin 必須改用 `api.registerHttpRoute({ path, auth, match, handler })`
+- **解決問題**: 舊 API 缺乏明確的 auth 設定
+- **影響**: **使用 `api.registerHttpHandler(...)` 的 plugin 需更新**
+
+### ⭐⭐ Zalo Personal plugin 移除外部 CLI 依賴
+- **用途**: `@openclaw/zalouser` 改用原生 `zca-js` in-process 整合
+- **解決問題**: 依賴外部 `openzca`/`zca-cli` binary 造成部署複雜度
+- **影響**: **升級後需執行 `openclaw channels login --channel zalouser` 重新登入**
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Gateway/Security hardening
+- **用途**: 將 loopback-origin dev allowance 綁定至實際本地 socket（非 Host header），強化 safe-regex 偵測（量化模糊交替模式），限制 session-filter 及 log-redaction 的大型 regex 輸入
+- **解決問題**: Host header 偽造可能繞過 loopback 限制；惡意 regex 可能造成 ReDoS
+- **影響**: 防止 Host header 偽造攻擊，降低 ReDoS 風險
+
+```text
+┌──────────────────────┐
+│  WebSocket 連線請求   │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  實際 socket 是       │─Yes─►│  允許 dev allowance  │
+│  本地 loopback？      │     └──────────────────────┘
+└──────────────────────┘
+          │ No
+          ▼
+┌──────────────────────┐
+│  拒絕 / 警告          │
+│  (記錄 metrics)       │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Security/ACP sandbox inheritance ([#32254](https://github.com/openclaw/openclaw/pull/32254))
+- **用途**: `sessions_spawn` 拒絕來自沙箱 session 的 ACP spawn 請求，並拒絕 ACP runtime 的 `sandbox="require"`
+- **解決問題**: 沙箱內的 agent 可透過 ACP 初始化繞過沙箱邊界，在 host 端執行任意操作
+- **影響**: 防止沙箱逃逸攻擊，確保沙箱隔離的完整性
+
+```text
+┌──────────────────────┐
+│  Sandboxed Session   │
+│  sessions_spawn ACP  │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  requester 是沙箱？   │─Yes─►│  拒絕（fail-closed） │
+└──────────────────────┘     └──────────────────────┘
+          │ No
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  sandbox="require"？  │─Yes─►│  拒絕（fail-closed） │
+└──────────────────────┘     └──────────────────────┘
+          │ No
+          ▼
+┌──────────────────────┐
+│  允許 ACP spawn       │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Security/Web tools SSRF guard
+- **用途**: 設定 proxy env vars 時，`web_fetch` 及 citation-redirect URL 檢查仍保持 DNS pinning；需明確 dangerous opt-in 才能讓 env-proxy 繞過 pinned dispatch
+- **解決問題**: proxy 設定可能被利用繞過 SSRF 防護，存取內部服務
+- **影響**: 防止透過 proxy 設定進行 SSRF 攻擊
+
+### ⭐⭐⭐ Security/Prompt spoofing hardening ([#30448](https://github.com/openclaw/openclaw/pull/30448))
+- **用途**: 停止將 queued runtime events 注入 user-role prompt，改透過受信任的 system-prompt context 路由；中和入站訊息中的 `[System Message]`、行首 `System:` 等偽造標記
+- **解決問題**: 惡意使用者可透過偽造 system message 標記操控 agent 行為
+- **影響**: 防止 prompt injection 攻擊，確保 system prompt 的可信度
+
+```text
+┌──────────────────────┐
+│  入站使用者訊息       │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  含 [System Message] │─Yes─►│  中和偽造標記         │
+│  或 "System:" 前綴？  │     │  → 視為普通文字       │
+└──────────────────────┘     └──────────────────────┘
+          │ No
+          ▼
+┌──────────────────────┐
+│  Runtime events      │
+│  → system-prompt     │
+│    context（受信任）  │
+└──────────────────────┘
+```
+
+### ⭐⭐ Gateway/Plugin HTTP hardening
+- **用途**: plugin route 需明確設定 `auth`，新增 route ownership guards，集中 plugin path matching/auth 邏輯
+- **解決問題**: plugin 可能在未授權情況下註冊 HTTP route
+- **影響**: 強化 plugin HTTP 端點的存取控制
+
+### ⭐⭐ Security/Webhook request hardening
+- **用途**: BlueBubbles 及 Google Chat webhook handler 強制 auth-before-body parsing，LINE signature verification 加入嚴格的 pre-auth body/time budget
+- **解決問題**: 未驗證的 slow-body 請求可能造成 DoS
+- **影響**: 防止未驗證的 slow-body DoS 攻擊
+
+### ⭐⭐ Gateway/WS security ([#28670](https://github.com/openclaw/openclaw/pull/28670))
+- **用途**: `ws://` 預設僅限 loopback，需設定 `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` 才可開放私有網路
+- **解決問題**: 明文 WebSocket 可能在私有網路中被攔截
+- **影響**: 預設更安全，需明確 opt-in 才能開放私有網路明文 WS
+
+### ⭐⭐ Config/backups hardening ([#31718](https://github.com/openclaw/openclaw/pull/31718))
+- **用途**: 備份檔強制 `0600` 權限，清理 managed backup ring 外的孤立 `.bak.*` 檔案
+- **解決問題**: 備份檔可能因權限過寬或孤立檔案造成憑證洩漏
+- **影響**: 降低備份檔憑證洩漏風險
+
+### ⭐⭐ Security/Node exec approvals
+- **用途**: 執行/轉發前立即重新驗證 approval-bound `cwd` 身份，`cwd` 漂移時 fail-closed
+- **解決問題**: approval 後 `cwd` 可能被替換，導致執行非預期路徑
+- **影響**: 防止 approval 後的 cwd 替換攻擊
+
+### ⭐⭐ Security/Skills archive extraction
+- **用途**: 統一 tar.gz/tar.bz2 安全檢查，強制壓縮大小限制，tar.bz2 在 preflight 與 extraction 間變更時 fail-closed
+- **解決問題**: 惡意 archive 可能繞過 entry-type/size 防護
+- **影響**: 防止惡意 skill archive 的路徑穿越及大小繞過攻擊
+
+### ⭐ Security/fs-safe write hardening
+- **用途**: `writeFileWithinRoot` 使用同目錄 temp write + atomic rename，加入 post-write inode/hardlink 重新驗證，rename 失敗時不截斷現有目標
+- **解決問題**: 寫入過程中的 symlink rebind race 可能導致寫入邊界外的檔案
+- **影響**: 防止 TOCTOU 攻擊，確保寫入操作的原子性
+
+### ⭐ Security audit/skills workspace hardening
+- **用途**: `openclaw security audit` 新增 `skills.workspace.symlink_escape` 警告，偵測 workspace skills 解析至 workspace root 外的情況
+- **解決問題**: symlink chain drift 可能讓 skill 存取 workspace 外的檔案
+- **影響**: 提早發現 workspace skill symlink 逃逸問題
+
+### ⭐ Sandbox/Bootstrap context boundary hardening
+- **用途**: 拒絕解析至 source workspace 外的 symlink/hardlink alias bootstrap seed 檔案，post-compaction `AGENTS.md` 改用 boundary-verified file open
+- **解決問題**: workspace aliasing 可能注入 host 檔案內容至 agent context
+- **影響**: 防止透過 workspace aliasing 的 context injection 攻擊
+
+### ⭐ Security/Nodes camera URL downloads
+- **用途**: 綁定 `camera.snap`/`camera.clip` URL payload 下載至 resolved node host，`remoteIp` 不可用時 fail-closed，使用 SSRF-guarded fetch 含 redirect host/protocol 檢查
+- **解決問題**: camera 工具可能被利用進行 off-node fetch pivot
+- **影響**: 防止透過 camera 工具的 SSRF 攻擊
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Gateway/Subagent TLS pairing (Fixes [#30740](https://github.com/openclaw/openclaw/issues/30740))
+- **用途**: 允許已驗證的本地 `gateway-client` backend self-connection 跳過 device pairing，非本地/direct-host 路徑仍需 pairing
+- **解決問題**: `gateway.tls.enabled=true` 的 Docker/LAN 環境中 `sessions_spawn` 無法運作
+- **影響**: 修復 TLS 環境下的 subagent spawn，Docker 部署可正常使用
+
+```text
+┌──────────────────────┐
+│  gateway-client      │
+│  self-connection     │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  已驗證且為本地？     │─Yes─►│  跳過 device pairing │
+└──────────────────────┘     └──────────────────────┘
+          │ No
+          ▼
+┌──────────────────────┐
+│  需要 device pairing  │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Sessions/Lock recovery ([#26443](https://github.com/openclaw/openclaw/pull/26443), Fixes [#27252](https://github.com/openclaw/openclaw/issues/27252))
+- **用途**: 比對 lock 檔案 `starttime` 與 `/proc/<pid>/stat` starttime 偵測 Linux PID 回收，立即回收容器化 PID 重用場景的過期 lock 檔案
+- **解決問題**: 容器重啟後 PID 被回收，舊 lock 檔案阻塞新 session 建立
+- **影響**: 容器環境下 session lock 可靠性大幅提升，不再因 PID 重用卡死
+
+```text
+┌──────────────────────┐
+│  發現 .jsonl.lock    │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  PID 仍存在？         │─No──►│  立即回收 lock        │
+└──────────────────────┘     └──────────────────────┘
+          │ Yes
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  starttime 相符？     │─No──►│  PID 已回收，回收 lock│
+└──────────────────────┘     └──────────────────────┘
+          │ Yes
+          ▼
+┌──────────────────────┐
+│  Lock 有效，等待      │
+└──────────────────────┘
+```
+
+### ⭐⭐ OpenAI Codex OAuth/TLS prerequisites ([#32051](https://github.com/openclaw/openclaw/pull/32051))
+- **用途**: 新增 OAuth TLS cert-chain preflight，提供可操作的 cert trust 失敗修復指引；僅對 OpenAI Codex OAuth 設定或明確 `doctor --deep` 執行 TLS prerequisite probe
+- **解決問題**: cert trust 失敗時缺乏明確的錯誤訊息和修復指引；無條件 probe 增加啟動延遲
+- **影響**: Codex OAuth 設定問題更易診斷，非 Codex 設定不受額外 probe 延遲影響
+
+### ⭐⭐ Slack/Bolt startup compatibility ([#32033](https://github.com/openclaw/openclaw/pull/32033))
+- **用途**: 移除無效的 `message.channels` 和 `message.groups` 事件註冊，channel/group 流量改由統一 `message` handler 處理
+- **解決問題**: Bolt 4.6+ 啟動時因無效事件註冊崩潰
+- **影響**: 修復 Slack provider 在 Bolt 4.6+ 的啟動問題
+
+### ⭐⭐ Voice-call/runtime lifecycle ([#32395](https://github.com/openclaw/openclaw/pull/32395))
+- **用途**: 重置失敗的 runtime promise 防止 `EADDRINUSE` 迴圈，使 webhook `start()` 冪等，啟動失敗後完整清理 webhook/tunnel/tailscale 資源
+- **解決問題**: 語音通話啟動失敗後 port 被佔用，導致後續啟動也失敗
+- **影響**: 語音通話啟動更可靠，失敗後可正常重試
+
+### ⭐⭐ Webchat/silent token leak ([#32015](https://github.com/openclaw/openclaw/issues/32015))
+- **用途**: 過濾 `chat.history` 回應中的 `NO_REPLY`-only transcript 條目，client 端加入防禦性 guard
+- **解決問題**: 內部 `NO_REPLY` silent token 顯示為使用者可見的聊天泡泡
+- **影響**: 使用者不再看到內部 token 洩漏，聊天介面更乾淨
+
+### ⭐⭐ Feishu/multi-app mention routing ([#30315](https://github.com/openclaw/openclaw/pull/30315))
+- **用途**: 在多 bot 群組中驗證 mention display name 及 bot `open_id`，防止 Feishu WebSocket remapping 造成的誤觸發 self-mention
+- **解決問題**: `requireMention` 下非被 mention 的 bot 也會回應
+- **影響**: 多 bot 群組中只有被 mention 的 bot 才會回應
+
+### ⭐⭐ Feishu/group broadcast dispatch ([#29575](https://github.com/openclaw/openclaw/pull/29575))
+- **用途**: 新增可設定的多 agent 群組 broadcast dispatch，含 observer-session 隔離、跨帳號 dedupe 防護及非 mention 歷史緩衝規則
+- **解決問題**: broadcast/topic 工作流程中出現重複回放
+- **影響**: 多 agent 群組廣播更可靠，無重複訊息
+
+### ⭐ Telegram/inbound media filenames ([#31837](https://github.com/openclaw/openclaw/pull/31837))
+- **用途**: 保留 document/audio/video/animation 下載的原始 `file_name` metadata
+- **解決問題**: 儲存的入站附件使用不透明的 Telegram 檔案路徑而非原始檔名
+- **影響**: 下載的附件保留發送者提供的原始檔名
+
+### ⭐ Exec approvals/allowlist matching ([#32162](https://github.com/openclaw/openclaw/pull/32162))
+- **用途**: 跳脫 path-pattern literals 中的 regex metacharacters（保留 glob wildcards），修復 `/usr/bin/g++` 等含特殊字元路徑的匹配
+- **解決問題**: allowlist 中含 `+`、`.` 等 regex 特殊字元的路徑無法正確匹配或造成崩潰
+- **影響**: exec allowlist 對特殊字元路徑的匹配更可靠
+
+### ⭐ Models/Codex usage labels ([#31938](https://github.com/openclaw/openclaw/pull/31938))
+- **用途**: 當 API window seconds 模糊回報為 24h 時，從 reset cadence 推斷每週次要使用窗口
+- **解決問題**: `openclaw models status` 將每週限制誤標為每日限制
+- **影響**: Codex 使用量顯示更準確
+
+### ⭐ Plugin command/runtime hardening ([#31997](https://github.com/openclaw/openclaw/pull/31997))
+- **用途**: 在 registration 邊界驗證並正規化 plugin command name/description，防止 Telegram native menu normalization 路徑因格式錯誤的 plugin command spec 崩潰
+- **解決問題**: 格式錯誤的 plugin command 造成 gateway 啟動崩潰
+- **影響**: gateway 啟動更穩健，不受格式錯誤的 plugin command 影響
+
+### ⭐ Telegram/duplicate-token guard ([#31973](https://github.com/openclaw/openclaw/pull/31973))
+- **用途**: 防護 duplicate-token 檢查及 gateway 啟動 token normalization，避免 account token 缺失時 `token.trim()` 崩潰
+- **解決問題**: 缺少 bot token 的帳號設定造成 gateway 啟動崩潰
+- **影響**: 不完整的 Telegram 帳號設定不再造成 gateway 崩潰
+
+### ⭐ Browser/CDP startup diagnostics ([#29312](https://github.com/openclaw/openclaw/pull/29312))
+- **用途**: 啟動逾時錯誤中包含 Chrome stderr 輸出及 Linux no-sandbox 提示
+- **解決問題**: Chrome 啟動失敗時缺乏診斷資訊
+- **影響**: 更容易診斷 Chrome 啟動失敗原因
+
+### ⭐ Feishu/session-memory hook parity ([#31437](https://github.com/openclaw/openclaw/pull/31437))
+- **用途**: Feishu `/new` 和 `/reset` 指令執行時觸發共享 `before_reset` session-memory hook
+- **解決問題**: Feishu reset 流程不觸發 memory hook，行為與其他 channel 不一致
+- **影響**: Feishu reset 行為與其他 channel 一致
+
+### ⭐ Gateway/Heartbeat model reload ([#32046](https://github.com/openclaw/openclaw/pull/32046))
+- **用途**: 將 `models.*` 和 `agents.defaults.model` config 更新視為 heartbeat hot-reload 觸發條件
+- **解決問題**: 更新 model 設定後需完整重啟 gateway 才能生效
+- **影響**: model 設定變更可透過 heartbeat 熱重載，無需重啟 gateway
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 4 | 6 | 13 項 |
+| 重大變更 | 2 | 2 | 0 | 4 項 |
+| 安全性提升 | 4 | 6 | 4 | 14 項 |
+| 錯誤修復 | 2 | 5 | 8 | 15 項 |
+| **總計** | **11** | **17** | **18** | **46 項** |
+
+> 本版本包含大量安全性強化，建議所有使用者盡快升級。重大變更請參閱上方說明，特別注意 onboarding 預設 tools.profile 及 ACP dispatch 預設啟用的變更。
+
+**發佈日期**: 2026-03-03  
+**版本**: 2026.3.2  
+**狀態**: Production Ready  
+**GitHub Release**: [v2026.3.2](https://github.com/openclaw/openclaw/releases/tag/v2026.3.2)


### PR DESCRIPTION
Closes #209

## 變更內容

新增 OpenClaw v2026.3.2 版本發佈說明（zh-TW）。

## 涵蓋項目

- **功能更新** 13 項（⭐⭐⭐×3, ⭐⭐×4, ⭐×6）
- **重大變更** 4 項
- **安全性提升** 14 項（⭐⭐⭐×4, ⭐⭐×6, ⭐×4）
- **錯誤修復** 15 項（⭐⭐⭐×2, ⭐⭐×5, ⭐×8）

## Checklist

- [x] GitHub release page reviewed
- [x] 所有項目含星級評分
- [x] 依星級降序排列
- [x] 所有項目含 PR/Issue 連結（無編號者連至 release tag）
- [x] 所有項目含用途、解決問題、影響
- [x] 所有 ⭐⭐⭐ 項目含 ASCII flowchart
- [x] 概述項目與詳細章節同步
- [x] 總結表格完整
- [x] GitHub release 連結已包含
