### PR TITLE
docs: update agent-browser-agentcore for native Rust implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ temp/
 
 # Node modules (optional, uncomment if needed)
 # node_modules/
+.kiro

--- a/.kiro/steering/github.md
+++ b/.kiro/steering/github.md
@@ -1,0 +1,5 @@
+When writing issue or PR for this repo, switch to the "thepagent" GitHub account:
+
+```bash
+gh auth switch -u thepagent
+```

--- a/.kiro/steering/github.md
+++ b/.kiro/steering/github.md
@@ -1,5 +1,0 @@
-When writing issue or PR for this repo, switch to the "thepagent" GitHub account:
-
-```bash
-gh auth switch -u thepagent
-```

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -118,18 +118,14 @@ cd cli
 cargo build --release --features agentcore
 # 直接使用 cli/target/release/agent-browser --native
 
-# 3) 下載 Chromium（AgentCore 可選）
-# 只有在遇到 Playwright/Chromium 相關錯誤時才需要：
-agent-browser install
-
-# 4) 連線 AWS Bedrock AgentCore Browser
+# 3) 連線 AWS Bedrock AgentCore Browser
 # 憑證會自動從環境變數或 AWS CLI 解析（支援 SSO、profiles、IAM roles）
 agent-browser -p agentcore open https://x.com/home
 
 # 使用 browser profile 保持登入狀態：
 AGENTCORE_PROFILE_ID=my-profile agent-browser -p agentcore open https://x.com/home
 
-# 5) 收尾
+# 4) 收尾
 agent-browser close
 ```
 

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -94,7 +94,7 @@ Profile persistence (cookies/localStorage)
 ## TL;DR（最短成功路徑）
 
 ```bash
-# 1) build 這個 PR 的版本（TypeScript daemon + Rust CLI）
+# 1) Build the PR version (TypeScript daemon + Rust CLI with AgentCore)
 git clone https://github.com/vercel-labs/agent-browser.git
 cd agent-browser
 
@@ -103,30 +103,47 @@ git checkout pr-397
 
 # 1a) Build TypeScript daemon
 npm install
-npm run build          # 產出 dist/（Node.js daemon）
+npm run build          # Output: dist/ (Node.js daemon)
 
-# 1b) Build Rust CLI binary
+# 1b) Build Rust CLI binary with AgentCore support
 cd cli
-cargo build --release  # 產出 cli/target/release/agent-browser
+cargo build --release --features agentcore  # Output: cli/target/release/agent-browser
 cd ..
 
-# 1c) 安裝到全域
+# 1c) Install globally
 npm i -g .
-# 用 Rust binary 覆蓋 npm 安裝的 JS wrapper：
+# Replace npm's JS wrapper with Rust binary:
 cp cli/target/release/agent-browser "$(dirname $(which agent-browser))/agent-browser"
 
-# 2) 下載 Chromium（建議，但可選）
-# 若你主要使用 AWS AgentCore Browser（`-p agentcore`），多數情況可先略過。
-# 只有在遇到 Playwright/Chromium 相關錯誤（例如 browser binaries not installed）時，再執行：
+# 2) Download Chromium (optional for AgentCore)
+# Only needed if you see Playwright/Chromium errors:
 agent-browser install
 
-# 3) 連 AWS Bedrock AgentCore Browser（需要 AWS credentials）
-export AGENTCORE_REGION=us-east-1
+# 3) Connect to AWS Bedrock AgentCore Browser
+# Credentials are auto-resolved from env vars or AWS CLI (supports SSO, profiles, IAM roles)
 agent-browser -p agentcore open https://x.com/home
 
-# 4) 收尾
+# With browser profile for persistent login state:
+AGENTCORE_PROFILE_ID=my-profile agent-browser -p agentcore open https://x.com/home
+
+# 4) Cleanup
 agent-browser close
 ```
+
+### Credential Resolution
+
+Credentials are automatically resolved from:
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+2. AWS CLI (`aws configure export-credentials`) - supports SSO, profiles, IAM roles
+
+No need to manually export credentials with `eval $(aws configure export-credentials ...)`.
+
+### Compatibility
+
+| Daemon Mode | Status | Notes |
+|-------------|--------|-------|
+| Node.js (default) | ✅ Full support | Recommended |
+| Native (`--native`) | ⚠️ Experimental | Known issues: creates new session per command, `eval` not implemented |
 
 ---
 

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -94,39 +94,42 @@ Profile persistence (cookies/localStorage)
 ## TL;DR（最短成功路徑）
 
 ```bash
-# 1) Build PR 版本（TypeScript daemon + Rust CLI with AgentCore）
+# 1) 取得 PR 版本
 git clone https://github.com/vercel-labs/agent-browser.git
 cd agent-browser
 
 git fetch origin pull/397/head:pr-397
 git checkout pr-397
 
-# 1a) Build TypeScript daemon
+# 2) Build（依你選擇的 daemon 模式）
+
+# === 選項 A：Node.js daemon（預設，建議）===
 npm install
 npm run build          # 產出 dist/（Node.js daemon）
-
-# 1b) Build Rust CLI binary（含 AgentCore 支援）
 cd cli
-cargo build --release --features agentcore  # 產出 cli/target/release/agent-browser
+cargo build --release --features agentcore
 cd ..
