### PR TITLE
fix: require thepagent approval when pending-final-approval label is present

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -109,6 +109,16 @@ jobs:
               return;
             }
 
+            // If pending-final-approval label is present, require thepagent approval
+            const prLabels = (pr.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+            if (prLabels.includes('pending-final-approval')) {
+              const thepagentApproved = latestByUser.get('thepagent') === 'APPROVED';
+              if (!thepagentApproved) {
+                core.info(`PR #${prNumber} has pending-final-approval but no thepagent approval; skip.`);
+                return;
+              }
+            }
+
             // Gate on mergeability + required checks.
             // NOTE: mergeable_state is flaky/transient (often reports `unstable` even when checks are green),
             // so we avoid using it as the primary signal.


### PR DESCRIPTION
PR #277 合併時遺漏此 commit。補上 `auto-merge-approved.yml` 的邏輯：當 PR 有 `pending-final-approval` label 時，必須有 `thepagent` 的 approve 才執行合併。