### PR TITLE
fix: use pull_request_target to support fork PRs in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -6,7 +6,9 @@ on:
     types: [submitted]
 
   # Re-evaluate when labels change, new commits are pushed, or PR is opened/reopened
-  pull_request:
+  # pull_request_target runs in base repo context, allowing access to secrets for fork PRs.
+  # Safe because this workflow never checks out fork code — only calls github.rest.* APIs.
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 
   # Re-evaluate when a check suite completes (so we can merge right after CI turns green)

--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -6,8 +6,8 @@ on:
     types: [submitted]
 
   # Re-evaluate when labels change, new commits are pushed, or PR is opened/reopened
-  # pull_request_target runs in base repo context, allowing access to secrets for fork PRs.
-  # Safe because this workflow never checks out fork code — only calls github.rest.* APIs.
+  # WARNING: This workflow uses pull_request_target (has access to secrets).
+  # NEVER add actions/checkout here — doing so would expose secrets to fork code.
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
 


### PR DESCRIPTION
## 問題

`auto-merge-approved.yml` 使用 `pull_request` 觸發，fork PR 的 workflow run 從 fork 分支讀取，無法存取 `THEPAGENT_PAT` secret，導致：

- `actions/github-script` 收到空的 `github-token` → `Error: Input required and not supplied: github-token`
- auto-merge 對所有 fork PR 失效

## 解法

將觸發條件改為 `pull_request_target`，workflow run 改從 base repo 讀取，secrets 即可用。

## 安全性

`pull_request_target` 有洩漏 secrets 的風險，但此 workflow **完全不 checkout fork 程式碼**，只呼叫 `github.rest.*` API 與 `gh pr merge`，無執行 fork 程式碼的機會，故安全無虞。

判斷原則：
```
有 checkout fork 程式碼 → 危險 ❌
純 github.rest.* API 呼叫 → 安全 ✅
```

## 變更範圍

`auto-merge-approved.yml` 觸發條件：

```yaml
# 修改前
on:
  pull_request_review:
    types: [submitted]
  pull_request:
    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
  check_suite:
    types: [completed]

# 修改後
on:
  pull_request_review:
    types: [submitted]
  pull_request_target:
    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
  check_suite:
    types: [completed]
```
