### PR TITLE
fix: use THEPAGENT_PAT in auto-merge-approved workflow

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -29,6 +29,7 @@ jobs:
         id: check
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.THEPAGENT_PAT }}
           script: |
             // Determine PR number depending on trigger
             let prNumber;


### PR DESCRIPTION
## Problem

The `auto-merge-approved` workflow uses the default `GITHUB_TOKEN` for `actions/github-script`, which lacks `issues: write` permission to add labels (e.g. `invalid-author`), causing a 403 error.

## Fix

Add `github-token: ${{ secrets.THEPAGENT_PAT }}` to the `actions/github-script` step so all `github.rest.*` calls use the PAT with sufficient permissions.