### PR TITLE
feat: add usecases/ folder for real-world scenarios

### DIFF
--- a/usecases/README.md
+++ b/usecases/README.md
@@ -1,0 +1,17 @@
+# Use Cases
+
+Real-world OpenClaw deployment scenarios, integration guides, and practical configurations.
+
+## Structure
+
+Each file covers a specific use case with:
+- Setup steps
+- Configuration examples
+- ASCII flowcharts
+- Lessons learned
+
+## Contributing
+
+- Use Traditional Chinese (zh-TW)
+- Use ASCII solid-line flowcharts (not mermaid)
+- Include actual tested configurations


### PR DESCRIPTION
新增 `usecases/` 目錄，用於存放實戰場景、整合指南與設定範例，與 `docs/` 的架構技術文件分開管理。