-
-# 1c) 安裝到全域
 npm i -g .
-# 用 Rust binary 覆蓋 npm 安裝的 JS wrapper：
 cp cli/target/release/agent-browser "$(dirname $(which agent-browser))/agent-browser"
 
-# 2) 下載 Chromium（AgentCore 可選）
+# === 選項 B：Native daemon（--native，實驗性）===
+# 可跳過 npm install / npm run build，只需：
+cd cli
+cargo build --release --features agentcore
+# 直接使用 cli/target/release/agent-browser --native
+
+# 3) 下載 Chromium（AgentCore 可選）
 # 只有在遇到 Playwright/Chromium 相關錯誤時才需要：
 agent-browser install
 
-# 3) 連線 AWS Bedrock AgentCore Browser
+# 4) 連線 AWS Bedrock AgentCore Browser
 # 憑證會自動從環境變數或 AWS CLI 解析（支援 SSO、profiles、IAM roles）
 agent-browser -p agentcore open https://x.com/home
 
 # 使用 browser profile 保持登入狀態：
 AGENTCORE_PROFILE_ID=my-profile agent-browser -p agentcore open https://x.com/home
 
-# 4) 收尾
+# 5) 收尾
 agent-browser close
 ```
 

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -94,7 +94,7 @@ Profile persistence (cookies/localStorage)
 ## TL;DR（最短成功路徑）
 
 ```bash
-# 1) Build the PR version (TypeScript daemon + Rust CLI with AgentCore)
+# 1) Build PR 版本（TypeScript daemon + Rust CLI with AgentCore）
 git clone https://github.com/vercel-labs/agent-browser.git
 cd agent-browser
 
@@ -103,47 +103,47 @@ git checkout pr-397
 
 # 1a) Build TypeScript daemon
 npm install
-npm run build          # Output: dist/ (Node.js daemon)
+npm run build          # 產出 dist/（Node.js daemon）
 
-# 1b) Build Rust CLI binary with AgentCore support
+# 1b) Build Rust CLI binary（含 AgentCore 支援）
 cd cli
-cargo build --release --features agentcore  # Output: cli/target/release/agent-browser
+cargo build --release --features agentcore  # 產出 cli/target/release/agent-browser
 cd ..
 
-# 1c) Install globally
+# 1c) 安裝到全域
 npm i -g .
-# Replace npm's JS wrapper with Rust binary:
+# 用 Rust binary 覆蓋 npm 安裝的 JS wrapper：
 cp cli/target/release/agent-browser "$(dirname $(which agent-browser))/agent-browser"
 
-# 2) Download Chromium (optional for AgentCore)
-# Only needed if you see Playwright/Chromium errors:
+# 2) 下載 Chromium（AgentCore 可選）
+# 只有在遇到 Playwright/Chromium 相關錯誤時才需要：
 agent-browser install
 
-# 3) Connect to AWS Bedrock AgentCore Browser
-# Credentials are auto-resolved from env vars or AWS CLI (supports SSO, profiles, IAM roles)
+# 3) 連線 AWS Bedrock AgentCore Browser
+# 憑證會自動從環境變數或 AWS CLI 解析（支援 SSO、profiles、IAM roles）
 agent-browser -p agentcore open https://x.com/home
 
-# With browser profile for persistent login state:
+# 使用 browser profile 保持登入狀態：
 AGENTCORE_PROFILE_ID=my-profile agent-browser -p agentcore open https://x.com/home
 
-# 4) Cleanup
+# 4) 收尾
 agent-browser close
 ```
 
-### Credential Resolution
+### 憑證解析（Credential Resolution）
 
-Credentials are automatically resolved from:
-1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
-2. AWS CLI (`aws configure export-credentials`) - supports SSO, profiles, IAM roles
+憑證會自動從以下來源解析：
+1. 環境變數（`AWS_ACCESS_KEY_ID`、`AWS_SECRET_ACCESS_KEY`）
+2. AWS CLI（`aws configure export-credentials`）— 支援 SSO、profiles、IAM roles
 
-No need to manually export credentials with `eval $(aws configure export-credentials ...)`.
+不再需要手動用 `eval $(aws configure export-credentials ...)` 匯出憑證。
 
-### Compatibility
+### 相容性（Compatibility）
 
-| Daemon Mode | Status | Notes |
-|-------------|--------|-------|
-| Node.js (default) | ✅ Full support | Recommended |
-| Native (`--native`) | ⚠️ Experimental | Known issues: creates new session per command, `eval` not implemented |
+| Daemon 模式 | 狀態 | 備註 |
+|-------------|------|------|
+| Node.js（預設） | ✅ 完整支援 | 建議使用 |
+| Native（`--native`） | ⚠️ 實驗性 | 已知問題：每個指令都會建立新 session、`eval` 尚未實作 |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `docs/howto/agent-browser-agentcore.md` to reflect the new native Rust implementation in PR #397.

## Changes

- Add `--features agentcore` to build command
- Document auto credential resolution (env vars + AWS CLI)
- Add compatibility table for Node.js vs native daemon
- Note known issues with `--native` flag

Closes #248

## Reference
- PR: https://github.com/vercel-labs/agent-browser/pull/397
