### PR TITLE
fix: use pull_request_review_target for trusted approval labels

### DIFF
--- a/.github/workflows/trusted-approval-labels.yml
+++ b/.github/workflows/trusted-approval-labels.yml
@@ -3,7 +3,7 @@ name: Trusted Approval Labels
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
-  pull_request_review:
+  pull_request_review_target:
     types: [submitted, dismissed]
 
 permissions:


### PR DESCRIPTION
## Problem

`pull_request_review` event uses the head branch workflow file. When the head branch doesn't have the workflow file, GitHub falls back to base branch but **does not inject secrets**, causing `THEPAGENT_PAT` to be empty.

## Fix

Replace `pull_request_review` with `pull_request_review_target`, which:
- Always uses the **base branch workflow** (safe, no fork code checkout)
- Secrets are properly injected
- Still triggers on review `submitted` / `dismissed` events