### PR TITLE
docs: remove date from release notes title (timezone confusion)

### DIFF
--- a/release-notes/2026-02-17.md
+++ b/release-notes/2026-02-17.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.17 版本發佈說明 (2026-02-17)
+# OpenClaw v2026.2.17 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.17)
 

--- a/release-notes/2026-02-19.md
+++ b/release-notes/2026-02-19.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.19 版本發佈說明（2026-02-19）
+# OpenClaw v2026.2.19 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.19)
 

--- a/release-notes/2026-02-21.md
+++ b/release-notes/2026-02-21.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.21 Release Notes (2026-02-21)
+# OpenClaw v2026.2.21 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.21)
 

--- a/release-notes/2026-02-22.md
+++ b/release-notes/2026-02-22.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.22 Release Notes (2026-02-22)
+# OpenClaw v2026.2.22 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)
 

--- a/release-notes/GUIDELINES.md
+++ b/release-notes/GUIDELINES.md
@@ -6,14 +6,14 @@ This document defines the guidelines for generating release notes for each OpenC
 
 - **Filename**: `release-notes/YYYY-MM-DD.md`
 - **Date**: Use the release date (e.g., `2026-02-15.md`)
-- **Header**: Include the release date in the title (e.g., `# OpenClaw v2026.02.15 Release Notes (2026-02-15)`)
+- **Header**: Use version only in the title (e.g., `# OpenClaw v2026.02.15 版本發佈說明`). Do not include the date in the title to avoid timezone confusion.
 
 ## Document Structure
 
 ### 1. Header
 
 Include:
-- Release title with version and date
+- Release title with version (no date in title)
 - GitHub Release link (e.g., `[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.15)`)
 
 ### 2. Overview


### PR DESCRIPTION
Title 中的日期（如 `(2026-02-15)`）因時區不同可能造成混淆，改為僅保留版本號。

更新 GUIDELINES.md：
- Header 格式：`# OpenClaw v2026.02.15 版本發佈說明`（移除日期）
- 說明不在 title 中放日期，避免時區混淆