### PR TITLE
release-notes: add zh-TW release notes for OpenClaw v2026.3.7

### DIFF
--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -1,0 +1,601 @@
+# OpenClaw v2026.3.7 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+- ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
+- ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+- ⭐⭐⭐ **Gateway auth 模式強制設定（Breaking）**：同時設定 token 與 password 時須明確指定 `gateway.auth.mode` ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- ⭐⭐ **Telegram 每主題獨立 Agent 路由**：論壇群組各主題可設定不同 agentId ([#33647](https://github.com/openclaw/openclaw/pull/33647))
+- ⭐⭐ **Web UI 西班牙語支援**：Control UI 新增 `es` 語系，含 lazy loading 與語言選擇器 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
+- ⭐⭐ **Onboarding 網路搜尋精靈**：設定精靈新增 provider 選擇步驟，支援 SecretRef ref-mode ([#34009](https://github.com/openclaw/openclaw/pull/34009))
+- ⭐⭐ **Perplexity Search API**：切換至 Search API，支援結構化結果與語言/地區/時間篩選 ([#33822](https://github.com/openclaw/openclaw/pull/33822))
+- ⭐⭐ **Gateway SecretRef auth 支援**：`gateway.auth.token` 支援 SecretRef，含 auth-mode 防護 ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- ⭐⭐ **Docker/Podman 擴充套件預烘焙**：`OPENCLAW_EXTENSIONS` 環境變數支援容器建置時預安裝依賴 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
+- ⭐⭐ **Plugin `before_prompt_build` 系統 context 欄位**：新增 `prependSystemContext`/`appendSystemContext` 降低 prompt token 成本 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
+- ⭐⭐ **Compaction 生命週期事件**：emit `session:compact:before/after` 事件供自動化監聽 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
+- ⭐⭐ **Google Gemini 3.1 Flash-Lite**：新增 `google/gemini-3.1-flash-lite-preview` 完整支援
+- ⭐ **Gateway `--password-file` CLI 強化**：新增 `--password-file` 參數，避免密碼透過 process listing 洩漏
+- ⭐ **Mattermost 互動式 model picker**：新增 `/oc_model` 互動式 provider/model 瀏覽 ([#38767](https://github.com/openclaw/openclaw/pull/38767))
+- ⭐ **Docker 多階段建置**：重構 Dockerfile 為多階段建置，產生最小化 runtime image ([#38479](https://github.com/openclaw/openclaw/pull/38479))
+- ⭐ **iOS App Store Connect 發佈準備**：對齊 bundle identifier、Fastlane 自動化、Keychain ASC auth ([#38936](https://github.com/openclaw/openclaw/pull/38936))
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Config 載入失敗關閉**：`loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，防止靜默回退至寬鬆預設值 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
+- ⭐⭐⭐ **Config 無效載入 fail-closed**：停止將 `INVALID_CONFIG` 轉換為空 runtime config ([#28140](https://github.com/openclaw/openclaw/issues/28140))
+- ⭐⭐⭐ **Security/archive ZIP 強化**：ZIP 解壓縮使用同目錄 temp + atomic rename，拒絕 hardlink alias race
+- ⭐⭐ **Gateway 安全回應標頭**：新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` ([#30186](https://github.com/openclaw/openclaw/pull/30186))
+- ⭐⭐ **依賴安全性修補**：修補 Hono 漏洞（pin `hono@4.12.5`）；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
+- ⭐⭐ **Cron 檔案權限強化**：cron store/backup/run-log 強制 `0600`，目錄強制 `0700` ([#36078](https://github.com/openclaw/openclaw/pull/36078))
+- ⭐⭐ **Security/Nostr profile mutation 強化**：non-loopback forwarded header fail-closed，拒絕 cross-site 請求
+- ⭐⭐ **Auth 標籤安全**：移除 `/status`/`/models` 中的 token/API key 片段 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
+- ⭐⭐ **ACP sandbox spawn 防護**：封鎖沙箱 session 執行 `/acp spawn`，與 `sessions_spawn` 政策一致
+- ⭐ **Config 驗證日誌清理**：清理 config 驗證訊息中的控制字元與 ANSI escape sequence ([#39116](https://github.com/openclaw/openclaw/pull/39116))
+- ⭐ **SecretRef models.json 持久化強化**：防止 SecretRef 管理的 api key 寫入 models.json ([#38955](https://github.com/openclaw/openclaw/pull/38955))
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Sessions bootstrap cache rollover 失效**：session 重置後正確清除 bootstrap 快取，確保 `AGENTS.md` 等更新即時生效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
+- ⭐⭐⭐ **Cron restart catch-up 語意**：重啟後正確補跑中斷的 recurring job，不重跑 one-shot job ([#34466](https://github.com/openclaw/openclaw/pull/34466))
+- ⭐⭐⭐ **Venice provider 400 錯誤**：對齊 per-model token 限制、停用不支援 function calling 的 tool wiring ([#38168](https://github.com/openclaw/openclaw/issues/38168))
+- ⭐⭐⭐ **Control UI iMessage 重複路由**：修復 Control UI 聊天回覆被重複送至 iMessage 的問題 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
+- ⭐⭐⭐ **Discord DM session key 正規化**：修復 legacy `discord:dm:*` key 導致 DM 無回覆的問題
+- ⭐⭐⭐ **TUI `/new` session 隔離**：`/new` 改為分配唯一 `tui-<uuid>` session key，修復多 TUI 客戶端互相收到對方回覆的問題 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
+- ⭐⭐ **Memory BM25 搜尋排序**：修復 `bm25RankToScore()` 負值排序，強關鍵字匹配正確排在前面 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
+- ⭐⭐ **Telegram polling health monitor**：Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
+- ⭐⭐ **ACP NO_REPLY 抑制**：過濾 ACP `NO_REPLY` lead fragment，console-backed ACP session 不再洩漏佔位符 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
+- ⭐⭐ **Codex CLI sandbox 預設值**：內建 Codex backend 從 `read-only` 改為 `workspace-write` ([#39336](https://github.com/openclaw/openclaw/pull/39336))
+- ⭐⭐ **Routing binding lookup 效能**：預先索引 route binding，修復大型 binding 設定下 `resolveAgentRoute` 多秒延遲 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
+- ⭐⭐ **Slack app_mention race dedupe**：修復 Slack 近乎同時送達導致重複回覆的問題 ([#37033](https://github.com/openclaw/openclaw/pull/37033))
+- ⭐⭐ **Telegram DM draft 重複顯示**：修復串流結束後短暫出現重複回覆的問題 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
+- ⭐⭐ **LINE auth boundary 強化**：統一 LINE webhook authn/z 邊界語意，含 replay/duplication 控制
+- ⭐ **Onboarding local tools.profile 預設值**：未設定時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
+- ⭐ **Browser session cleanup**：session 重置/刪除時關閉追蹤的瀏覽器分頁，防止記憶體洩漏 ([#36666](https://github.com/openclaw/openclaw/issues/36666))
+- ⭐ **iMessage echo loop 強化**：清除 assistant 內部 scaffolding，防止 echo 放大至佇列溢出 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Context Engine 插件介面 ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+- **用途**: 新增 `ContextEngine` 插件槽，支援 `bootstrap`、`ingest`、`assemble`、`compact`、`afterTurn`、`prepareSubagentSpawn`、`onSubagentEnded` 等完整生命週期 hook；提供 `LegacyContextEngine` wrapper 保留現有壓縮行為
+- **解決問題**: 過去無法在不修改核心壓縮邏輯的情況下替換 context 管理策略，社群插件（如 `lossless-claw`）無法提供替代方案
+- **影響**: 未設定 context engine 插件時行為完全不變；設定後可完全接管 context 生命週期，大幅提升可擴充性
+
+```text
+┌─────────────────────┐
+│  Plugin 設定解析     │
+│  (config-driven)    │
+└──────────┬──────────┘
+           │ 找到 ContextEngine plugin
+           ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│  slot registry 註冊  │────►│  AsyncLocalStorage   │
+│  (bootstrap hook)   │     │  scoped subagent ctx │
+└──────────┬──────────┘     └──────────────────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  每個 turn 執行      │
+│  ingest → assemble  │
+│  → afterTurn        │
+└──────────┬──────────┘
+           │ 需要壓縮時
+           ▼
+┌─────────────────────┐
+│  compact hook       │
+│  (plugin 自訂邏輯)   │
+└─────────────────────┘
+```
+
+### ⭐⭐⭐ ACP 持久化頻道綁定 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
+- **用途**: 新增持久化的 Discord 頻道與 Telegram 主題 ACP session 綁定儲存、路由解析，以及 CLI/文件支援
+- **解決問題**: 過去 ACP thread 目標在重啟後消失，無法一致管理
+- **影響**: ACP 綁定跨重啟保存，可透過 CLI 統一管理，大幅提升長期部署的穩定性
+
+```text
+┌──────────────────┐
+│  /acp spawn      │
+│  --channel here  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐     ┌─────────────────────┐
+│  binding 寫入    │────►│  持久化儲存          │
+│  (channel/topic) │     │  (disk-backed)       │
+└──────────────────┘     └──────────┬──────────┘
+                                    │ 重啟後
+                                    ▼
+                         ┌─────────────────────┐
+                         │  路由解析            │
+                         │  resolveBinding()   │
+                         └─────────────────────┘
+                                    │
+                                    ▼
+                         ┌─────────────────────┐
+                         │  ACP session 恢復    │
+                         └─────────────────────┘
+```
+
+### ⭐⭐⭐ Telegram ACP 主題綁定 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+- **用途**: 支援 Telegram Mac Unicode dash 前綴的 `/acp spawn` 參數解析；新增 `--thread here|auto` 綁定 Telegram 論壇主題；路由後續訊息至 ACP session；新增可操作的 Telegram 核准按鈕；成功綁定後在主題內釘選確認訊息
+- **解決問題**: Telegram Mac 客戶端的 Unicode dash 導致指令解析失敗；論壇主題無法持久綁定 ACP session
+- **影響**: Telegram 論壇群組可為每個主題建立獨立 ACP session，提升多主題工作流程的組織性
+
+```text
+┌─────────────────────────┐
+│  Telegram 訊息           │
+│  /acp spawn --thread here│
+└───────────┬─────────────┘
+            │ Unicode dash 正規化
+            ▼
+┌─────────────────────────┐
+│  參數解析                │
+│  (--thread here/auto)   │
+└───────────┬─────────────┘
+            │
+            ▼
+┌─────────────────────────┐     ┌──────────────────┐
+│  topic binding 建立      │────►│  釘選確認訊息     │
+└───────────┬─────────────┘     └──────────────────┘
+            │
+            ▼
+┌─────────────────────────┐
+│  後續訊息路由至           │
+│  綁定的 ACP session      │
+└─────────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway auth 模式強制設定 — Breaking Change ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- **用途**: 同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，須明確設定 `gateway.auth.mode` 為 `token` 或 `password`；同時新增 `gateway.auth.token` 的 SecretRef 支援
+- **解決問題**: 雙重 auth 設定下行為不明確，可能導致啟動/配對/TUI 失敗
+- **影響**: ⚠️ **升級前必須設定 `gateway.auth.mode`**，否則啟動將失敗
+
+```text
+┌──────────────────────────┐
+│  gateway 啟動             │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│  檢查 auth 設定           │
+│  token + password 都存在? │
+└────────────┬─────────────┘
+             │ 是
+             ▼
+┌──────────────────────────┐
+│  gateway.auth.mode 設定? │
+└──────┬───────────────────┘
+       │ 否                  │ 是 (token/password)
+       ▼                     ▼
+┌──────────────┐    ┌────────────────────┐
+│  啟動失敗     │    │  使用指定 auth 模式 │
+│  (fail-close)│    └────────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐ Telegram 每主題獨立 Agent 路由 ([#33647](https://github.com/openclaw/openclaw/pull/33647))
+- **用途**: 論壇群組各主題可設定不同 `agentId`，DM 主題亦支援獨立 session
+- **解決問題**: 過去所有主題共用同一 agent，無法為不同主題分配專屬 agent
+- **影響**: 可為不同工作主題（如開發、客服、行銷）分配不同 agent，提升多用途部署彈性
+
+### ⭐⭐ Web UI 西班牙語支援 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
+- **用途**: Control UI 新增 `es` 語系，含語系偵測、lazy loading 與語言選擇器標籤
+- **解決問題**: 西班牙語使用者只能使用英文介面
+- **影響**: 擴大 Control UI 的語言覆蓋範圍，改善西班牙語使用者體驗
+
+### ⭐⭐ Onboarding 網路搜尋精靈 ([#34009](https://github.com/openclaw/openclaw/pull/34009))
+- **用途**: 設定精靈新增 provider 選擇步驟與完整 provider 清單，支援 SecretRef ref-mode
+- **解決問題**: 新使用者設定網路搜尋 provider 時缺乏引導
+- **影響**: 降低初次設定門檻，SecretRef 支援提升安全性
+
+### ⭐⭐ Perplexity Search API ([#33822](https://github.com/openclaw/openclaw/pull/33822))
+- **用途**: 切換 Perplexity provider 至 Search API，支援結構化結果與語言/地區/時間篩選
+- **解決問題**: 舊版 API 不支援結構化輸出與進階篩選
+- **影響**: 搜尋結果更精確，可依語言、地區、時間範圍過濾
+
+### ⭐⭐ Docker/Podman 擴充套件預烘焙 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
+- **用途**: 新增 `OPENCLAW_EXTENSIONS` 環境變數，容器建置時可預安裝選定的 bundled extension npm 依賴
+- **解決問題**: 容器啟動時動態安裝依賴導致啟動慢且不可重現
+- **影響**: 容器部署啟動更快、更可重現
+
+### ⭐⭐ Plugin `before_prompt_build` 系統 context 欄位 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
+- **用途**: 新增 `prependSystemContext`/`appendSystemContext`，讓靜態 plugin 指引放入 system prompt 空間
+- **解決問題**: plugin 指引重複注入 user-prompt 空間，增加 token 成本且影響 provider caching
+- **影響**: 降低重複 prompt token 成本，改善 provider cache 命中率
+
+### ⭐⭐ Compaction 生命週期事件 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
+- **用途**: emit `session:compact:before`/`session:compact:after` 內部事件，含 session/count metadata
+- **解決問題**: 自動化無法一致地監聽 compaction 執行
+- **影響**: 插件與自動化可在 compaction 前後執行自訂邏輯
+
+### ⭐⭐ Google Gemini 3.1 Flash-Lite 支援
+- **用途**: 新增 `google/gemini-3.1-flash-lite-preview` 完整支援，含 model-id 正規化、預設別名、media 查詢
+- **解決問題**: 缺乏對最新 Gemini Flash-Lite 模型的原生支援
+- **影響**: 使用者可直接使用 Gemini 3.1 Flash-Lite，享有更低成本的推理選項
+
+### ⭐ Gateway `--password-file` CLI 強化
+- **用途**: 新增 `openclaw gateway run --password-file`，使用 inline `--password` 時發出警告
+- **解決問題**: inline `--password` 可能透過 process listing 洩漏密碼
+- **影響**: 提升 gateway 啟動時的密碼安全性
+
+### ⭐ Mattermost 互動式 model picker ([#38767](https://github.com/openclaw/openclaw/pull/38767))
+- **用途**: 新增 `/oc_model`/`/oc_models` 互動式 provider/model 瀏覽，修復 picker callback 更新
+- **解決問題**: Mattermost 缺乏 Telegram 風格的互動式 model 選擇介面
+- **影響**: 改善 Mattermost 使用者切換模型的體驗
+
+### ⭐ Docker 多階段建置 ([#38479](https://github.com/openclaw/openclaw/pull/38479))
+- **用途**: 重構 Dockerfile 為多階段建置，產生不含 build tools、source code 或 Bun 的最小化 runtime image；新增 `OPENCLAW_VARIANT=slim` build arg
+- **解決問題**: 單階段建置產生的 image 過大，包含不必要的建置工具
+- **影響**: 容器 image 更小、更安全，部署更快
+
+### ⭐ iOS App Store Connect 發佈準備 ([#38936](https://github.com/openclaw/openclaw/pull/38936))
+- **用途**: 對齊 iOS bundle identifier 至 `ai.openclaw.client`、更新 Watch app 圖示、Fastlane metadata/截圖自動化、Keychain ASC auth
+- **解決問題**: iOS 發佈流程缺乏自動化，bundle identifier 不一致
+- **影響**: 簡化 App Store 發佈流程，提升 CI/CD 可靠性
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Config 載入失敗關閉 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
+- **用途**: `loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，不再靜默回退至寬鬆 runtime 預設值
+- **解決問題**: 無效設定可能靜默使用寬鬆預設值，導致安全設定失效
+- **影響**: 設定錯誤時系統明確拒絕啟動，防止意外暴露
+
+```text
+┌──────────────────────┐
+│  loadConfig() 呼叫   │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  讀取 + 驗證設定      │
+└──────────┬───────────┘
+           │ 錯誤?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────┐  ┌──────────────────┐
+│ 拋出錯誤  │  │  正常載入 config  │
+│(fail-close)│  └──────────────────┘
+└──────────┘
+```
+
+### ⭐⭐⭐ Config 無效載入 fail-closed ([#28140](https://github.com/openclaw/openclaw/issues/28140))
+- **用途**: 停止將 `INVALID_CONFIG` 轉換為空 runtime config；有效設定僅透過明確的 best-effort 診斷讀取提供
+- **解決問題**: 未知 key 可能靜默丟棄安全敏感設定
+- **影響**: 設定驗證失敗時系統 fail-closed，防止安全設定被靜默忽略
+
+```text
+┌──────────────────────┐
+│  config 驗證          │
+└──────────┬───────────┘
+           │ INVALID_CONFIG?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────────┐  ┌──────────────────┐
+│ fail-closed  │  │  正常 runtime    │
+│ (不轉空 cfg) │  └──────────────────┘
+└──────┬───────┘
+       │ 診斷讀取
+       ▼
+┌──────────────┐
+│ best-effort  │
+│ 診斷路徑     │
+└──────────────┘
+```
+
+### ⭐⭐⭐ Security/archive ZIP 強化
+- **用途**: ZIP 解壓縮改用同目錄 temp file + atomic rename，解壓後重新開啟並拒絕 destination root 外的 hardlink alias race
+- **解決問題**: ZIP 解壓縮存在 hardlink path traversal 風險
+- **影響**: 防止惡意 ZIP 檔案透過 hardlink race 逃逸至目標目錄外
+
+```text
+┌──────────────────────┐
+│  ZIP 解壓縮請求       │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  同目錄 temp file 寫入│
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  atomic rename       │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  重新開啟驗證         │
+│  hardlink alias 檢查  │
+└──────────┬───────────┘
+           │ 逃逸?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────┐  ┌──────────────┐
+│  拒絕     │  │  解壓縮完成  │
+└──────────┘  └──────────────┘
+```
+
+### ⭐⭐ Gateway 安全回應標頭 ([#30186](https://github.com/openclaw/openclaw/pull/30186))
+- **用途**: 所有 gateway HTTP 回應新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` 基線安全標頭
+- **解決問題**: 缺乏 Permissions-Policy 標頭，瀏覽器可能允許不必要的硬體存取
+- **影響**: 強化 Control UI 的瀏覽器安全邊界
+
+### ⭐⭐ 依賴安全性修補
+- **用途**: pin `hono@4.12.5`/`@hono/node-server@1.19.10` 修補 Hono 漏洞；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
+- **解決問題**: 上游依賴存在已知安全漏洞
+- **影響**: 消除已知 CVE，降低供應鏈攻擊風險
+
+### ⭐⭐ Cron 檔案權限強化 ([#36078](https://github.com/openclaw/openclaw/pull/36078))
+- **用途**: cron store/backup/run-log 強制 `0600` 權限，目錄強制 `0700`，包含舊版安裝的既有目錄
+- **解決問題**: cron 相關檔案權限過寬，可能被其他使用者讀取
+- **影響**: 防止本機多使用者環境下的 cron 資料洩漏
+
+### ⭐⭐ Security/Nostr profile mutation 強化
+- **用途**: non-loopback forwarded client header (`x-forwarded-for`/`x-real-ip`) fail-closed；拒絕 `sec-fetch-site: cross-site` 請求
+- **解決問題**: proxy 轉發或瀏覽器跨站請求可能繞過 loopback 防護
+- **影響**: 防止 proxy 環境下的 Nostr profile 偽造攻擊
+
+### ⭐⭐ Auth 標籤安全 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
+- **用途**: 移除 `/status`/`/models` 輸出中的 token 與 API key 片段
+- **解決問題**: 狀態輸出可能洩漏憑證片段
+- **影響**: 降低憑證意外暴露於日誌或螢幕截圖的風險
+
+### ⭐⭐ ACP sandbox spawn 防護
+- **用途**: 封鎖沙箱 requester session 執行 `/acp spawn`，與 `sessions_spawn({ runtime: "acp" })` 的 host-runtime 防護一致
+- **解決問題**: 沙箱 session 可透過 `/acp spawn` 指令路徑繞過沙箱邊界
+- **影響**: 關閉沙箱邊界的指令路徑政策缺口
+
+### ⭐ Config 驗證日誌清理 ([#39116](https://github.com/openclaw/openclaw/pull/39116))
+- **用途**: 清理 config 驗證 issue 路徑/訊息中的控制字元與 ANSI escape sequence
+- **解決問題**: 惡意設定內容可能透過 ANSI escape 注入誤導性終端輸出
+- **影響**: 防止設定驗證日誌被用於終端注入攻擊
+
+### ⭐ SecretRef models.json 持久化強化 ([#38955](https://github.com/openclaw/openclaw/pull/38955))
+- **用途**: 防止 SecretRef 管理的 api key 與 headers 寫入 models.json；擴大 audit/apply 覆蓋範圍
+- **解決問題**: SecretRef 管理的憑證可能以明文形式持久化至磁碟
+- **影響**: 確保 SecretRef 憑證不會意外寫入設定檔案
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Sessions bootstrap cache rollover 失效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
+- **用途**: session 重置（daily/idle/forced）後正確清除 workspace bootstrap 快取，確保 `AGENTS.md`/`MEMORY.md`/`USER.md` 更新即時生效
+- **解決問題**: session 重置後 bootstrap 快取未清除，`AGENTS.md` 等更新直到 gateway 重啟才生效
+- **影響**: 設定更新後立即反映，不再需要重啟 gateway
+
+```text
+┌──────────────────────┐
+│  session reset 觸發   │
+│  (daily/idle/forced) │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  等待 embedded run   │
+│  shutdown 完成        │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  清除 bootstrap      │
+│  cache snapshot      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  下次 session 啟動    │
+│  重新載入 AGENTS.md  │
+│  MEMORY.md / USER.md │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Cron restart catch-up 語意修正
+- **用途**: 重啟後補跑中斷的 recurring job 與錯過的 immediate cron slot；不重跑中斷的 one-shot job；防護 malformed schedule 導致啟動中止
+- **解決問題**: 重啟後 recurring job 不補跑，或 one-shot job 被錯誤重跑；malformed schedule 導致啟動失敗
+- **影響**: cron 重啟後行為符合預期，不再遺漏或重複執行
+
+```text
+┌──────────────────────┐
+│  gateway 重啟         │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  掃描中斷的 cron jobs │
+└──────────┬───────────┘
+           │
+     ┌─────┴──────────────┐
+     │ recurring job?      │ one-shot job?
+     ▼                     ▼
+┌──────────┐         ┌──────────────┐
+│  補跑    │         │  跳過        │
+│  missed  │         │  (不重跑)    │
+│  slots   │         └──────────────┘
+└──────────┘
+```
+
+### ⭐⭐⭐ Venice provider 400 錯誤修復 ([#38168](https://github.com/openclaw/openclaw/issues/38168))
+- **用途**: 對齊 per-model Venice completion-token 限制與 discovery metadata；停用不支援 function calling 的 Venice model 的 tool wiring；同步靜態 fallback catalog
+- **解決問題**: 預設 Venice 設定因 `max_completion_tokens` 超限或 unsupported-tools 導致 400 錯誤
+- **影響**: Venice provider 開箱即用，不再需要手動調整 token 限制
+
+```text
+┌──────────────────────┐
+│  Venice model 請求    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  discovery metadata  │
+│  token limit 對齊    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  支援 function call? │
+└──────┬───────────────┘
+       │ 否              │ 是
+       ▼                 ▼
+┌──────────────┐  ┌──────────────────┐
+│  停用 tool   │  │  正常 tool wiring │
+│  wiring      │  └──────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐⭐ Control UI iMessage 重複路由修復 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
+- **用途**: 保持 internal webchat turn 在 dispatcher delivery，不進行 origin-channel reroute，防止 Control UI 聊天回覆被重複送至 iMessage
+- **解決問題**: Control UI 聊天回覆被錯誤路由至 iMessage，導致重複訊息
+- **影響**: Control UI 與 iMessage 頻道路由正確隔離
+
+```text
+┌──────────────────────┐
+│  Control UI 聊天回覆  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  internal webchat?   │
+└──────┬───────────────┘
+       │ 是              │ 否
+       ▼                 ▼
+┌──────────────┐  ┌──────────────────────┐
+│  dispatcher  │  │  origin-channel route │
+│  delivery    │  │  (外部頻道)           │
+│  (不 reroute)│  └──────────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐⭐ Discord DM session key 正規化
+- **用途**: 將 legacy `discord:dm:*` 與 phantom `discord:channel:<user>` session key 重寫為 `discord:direct:*`，修復多 agent Discord DM 無回覆問題
+- **解決問題**: legacy session key 格式導致 DM 落入空的 channel-shaped session，無法正確回覆
+- **影響**: Discord DM 路由正確，多 agent 設定下 DM 不再靜默失敗
+
+```text
+┌──────────────────────┐
+│  Discord DM 入站      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  session key 偵測     │
+│  discord:dm:* ?      │
+└──────┬───────────────┘
+       │ 是
+       ▼
+┌──────────────────────┐
+│  重寫為               │
+│  discord:direct:*    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  正確路由至 DM session│
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ TUI `/new` session 隔離 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
+- **用途**: `/new` 改為分配唯一 `tui-<uuid>` session key，不再重置共用 agent session；同時清理 `/new`/`/reset` 失敗文字的終端渲染
+- **解決問題**: 多個 TUI 客戶端連接同一 agent 時，`/new` 重置共用 session 導致互相收到對方的回覆
+- **影響**: 多 TUI 客戶端可獨立使用，不再互相干擾
+
+```text
+┌──────────────────────┐
+│  TUI 客戶端 A: /new  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  分配 tui-<uuid-A>   │
+│  session key         │
+└──────────────────────┘
+
+┌──────────────────────┐
+│  TUI 客戶端 B: /new  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  分配 tui-<uuid-B>   │
+│  session key (獨立)  │
+└──────────────────────┘
+```
+
+### ⭐⭐ Memory BM25 搜尋排序修復 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
+- **用途**: 修復 `bm25RankToScore()` 中 FTS5 BM25 負值排序，確保強關鍵字匹配排在弱匹配前面
+- **解決問題**: BM25 負值排序邏輯錯誤，導致搜尋結果排序反轉或崩潰
+- **影響**: memory 關鍵字搜尋結果排序正確，最相關結果優先顯示
+
+### ⭐⭐ Telegram polling health monitor 修復 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
+- **用途**: Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟；透過共用 health evaluation 串接頻道身份
+- **解決問題**: Telegram polling 連線因長時間運行被誤判為 stale，觸發不必要的重啟/配對風暴
+- **影響**: Telegram polling 連線穩定，不再因長時間運行而被誤重啟
+
+### ⭐⭐ ACP NO_REPLY 抑制修復 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
+- **用途**: 在 `openclaw agent` logging/delivery 前過濾 ACP `NO_REPLY` lead fragment 與 silent-only final
+- **解決問題**: console-backed ACP session 在日誌/輸出中洩漏 `NO`/`NO_REPLY` 佔位符
+- **影響**: ACP session 輸出乾淨，不再出現無意義的佔位符文字
+
+### ⭐⭐ Codex CLI sandbox 預設值修正 ([#39336](https://github.com/openclaw/openclaw/pull/39336))
+- **用途**: 內建 Codex backend 從 `read-only` 改為 `workspace-write`，讓 coding run 開箱即可編輯檔案
+- **解決問題**: 預設 `read-only` sandbox 導致 Codex coding run 無法寫入檔案
+- **影響**: Codex coding agent 開箱即用，不再需要手動調整 sandbox 設定
+
+### ⭐⭐ Routing binding lookup 效能修復 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
+- **用途**: 預先以 channel/account 索引 route binding，避免 channel-account cache rollover 時全量重掃
+- **解決問題**: 大型 binding 設定下 `resolveAgentRoute` 每次呼叫需多秒
+- **影響**: 大型部署的訊息路由延遲大幅降低
+
+### ⭐⭐ Slack app_mention race dedupe ([#37033](https://github.com/openclaw/openclaw/pull/37033))
+- **用途**: `app_mention` dispatch 勝出時，抑制同 `ts` 的 `message` dispatch，防止近乎同時送達的 Slack 事件產生重複回覆
+- **解決問題**: Slack 同時送達 `app_mention` 與 `message` 事件導致重複回覆
+- **影響**: Slack 提及不再產生重複回覆
+
+### ⭐⭐ Telegram DM draft 重複顯示修復 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
+- **用途**: 最終訊息實體化後清除 stale DM draft preview，包含 DM topic lookup 失敗時的 threadless fallback
+- **解決問題**: 串流結束後短暫出現重複回覆（preview + final 同時顯示）
+- **影響**: Telegram DM 串流回覆顯示乾淨，不再出現短暫重複
+
+### ⭐⭐ LINE auth boundary 強化
+- **用途**: 統一 LINE webhook authn/z 邊界語意，含 pairing-store account scoping、DM/group allowlist 分離、fail-closed webhook auth、replay/duplication 控制
+- **解決問題**: LINE webhook 認證邊界不一致，存在 replay 與重複處理風險
+- **影響**: LINE 頻道安全性與可靠性大幅提升
+
+### ⭐ Onboarding local tools.profile 預設值修正
+- **用途**: 未設定 local `tools.profile` 時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
+- **解決問題**: 新本地安裝預設 `messaging` profile，缺少檔案與 runtime 工具
+- **影響**: 本地安裝開箱即有完整工具集
+
+### ⭐ Browser session cleanup ([#36666](https://github.com/openclaw/openclaw/issues/36666))
+- **用途**: 追蹤 session-scoped browser tool 開啟的分頁，在 `sessions.reset`/`sessions.delete` 時關閉
+- **解決問題**: session 結束後瀏覽器分頁殘留，導致記憶體持續增長
+- **影響**: 長時間運行的部署記憶體使用更穩定
+
+### ⭐ iMessage echo loop 強化 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
+- **用途**: 清除 assistant 內部 scaffolding、丟棄反射的 assistant-content 訊息、延長 echo-cache 保留時間、在放大至佇列溢出前抑制重複 loop 流量
+- **解決問題**: iMessage echo loop 可能放大至佇列溢出，導致服務中斷
+- **影響**: iMessage 部署更穩定，防止 echo loop 導致的服務降級
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 4 | 9 | 5 | 18 項 |
+| 安全性 | 3 | 6 | 2 | 11 項 |
+| 錯誤修復 | 6 | 10 | 3 | 19 項 |
+| **總計** | **13** | **25** | **10** | **48 項** |
+
+**發佈日期**: 2026-03-08
+**版本**: 2026.3.7
+**狀態**: Production Ready
+**GitHub Release**: [v2026.3.7](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -12,6 +12,31 @@
 
 ### 功能更新 (Features)
 - ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+
+```text
+  無插件（預設）                有 ContextEngine 插件
+  ┌─────────────────┐          ┌─────────────────────┐
+  │  LegacyContext  │          │  Plugin 實作         │
+  │  Engine（內建） │          │  (e.g. lossless-claw)│
+  └────────┬────────┘          └──────────┬──────────┘
+           │                              │
+           └──────────┬───────────────────┘
+                      ▼
+           ┌─────────────────────┐
+           │  slot registry      │
+           │  bootstrap → ingest │
+           │  → assemble         │
+           │  → compact          │
+           │  → afterTurn        │
+           └─────────────────────┘
+                      │
+                      ▼
+           ┌─────────────────────┐
+           │  核心邏輯不變        │
+           │  零行為差異（無插件）│
+           └─────────────────────┘
+```
+
 - ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
 - ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
 

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -2,6 +2,12 @@
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
 
+## ⚠️ Breaking Change
+
+**Gateway auth 模式強制設定**：同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，**升級前必須在設定檔中明確指定 `gateway.auth.mode: token` 或 `gateway.auth.mode: password`**，否則 gateway 將無法啟動。詳見 [#35094](https://github.com/openclaw/openclaw/pull/35094)。
+
+---
+
 ## 概述
 
 ### 功能更新 (Features)

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -14,6 +14,32 @@
 - ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
 - ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
 - ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+
+```text
+ACP 頻道整合架構（v2026.3.7）
+
+  Discord                        Telegram
+  ┌─────────────────┐            ┌─────────────────────┐
+  │  頻道 #dev      │            │  論壇主題 #backend  │
+  │  /acp spawn     │            │  /acp spawn         │
+  │  --channel here │            │  --thread here      │
+  └────────┬────────┘            └──────────┬──────────┘
+           │                                │
+           ▼                                ▼
+  ┌─────────────────────────────────────────────────────┐
+  │              持久化 Binding 儲存                     │
+  │   channel/topic  ──►  ACP session ID               │
+  │   (跨重啟保存)                                       │
+  └──────────────────────────┬──────────────────────────┘
+                             │
+                             ▼
+  ┌─────────────────────────────────────────────────────┐
+  │              路由解析 resolveBinding()               │
+  │   後續訊息  ──►  綁定的 ACP session                 │
+  │   per-topic agentId override 支援                   │
+  └─────────────────────────────────────────────────────┘
+```
+
 - ⭐⭐⭐ **Gateway auth 模式強制設定（Breaking）**：同時設定 token 與 password 時須明確指定 `gateway.auth.mode` ([#35094](https://github.com/openclaw/openclaw/pull/35094))
 - ⭐⭐ **Telegram 每主題獨立 Agent 路由**：論壇群組各主題可設定不同 agentId ([#33647](https://github.com/openclaw/openclaw/pull/33647))
 - ⭐⭐ **Web UI 西班牙語支援**：Control UI 新增 `es` 語系，含 lazy loading 與語言選擇器 ([#35038](https://github.com/openclaw/openclaw/pull/35038))


### PR DESCRIPTION
Closes #284

## 變更內容

新增 OpenClaw v2026.3.7 的繁體中文版本發佈說明。

### 涵蓋項目
- **功能更新**：18 項（⭐⭐⭐×4、⭐⭐×9、⭐×5）
- **安全性提升**：11 項（⭐⭐⭐×3、⭐⭐×6、⭐×2）
- **錯誤修復**：19 項（⭐⭐⭐×6、⭐⭐×10、⭐×3）

### 重點
- Context Engine 插件介面（#22201）
- ACP 持久化頻道綁定（#34873、#36683）
- Gateway auth 模式 Breaking Change（#35094）
- Sessions bootstrap cache rollover 修復（#38494）
- TUI /new session 隔離修復（#39238）
- 所有 ⭐⭐⭐ 項目均含 ASCII flowchart

遵循 `release-notes/GUIDELINES.md` 規範。