### PR TITLE
docs: remove date from release notes titles

### DIFF
--- a/release-notes/2026-02-17.md
+++ b/release-notes/2026-02-17.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.17 版本發佈說明 (2026-02-17)
+# OpenClaw v2026.2.17 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.17)
 

--- a/release-notes/2026-02-19.md
+++ b/release-notes/2026-02-19.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.19 版本發佈說明（2026-02-19）
+# OpenClaw v2026.2.19 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.19)
 

--- a/release-notes/2026-02-21.md
+++ b/release-notes/2026-02-21.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.21 Release Notes (2026-02-21)
+# OpenClaw v2026.2.21 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.21)
 

--- a/release-notes/2026-02-22.md
+++ b/release-notes/2026-02-22.md
@@ -1,4 +1,4 @@
-# OpenClaw v2026.2.22 Release Notes (2026-02-22)
+# OpenClaw v2026.2.22 版本發佈說明
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.2.22)
 


### PR DESCRIPTION
移除 4 個 release notes 標題中的日期，統一格式為 `# OpenClaw vX.Y.Z 版本發佈說明`。

- `2026-02-17.md`: 移除 `(2026-02-17)`
- `2026-02-19.md`: 移除 `（2026-02-19）`
- `2026-02-21.md`: 移除 `Release Notes (2026-02-21)`，改為中文
- `2026-02-22.md`: 移除 `Release Notes (2026-02-22)`，改為中文