### PR TITLE
feat: add trusted-approval-labels workflow

### DIFF
--- a/.github/workflows/trusted-approval-labels.yml
+++ b/.github/workflows/trusted-approval-labels.yml
@@ -1,0 +1,94 @@
+name: Trusted Approval Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply approval labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.THEPAGENT_PAT }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Resolve PR number
+            let prNumber = context.payload.pull_request?.number
+              ?? context.payload.review?.pull_request_url?.split('/').pop();
+            if (!prNumber) { core.info('No PR found; skip.'); return; }
+            prNumber = Number(prNumber);
+
+            // Load trusted authors
+            const { data: repoContent } = await github.rest.repos.getContent({
+              owner, repo, path: 'TRUSTED_AGENTS.md', ref: 'main',
+            });
+            const normalize = (n) => n ? n.replace(/\[bot\]$/, '') : n;
+            const trusted = Buffer.from(repoContent.content, 'base64').toString()
+              .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+            const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
+
+            // Check PR commits are from trusted authors (eligible PR)
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const invalidAuthors = [...new Set(
+              commits.map(c => c.author?.login).filter(n => n && !trustedSet.has(normalize(n)))
+            )];
+            if (invalidAuthors.length) {
+              core.info(`PR #${prNumber} has untrusted commit authors: ${invalidAuthors.join(', ')}; skip.`);
+              return;
+            }
+
+            // Count approvals from trusted authors
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const latestByUser = new Map();
+            for (const r of reviews) {
+              if (r.user?.login) latestByUser.set(r.user.login, r.state);
+            }
+            const trustedApprovals = [...latestByUser.entries()]
+              .filter(([login, state]) => state === 'APPROVED' && trustedSet.has(normalize(login)))
+              .length;
+
+            core.info(`PR #${prNumber} trusted approvals: ${trustedApprovals}`);
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const labels = (pr.labels || []).map(l => l.name);
+
+            if (trustedApprovals >= 2) {
+              // Remove pending-trusted-approvals, add pending-final-approval
+              if (labels.includes('pending-trusted-approvals')) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: 'pending-trusted-approvals',
+                });
+              }
+              if (!labels.includes('pending-final-approval')) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: ['pending-final-approval'],
+                });
+              }
+            } else {
+              // Add pending-trusted-approvals if not already present
+              if (!labels.includes('pending-trusted-approvals')) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: ['pending-trusted-approvals'],
+                });
+              }
+              // Remove pending-final-approval if approval was dismissed
+              if (labels.includes('pending-final-approval')) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: 'pending-final-approval',
+                });
+              }
+            }


### PR DESCRIPTION
## 摘要

我們現在將 PR 審核權限下放給所有受信任的 AI agents。當一個 eligible PR（所有 commits 來自 trusted authors）累積 **2 個來自 trusted authors 的 approve**，系統會自動將 PR 升級至 `pending-final-approval`，等待 `thepagent` 最終 approve 後自動合併。

## 流程

```
PR 提交（eligible：commits 皆來自 trusted authors）
        │
        ▼
加上 "pending-trusted-approvals"
        │
        │ 累積 2 個 trusted author approvals
        ▼
移除 "pending-trusted-approvals"
加上 "pending-final-approval"
        │
        │ thepagent approve
        ▼
auto-merge workflow 自動合併
```

## 變更檔案

- `trusted-approval-labels.yml`（新增）：管理 `pending-trusted-approvals` / `pending-final-approval` label
- `auto-merge-approved.yml`（修改）：當 PR 有 `pending-final-approval` label 時，必須有 `thepagent` 的 approve 才執行合併

## 備註
- 使用 `pull_request_target` + `THEPAGENT_PAT`（與 auto-merge 相同模式）
- ⚠️ 此 workflow 絕不可加入 `actions/checkout`，否則會將 secrets 暴露給 fork 程式碼
- 支援 review 被撤銷的情況（自動退回 `pending-trusted-approvals`）
- 與現有 `auto-merge-approved` workflow 並行運作
