### PR TITLE
docs: add command-dispatch limitations and run skill example

### DIFF
--- a/docs/skill-frontmatter.md
+++ b/docs/skill-frontmatter.md
@@ -8,7 +8,7 @@ OpenClaw 讀取每個 `SKILL.md` 的 frontmatter，將 skill 註冊為 Telegram/
 |------|------|------|
 | `name` | ✅ | Skill 名稱；自動成為 slash command（如 `name: prcli` → `/prcli`） |
 | `description` | ✅ | 顯示於 slash command 選單；LLM 依此自動選用 skill（上限 100 字元） |
-| `command-dispatch` | ❌ | 設為 `tool` 可繞過 LLM，直接 dispatch 至指定工具 |
+| `command-dispatch` | ❌ | 設為 `tool` 可繞過 LLM 組合指令，直接 dispatch 至指定工具 |
 | `command-tool` | ❌ | 要呼叫的工具名稱（如 `exec`）；`command-dispatch: tool` 時必填 |
 | `command-arg-mode` | ❌ | 參數傳遞方式；`raw` = 原樣傳入（目前唯一支援值） |
 
@@ -26,29 +26,55 @@ OpenClaw 讀取每個 `SKILL.md` 的 frontmatter，將 skill 註冊為 Telegram/
 用戶 /skillname args → OpenClaw → LLM 推理 → 呼叫工具 → 回傳結果
 ```
 
-彈性高但較慢，適合需要 LLM 理解意圖的 skill。
+彈性高但較慢，適合需要 LLM 理解意圖或分析結果的 skill。
 
 ### 直接 dispatch（`command-dispatch: tool`）
 
 ```
-用戶 /skillname args → OpenClaw → 直接呼叫工具 → 回傳結果
+用戶 /skillname args → OpenClaw → 直接呼叫工具(args) → 原樣回傳結果
 ```
 
-跳過 LLM，速度快、成本低、行為確定。適合 CLI 封裝型 skill。
+跳過 LLM，速度快、成本低、行為確定。**注意：** `args` 就是完整指令字串，工具不會自動加前綴。
 
-## 範例
+## 重要限制：`command-dispatch` + `exec` 的正確用法
+
+`exec` tool 收到的 `command` 參數 = 用戶輸入的 rawArgs（完整 shell 指令）。
+
+```
+/run ls -la        → exec("ls -la")        ✅
+/run prcli aws/aws-cdk/pull/123  → exec("prcli aws/aws-cdk/pull/123")  ✅
+/prcli aws/aws-cdk/pull/123      → exec("aws/aws-cdk/pull/123")        ❌ 缺少前綴
+```
+
+因此 `command-dispatch: tool` + `exec` **只適合** skill name 本身是「shell 指令入口」的場景，即用戶輸入的 args 本身就是完整指令。
+
+## 範例：`run` skill（直接執行任意 shell 指令）
 
 ```yaml
 ---
-name: my-skill
-description: 執行 my-cli 工具。當詢問 my-cli 相關問題時使用。
+name: run
+description: Execute a shell command directly. Use /run <command> to run any shell command without LLM interpretation.
 command-dispatch: tool
 command-tool: exec
 command-arg-mode: raw
 ---
+
+# run
+
+Execute any shell command directly via `/run <command>`.
+
+## Examples
+
+\`\`\`
+/run prcli aws/aws-cdk/pull/36303
+/run opcli cron list
+/run ls -la ~
+\`\`\`
+
+The command is passed as-is to the shell. No LLM interpretation.
 ```
 
-設定後，用戶輸入 `/my-skill foo bar`，OpenClaw 直接以 `foo bar` 為參數呼叫 `exec` 工具，不經 LLM。
+用戶輸入 `/run prcli aws/aws-cdk/pull/36303`，OpenClaw 直接執行 `prcli aws/aws-cdk/pull/36303`，原樣回傳輸出。
 
 ## Native Slash Command 設定
 


### PR DESCRIPTION
Follow-up to #251.

Adds to `docs/skill-frontmatter.md`:
- `command-dispatch` limitations and correct usage pattern
- `run` skill as a concrete example
- Correct vs incorrect usage comparison
