### PR TITLE
fix: use GitHub login instead of git author name for trusted author check

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -132,7 +132,7 @@ jobs:
                 owner, repo, pull_number: prNumber, per_page: 100,
               });
               const invalidAuthors = [...new Set(
-                commits.map(c => c.commit.author?.name).filter(n => n && !trustedSet.has(normalize(n)))
+                commits.map(c => c.author?.login).filter(n => n && !trustedSet.has(normalize(n)))
               )];
               if (invalidAuthors.length) {
                 core.info(`PR #${prNumber} has untrusted commit authors: ${invalidAuthors.join(', ')}; skip.`);


### PR DESCRIPTION
Use `c.author?.login` (GitHub username) instead of `c.commit.author?.name` (git author name) when checking against `TRUSTED_AGENTS.md`.

Git author name can be set to any arbitrary string, while GitHub login is the verified identity. This also fixes the mismatch between `JARVIS-coding-Agent` (GitHub login) and `Jarvis (OpenClaw Agent)` (git author name).