### PR TITLE
release-notes: OpenClaw 2026.3.8

### DIFF
--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -1,0 +1,601 @@
+# OpenClaw v2026.3.7 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+- ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
+- ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+- ⭐⭐⭐ **Gateway auth 模式強制設定（Breaking）**：同時設定 token 與 password 時須明確指定 `gateway.auth.mode` ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- ⭐⭐ **Telegram 每主題獨立 Agent 路由**：論壇群組各主題可設定不同 agentId ([#33647](https://github.com/openclaw/openclaw/pull/33647))
+- ⭐⭐ **Web UI 西班牙語支援**：Control UI 新增 `es` 語系，含 lazy loading 與語言選擇器 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
+- ⭐⭐ **Onboarding 網路搜尋精靈**：設定精靈新增 provider 選擇步驟，支援 SecretRef ref-mode ([#34009](https://github.com/openclaw/openclaw/pull/34009))
+- ⭐⭐ **Perplexity Search API**：切換至 Search API，支援結構化結果與語言/地區/時間篩選 ([#33822](https://github.com/openclaw/openclaw/pull/33822))
+- ⭐⭐ **Gateway SecretRef auth 支援**：`gateway.auth.token` 支援 SecretRef，含 auth-mode 防護 ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- ⭐⭐ **Docker/Podman 擴充套件預烘焙**：`OPENCLAW_EXTENSIONS` 環境變數支援容器建置時預安裝依賴 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
+- ⭐⭐ **Plugin `before_prompt_build` 系統 context 欄位**：新增 `prependSystemContext`/`appendSystemContext` 降低 prompt token 成本 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
+- ⭐⭐ **Compaction 生命週期事件**：emit `session:compact:before/after` 事件供自動化監聽 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
+- ⭐⭐ **Google Gemini 3.1 Flash-Lite**：新增 `google/gemini-3.1-flash-lite-preview` 完整支援
+- ⭐ **Gateway `--password-file` CLI 強化**：新增 `--password-file` 參數，避免密碼透過 process listing 洩漏
+- ⭐ **Mattermost 互動式 model picker**：新增 `/oc_model` 互動式 provider/model 瀏覽 ([#38767](https://github.com/openclaw/openclaw/pull/38767))
+- ⭐ **Docker 多階段建置**：重構 Dockerfile 為多階段建置，產生最小化 runtime image ([#38479](https://github.com/openclaw/openclaw/pull/38479))
+- ⭐ **iOS App Store Connect 發佈準備**：對齊 bundle identifier、Fastlane 自動化、Keychain ASC auth ([#38936](https://github.com/openclaw/openclaw/pull/38936))
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Config 載入失敗關閉**：`loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，防止靜默回退至寬鬆預設值 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
+- ⭐⭐⭐ **Config 無效載入 fail-closed**：停止將 `INVALID_CONFIG` 轉換為空 runtime config ([#28140](https://github.com/openclaw/openclaw/issues/28140))
+- ⭐⭐⭐ **Security/archive ZIP 強化**：ZIP 解壓縮使用同目錄 temp + atomic rename，拒絕 hardlink alias race
+- ⭐⭐ **Gateway 安全回應標頭**：新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` ([#30186](https://github.com/openclaw/openclaw/pull/30186))
+- ⭐⭐ **依賴安全性修補**：修補 Hono 漏洞（pin `hono@4.12.5`）；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
+- ⭐⭐ **Cron 檔案權限強化**：cron store/backup/run-log 強制 `0600`，目錄強制 `0700` ([#36078](https://github.com/openclaw/openclaw/pull/36078))
+- ⭐⭐ **Security/Nostr profile mutation 強化**：non-loopback forwarded header fail-closed，拒絕 cross-site 請求
+- ⭐⭐ **Auth 標籤安全**：移除 `/status`/`/models` 中的 token/API key 片段 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
+- ⭐⭐ **ACP sandbox spawn 防護**：封鎖沙箱 session 執行 `/acp spawn`，與 `sessions_spawn` 政策一致
+- ⭐ **Config 驗證日誌清理**：清理 config 驗證訊息中的控制字元與 ANSI escape sequence ([#39116](https://github.com/openclaw/openclaw/pull/39116))
+- ⭐ **SecretRef models.json 持久化強化**：防止 SecretRef 管理的 api key 寫入 models.json ([#38955](https://github.com/openclaw/openclaw/pull/38955))
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Sessions bootstrap cache rollover 失效**：session 重置後正確清除 bootstrap 快取，確保 `AGENTS.md` 等更新即時生效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
+- ⭐⭐⭐ **Cron restart catch-up 語意**：重啟後正確補跑中斷的 recurring job，不重跑 one-shot job ([#34466](https://github.com/openclaw/openclaw/pull/34466))
+- ⭐⭐⭐ **Venice provider 400 錯誤**：對齊 per-model token 限制、停用不支援 function calling 的 tool wiring ([#38168](https://github.com/openclaw/openclaw/issues/38168))
+- ⭐⭐⭐ **Control UI iMessage 重複路由**：修復 Control UI 聊天回覆被重複送至 iMessage 的問題 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
+- ⭐⭐⭐ **Discord DM session key 正規化**：修復 legacy `discord:dm:*` key 導致 DM 無回覆的問題
+- ⭐⭐⭐ **TUI `/new` session 隔離**：`/new` 改為分配唯一 `tui-<uuid>` session key，修復多 TUI 客戶端互相收到對方回覆的問題 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
+- ⭐⭐ **Memory BM25 搜尋排序**：修復 `bm25RankToScore()` 負值排序，強關鍵字匹配正確排在前面 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
+- ⭐⭐ **Telegram polling health monitor**：Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
+- ⭐⭐ **ACP NO_REPLY 抑制**：過濾 ACP `NO_REPLY` lead fragment，console-backed ACP session 不再洩漏佔位符 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
+- ⭐⭐ **Codex CLI sandbox 預設值**：內建 Codex backend 從 `read-only` 改為 `workspace-write` ([#39336](https://github.com/openclaw/openclaw/pull/39336))
+- ⭐⭐ **Routing binding lookup 效能**：預先索引 route binding，修復大型 binding 設定下 `resolveAgentRoute` 多秒延遲 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
+- ⭐⭐ **Slack app_mention race dedupe**：修復 Slack 近乎同時送達導致重複回覆的問題 ([#37033](https://github.com/openclaw/openclaw/pull/37033))
+- ⭐⭐ **Telegram DM draft 重複顯示**：修復串流結束後短暫出現重複回覆的問題 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
+- ⭐⭐ **LINE auth boundary 強化**：統一 LINE webhook authn/z 邊界語意，含 replay/duplication 控制
+- ⭐ **Onboarding local tools.profile 預設值**：未設定時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
+- ⭐ **Browser session cleanup**：session 重置/刪除時關閉追蹤的瀏覽器分頁，防止記憶體洩漏 ([#36666](https://github.com/openclaw/openclaw/issues/36666))
+- ⭐ **iMessage echo loop 強化**：清除 assistant 內部 scaffolding，防止 echo 放大至佇列溢出 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Context Engine 插件介面 ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+- **用途**: 新增 `ContextEngine` 插件槽，支援 `bootstrap`、`ingest`、`assemble`、`compact`、`afterTurn`、`prepareSubagentSpawn`、`onSubagentEnded` 等完整生命週期 hook；提供 `LegacyContextEngine` wrapper 保留現有壓縮行為
+- **解決問題**: 過去無法在不修改核心壓縮邏輯的情況下替換 context 管理策略，社群插件（如 `lossless-claw`）無法提供替代方案
+- **影響**: 未設定 context engine 插件時行為完全不變；設定後可完全接管 context 生命週期，大幅提升可擴充性
+
+```text
+┌─────────────────────┐
+│  Plugin 設定解析     │
+│  (config-driven)    │
+└──────────┬──────────┘
+           │ 找到 ContextEngine plugin
+           ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│  slot registry 註冊  │────►│  AsyncLocalStorage   │
+│  (bootstrap hook)   │     │  scoped subagent ctx │
+└──────────┬──────────┘     └──────────────────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  每個 turn 執行      │
+│  ingest → assemble  │
+│  → afterTurn        │
+└──────────┬──────────┘
+           │ 需要壓縮時
+           ▼
+┌─────────────────────┐
+│  compact hook       │
+│  (plugin 自訂邏輯)   │
+└─────────────────────┘
+```
+
+### ⭐⭐⭐ ACP 持久化頻道綁定 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
+- **用途**: 新增持久化的 Discord 頻道與 Telegram 主題 ACP session 綁定儲存、路由解析，以及 CLI/文件支援
+- **解決問題**: 過去 ACP thread 目標在重啟後消失，無法一致管理
+- **影響**: ACP 綁定跨重啟保存，可透過 CLI 統一管理，大幅提升長期部署的穩定性
+
+```text
+┌──────────────────┐
+│  /acp spawn      │
+│  --channel here  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐     ┌─────────────────────┐
+│  binding 寫入    │────►│  持久化儲存          │
+│  (channel/topic) │     │  (disk-backed)       │
+└──────────────────┘     └──────────┬──────────┘
+                                    │ 重啟後
+                                    ▼
+                         ┌─────────────────────┐
+                         │  路由解析            │
+                         │  resolveBinding()   │
+                         └─────────────────────┘
+                                    │
+                                    ▼
+                         ┌─────────────────────┐
+                         │  ACP session 恢復    │
+                         └─────────────────────┘
+```
+
+### ⭐⭐⭐ Telegram ACP 主題綁定 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+- **用途**: 支援 Telegram Mac Unicode dash 前綴的 `/acp spawn` 參數解析；新增 `--thread here|auto` 綁定 Telegram 論壇主題；路由後續訊息至 ACP session；新增可操作的 Telegram 核准按鈕；成功綁定後在主題內釘選確認訊息
+- **解決問題**: Telegram Mac 客戶端的 Unicode dash 導致指令解析失敗；論壇主題無法持久綁定 ACP session
+- **影響**: Telegram 論壇群組可為每個主題建立獨立 ACP session，提升多主題工作流程的組織性
+
+```text
+┌─────────────────────────┐
+│  Telegram 訊息           │
+│  /acp spawn --thread here│
+└───────────┬─────────────┘
+            │ Unicode dash 正規化
+            ▼
+┌─────────────────────────┐
+│  參數解析                │
+│  (--thread here/auto)   │
+└───────────┬─────────────┘
+            │
+            ▼
+┌─────────────────────────┐     ┌──────────────────┐
+│  topic binding 建立      │────►│  釘選確認訊息     │
+└───────────┬─────────────┘     └──────────────────┘
+            │
+            ▼
+┌─────────────────────────┐
+│  後續訊息路由至           │
+│  綁定的 ACP session      │
+└─────────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway auth 模式強制設定 — Breaking Change ([#35094](https://github.com/openclaw/openclaw/pull/35094))
+- **用途**: 同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，須明確設定 `gateway.auth.mode` 為 `token` 或 `password`；同時新增 `gateway.auth.token` 的 SecretRef 支援
+- **解決問題**: 雙重 auth 設定下行為不明確，可能導致啟動/配對/TUI 失敗
+- **影響**: ⚠️ **升級前必須設定 `gateway.auth.mode`**，否則啟動將失敗
+
+```text
+┌──────────────────────────┐
+│  gateway 啟動             │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│  檢查 auth 設定           │
+│  token + password 都存在? │
+└────────────┬─────────────┘
+             │ 是
+             ▼
+┌──────────────────────────┐
+│  gateway.auth.mode 設定? │
+└──────┬───────────────────┘
+       │ 否                  │ 是 (token/password)
+       ▼                     ▼
+┌──────────────┐    ┌────────────────────┐
+│  啟動失敗     │    │  使用指定 auth 模式 │
+│  (fail-close)│    └────────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐ Telegram 每主題獨立 Agent 路由 ([#33647](https://github.com/openclaw/openclaw/pull/33647))
+- **用途**: 論壇群組各主題可設定不同 `agentId`，DM 主題亦支援獨立 session
+- **解決問題**: 過去所有主題共用同一 agent，無法為不同主題分配專屬 agent
+- **影響**: 可為不同工作主題（如開發、客服、行銷）分配不同 agent，提升多用途部署彈性
+
+### ⭐⭐ Web UI 西班牙語支援 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
+- **用途**: Control UI 新增 `es` 語系，含語系偵測、lazy loading 與語言選擇器標籤
+- **解決問題**: 西班牙語使用者只能使用英文介面
+- **影響**: 擴大 Control UI 的語言覆蓋範圍，改善西班牙語使用者體驗
+
+### ⭐⭐ Onboarding 網路搜尋精靈 ([#34009](https://github.com/openclaw/openclaw/pull/34009))
+- **用途**: 設定精靈新增 provider 選擇步驟與完整 provider 清單，支援 SecretRef ref-mode
+- **解決問題**: 新使用者設定網路搜尋 provider 時缺乏引導
+- **影響**: 降低初次設定門檻，SecretRef 支援提升安全性
+
+### ⭐⭐ Perplexity Search API ([#33822](https://github.com/openclaw/openclaw/pull/33822))
+- **用途**: 切換 Perplexity provider 至 Search API，支援結構化結果與語言/地區/時間篩選
+- **解決問題**: 舊版 API 不支援結構化輸出與進階篩選
+- **影響**: 搜尋結果更精確，可依語言、地區、時間範圍過濾
+
+### ⭐⭐ Docker/Podman 擴充套件預烘焙 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
+- **用途**: 新增 `OPENCLAW_EXTENSIONS` 環境變數，容器建置時可預安裝選定的 bundled extension npm 依賴
+- **解決問題**: 容器啟動時動態安裝依賴導致啟動慢且不可重現
+- **影響**: 容器部署啟動更快、更可重現
+
+### ⭐⭐ Plugin `before_prompt_build` 系統 context 欄位 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
+- **用途**: 新增 `prependSystemContext`/`appendSystemContext`，讓靜態 plugin 指引放入 system prompt 空間
+- **解決問題**: plugin 指引重複注入 user-prompt 空間，增加 token 成本且影響 provider caching
+- **影響**: 降低重複 prompt token 成本，改善 provider cache 命中率
+
+### ⭐⭐ Compaction 生命週期事件 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
+- **用途**: emit `session:compact:before`/`session:compact:after` 內部事件，含 session/count metadata
+- **解決問題**: 自動化無法一致地監聽 compaction 執行
+- **影響**: 插件與自動化可在 compaction 前後執行自訂邏輯
+
+### ⭐⭐ Google Gemini 3.1 Flash-Lite 支援
+- **用途**: 新增 `google/gemini-3.1-flash-lite-preview` 完整支援，含 model-id 正規化、預設別名、media 查詢
+- **解決問題**: 缺乏對最新 Gemini Flash-Lite 模型的原生支援
+- **影響**: 使用者可直接使用 Gemini 3.1 Flash-Lite，享有更低成本的推理選項
+
+### ⭐ Gateway `--password-file` CLI 強化
+- **用途**: 新增 `openclaw gateway run --password-file`，使用 inline `--password` 時發出警告
+- **解決問題**: inline `--password` 可能透過 process listing 洩漏密碼
+- **影響**: 提升 gateway 啟動時的密碼安全性
+
+### ⭐ Mattermost 互動式 model picker ([#38767](https://github.com/openclaw/openclaw/pull/38767))
+- **用途**: 新增 `/oc_model`/`/oc_models` 互動式 provider/model 瀏覽，修復 picker callback 更新
+- **解決問題**: Mattermost 缺乏 Telegram 風格的互動式 model 選擇介面
+- **影響**: 改善 Mattermost 使用者切換模型的體驗
+
+### ⭐ Docker 多階段建置 ([#38479](https://github.com/openclaw/openclaw/pull/38479))
+- **用途**: 重構 Dockerfile 為多階段建置，產生不含 build tools、source code 或 Bun 的最小化 runtime image；新增 `OPENCLAW_VARIANT=slim` build arg
+- **解決問題**: 單階段建置產生的 image 過大，包含不必要的建置工具
+- **影響**: 容器 image 更小、更安全，部署更快
+
+### ⭐ iOS App Store Connect 發佈準備 ([#38936](https://github.com/openclaw/openclaw/pull/38936))
+- **用途**: 對齊 iOS bundle identifier 至 `ai.openclaw.client`、更新 Watch app 圖示、Fastlane metadata/截圖自動化、Keychain ASC auth
+- **解決問題**: iOS 發佈流程缺乏自動化，bundle identifier 不一致
+- **影響**: 簡化 App Store 發佈流程，提升 CI/CD 可靠性
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Config 載入失敗關閉 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
+- **用途**: `loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，不再靜默回退至寬鬆 runtime 預設值
+- **解決問題**: 無效設定可能靜默使用寬鬆預設值，導致安全設定失效
+- **影響**: 設定錯誤時系統明確拒絕啟動，防止意外暴露
+
+```text
+┌──────────────────────┐
+│  loadConfig() 呼叫   │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  讀取 + 驗證設定      │
+└──────────┬───────────┘
+           │ 錯誤?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────┐  ┌──────────────────┐
+│ 拋出錯誤  │  │  正常載入 config  │
+│(fail-close)│  └──────────────────┘
+└──────────┘
+```
+
+### ⭐⭐⭐ Config 無效載入 fail-closed ([#28140](https://github.com/openclaw/openclaw/issues/28140))
+- **用途**: 停止將 `INVALID_CONFIG` 轉換為空 runtime config；有效設定僅透過明確的 best-effort 診斷讀取提供
+- **解決問題**: 未知 key 可能靜默丟棄安全敏感設定
+- **影響**: 設定驗證失敗時系統 fail-closed，防止安全設定被靜默忽略
+
+```text
+┌──────────────────────┐
+│  config 驗證          │
+└──────────┬───────────┘
+           │ INVALID_CONFIG?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────────┐  ┌──────────────────┐
+│ fail-closed  │  │  正常 runtime    │
+│ (不轉空 cfg) │  └──────────────────┘
+└──────┬───────┘
+       │ 診斷讀取
+       ▼
+┌──────────────┐
+│ best-effort  │
+│ 診斷路徑     │
+└──────────────┘
+```
+
+### ⭐⭐⭐ Security/archive ZIP 強化
+- **用途**: ZIP 解壓縮改用同目錄 temp file + atomic rename，解壓後重新開啟並拒絕 destination root 外的 hardlink alias race
+- **解決問題**: ZIP 解壓縮存在 hardlink path traversal 風險
+- **影響**: 防止惡意 ZIP 檔案透過 hardlink race 逃逸至目標目錄外
+
+```text
+┌──────────────────────┐
+│  ZIP 解壓縮請求       │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  同目錄 temp file 寫入│
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  atomic rename       │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  重新開啟驗證         │
+│  hardlink alias 檢查  │
+└──────────┬───────────┘
+           │ 逃逸?
+     ┌─────┴──────┐
+     │ 是          │ 否
+     ▼             ▼
+┌──────────┐  ┌──────────────┐
+│  拒絕     │  │  解壓縮完成  │
+└──────────┘  └──────────────┘
+```
+
+### ⭐⭐ Gateway 安全回應標頭 ([#30186](https://github.com/openclaw/openclaw/pull/30186))
+- **用途**: 所有 gateway HTTP 回應新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` 基線安全標頭
+- **解決問題**: 缺乏 Permissions-Policy 標頭，瀏覽器可能允許不必要的硬體存取
+- **影響**: 強化 Control UI 的瀏覽器安全邊界
+
+### ⭐⭐ 依賴安全性修補
+- **用途**: pin `hono@4.12.5`/`@hono/node-server@1.19.10` 修補 Hono 漏洞；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
+- **解決問題**: 上游依賴存在已知安全漏洞
+- **影響**: 消除已知 CVE，降低供應鏈攻擊風險
+
+### ⭐⭐ Cron 檔案權限強化 ([#36078](https://github.com/openclaw/openclaw/pull/36078))
+- **用途**: cron store/backup/run-log 強制 `0600` 權限，目錄強制 `0700`，包含舊版安裝的既有目錄
+- **解決問題**: cron 相關檔案權限過寬，可能被其他使用者讀取
+- **影響**: 防止本機多使用者環境下的 cron 資料洩漏
+
+### ⭐⭐ Security/Nostr profile mutation 強化
+- **用途**: non-loopback forwarded client header (`x-forwarded-for`/`x-real-ip`) fail-closed；拒絕 `sec-fetch-site: cross-site` 請求
+- **解決問題**: proxy 轉發或瀏覽器跨站請求可能繞過 loopback 防護
+- **影響**: 防止 proxy 環境下的 Nostr profile 偽造攻擊
+
+### ⭐⭐ Auth 標籤安全 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
+- **用途**: 移除 `/status`/`/models` 輸出中的 token 與 API key 片段
+- **解決問題**: 狀態輸出可能洩漏憑證片段
+- **影響**: 降低憑證意外暴露於日誌或螢幕截圖的風險
+
+### ⭐⭐ ACP sandbox spawn 防護
+- **用途**: 封鎖沙箱 requester session 執行 `/acp spawn`，與 `sessions_spawn({ runtime: "acp" })` 的 host-runtime 防護一致
+- **解決問題**: 沙箱 session 可透過 `/acp spawn` 指令路徑繞過沙箱邊界
+- **影響**: 關閉沙箱邊界的指令路徑政策缺口
+
+### ⭐ Config 驗證日誌清理 ([#39116](https://github.com/openclaw/openclaw/pull/39116))
+- **用途**: 清理 config 驗證 issue 路徑/訊息中的控制字元與 ANSI escape sequence
+- **解決問題**: 惡意設定內容可能透過 ANSI escape 注入誤導性終端輸出
+- **影響**: 防止設定驗證日誌被用於終端注入攻擊
+
+### ⭐ SecretRef models.json 持久化強化 ([#38955](https://github.com/openclaw/openclaw/pull/38955))
+- **用途**: 防止 SecretRef 管理的 api key 與 headers 寫入 models.json；擴大 audit/apply 覆蓋範圍
+- **解決問題**: SecretRef 管理的憑證可能以明文形式持久化至磁碟
+- **影響**: 確保 SecretRef 憑證不會意外寫入設定檔案
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Sessions bootstrap cache rollover 失效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
+- **用途**: session 重置（daily/idle/forced）後正確清除 workspace bootstrap 快取，確保 `AGENTS.md`/`MEMORY.md`/`USER.md` 更新即時生效
+- **解決問題**: session 重置後 bootstrap 快取未清除，`AGENTS.md` 等更新直到 gateway 重啟才生效
+- **影響**: 設定更新後立即反映，不再需要重啟 gateway
+
+```text
+┌──────────────────────┐
+│  session reset 觸發   │
+│  (daily/idle/forced) │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  等待 embedded run   │
+│  shutdown 完成        │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  清除 bootstrap      │
+│  cache snapshot      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  下次 session 啟動    │
+│  重新載入 AGENTS.md  │
+│  MEMORY.md / USER.md │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Cron restart catch-up 語意修正
+- **用途**: 重啟後補跑中斷的 recurring job 與錯過的 immediate cron slot；不重跑中斷的 one-shot job；防護 malformed schedule 導致啟動中止
+- **解決問題**: 重啟後 recurring job 不補跑，或 one-shot job 被錯誤重跑；malformed schedule 導致啟動失敗
+- **影響**: cron 重啟後行為符合預期，不再遺漏或重複執行
+
+```text
+┌──────────────────────┐
+│  gateway 重啟         │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  掃描中斷的 cron jobs │
+└──────────┬───────────┘
+           │
+     ┌─────┴──────────────┐
+     │ recurring job?      │ one-shot job?
+     ▼                     ▼
+┌──────────┐         ┌──────────────┐
+│  補跑    │         │  跳過        │
+│  missed  │         │  (不重跑)    │
+│  slots   │         └──────────────┘
+└──────────┘
+```
+
+### ⭐⭐⭐ Venice provider 400 錯誤修復 ([#38168](https://github.com/openclaw/openclaw/issues/38168))
+- **用途**: 對齊 per-model Venice completion-token 限制與 discovery metadata；停用不支援 function calling 的 Venice model 的 tool wiring；同步靜態 fallback catalog
+- **解決問題**: 預設 Venice 設定因 `max_completion_tokens` 超限或 unsupported-tools 導致 400 錯誤
+- **影響**: Venice provider 開箱即用，不再需要手動調整 token 限制
+
+```text
+┌──────────────────────┐
+│  Venice model 請求    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  discovery metadata  │
+│  token limit 對齊    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  支援 function call? │
+└──────┬───────────────┘
+       │ 否              │ 是
+       ▼                 ▼
+┌──────────────┐  ┌──────────────────┐
+│  停用 tool   │  │  正常 tool wiring │
+│  wiring      │  └──────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐⭐ Control UI iMessage 重複路由修復 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
+- **用途**: 保持 internal webchat turn 在 dispatcher delivery，不進行 origin-channel reroute，防止 Control UI 聊天回覆被重複送至 iMessage
+- **解決問題**: Control UI 聊天回覆被錯誤路由至 iMessage，導致重複訊息
+- **影響**: Control UI 與 iMessage 頻道路由正確隔離
+
+```text
+┌──────────────────────┐
+│  Control UI 聊天回覆  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  internal webchat?   │
+└──────┬───────────────┘
+       │ 是              │ 否
+       ▼                 ▼
+┌──────────────┐  ┌──────────────────────┐
+│  dispatcher  │  │  origin-channel route │
+│  delivery    │  │  (外部頻道)           │
+│  (不 reroute)│  └──────────────────────┘
+└──────────────┘
+```
+
+### ⭐⭐⭐ Discord DM session key 正規化
+- **用途**: 將 legacy `discord:dm:*` 與 phantom `discord:channel:<user>` session key 重寫為 `discord:direct:*`，修復多 agent Discord DM 無回覆問題
+- **解決問題**: legacy session key 格式導致 DM 落入空的 channel-shaped session，無法正確回覆
+- **影響**: Discord DM 路由正確，多 agent 設定下 DM 不再靜默失敗
+
+```text
+┌──────────────────────┐
+│  Discord DM 入站      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  session key 偵測     │
+│  discord:dm:* ?      │
+└──────┬───────────────┘
+       │ 是
+       ▼
+┌──────────────────────┐
+│  重寫為               │
+│  discord:direct:*    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  正確路由至 DM session│
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ TUI `/new` session 隔離 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
+- **用途**: `/new` 改為分配唯一 `tui-<uuid>` session key，不再重置共用 agent session；同時清理 `/new`/`/reset` 失敗文字的終端渲染
+- **解決問題**: 多個 TUI 客戶端連接同一 agent 時，`/new` 重置共用 session 導致互相收到對方的回覆
+- **影響**: 多 TUI 客戶端可獨立使用，不再互相干擾
+
+```text
+┌──────────────────────┐
+│  TUI 客戶端 A: /new  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  分配 tui-<uuid-A>   │
+│  session key         │
+└──────────────────────┘
+
+┌──────────────────────┐
+│  TUI 客戶端 B: /new  │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  分配 tui-<uuid-B>   │
+│  session key (獨立)  │
+└──────────────────────┘
+```
+
+### ⭐⭐ Memory BM25 搜尋排序修復 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
+- **用途**: 修復 `bm25RankToScore()` 中 FTS5 BM25 負值排序，確保強關鍵字匹配排在弱匹配前面
+- **解決問題**: BM25 負值排序邏輯錯誤，導致搜尋結果排序反轉或崩潰
+- **影響**: memory 關鍵字搜尋結果排序正確，最相關結果優先顯示
+
+### ⭐⭐ Telegram polling health monitor 修復 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
+- **用途**: Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟；透過共用 health evaluation 串接頻道身份
+- **解決問題**: Telegram polling 連線因長時間運行被誤判為 stale，觸發不必要的重啟/配對風暴
+- **影響**: Telegram polling 連線穩定，不再因長時間運行而被誤重啟
+
+### ⭐⭐ ACP NO_REPLY 抑制修復 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
+- **用途**: 在 `openclaw agent` logging/delivery 前過濾 ACP `NO_REPLY` lead fragment 與 silent-only final
+- **解決問題**: console-backed ACP session 在日誌/輸出中洩漏 `NO`/`NO_REPLY` 佔位符
+- **影響**: ACP session 輸出乾淨，不再出現無意義的佔位符文字
+
+### ⭐⭐ Codex CLI sandbox 預設值修正 ([#39336](https://github.com/openclaw/openclaw/pull/39336))
+- **用途**: 內建 Codex backend 從 `read-only` 改為 `workspace-write`，讓 coding run 開箱即可編輯檔案
+- **解決問題**: 預設 `read-only` sandbox 導致 Codex coding run 無法寫入檔案
+- **影響**: Codex coding agent 開箱即用，不再需要手動調整 sandbox 設定
+
+### ⭐⭐ Routing binding lookup 效能修復 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
+- **用途**: 預先以 channel/account 索引 route binding，避免 channel-account cache rollover 時全量重掃
+- **解決問題**: 大型 binding 設定下 `resolveAgentRoute` 每次呼叫需多秒
+- **影響**: 大型部署的訊息路由延遲大幅降低
+
+### ⭐⭐ Slack app_mention race dedupe ([#37033](https://github.com/openclaw/openclaw/pull/37033))
+- **用途**: `app_mention` dispatch 勝出時，抑制同 `ts` 的 `message` dispatch，防止近乎同時送達的 Slack 事件產生重複回覆
+- **解決問題**: Slack 同時送達 `app_mention` 與 `message` 事件導致重複回覆
+- **影響**: Slack 提及不再產生重複回覆
+
+### ⭐⭐ Telegram DM draft 重複顯示修復 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
+- **用途**: 最終訊息實體化後清除 stale DM draft preview，包含 DM topic lookup 失敗時的 threadless fallback
+- **解決問題**: 串流結束後短暫出現重複回覆（preview + final 同時顯示）
+- **影響**: Telegram DM 串流回覆顯示乾淨，不再出現短暫重複
+
+### ⭐⭐ LINE auth boundary 強化
+- **用途**: 統一 LINE webhook authn/z 邊界語意，含 pairing-store account scoping、DM/group allowlist 分離、fail-closed webhook auth、replay/duplication 控制
+- **解決問題**: LINE webhook 認證邊界不一致，存在 replay 與重複處理風險
+- **影響**: LINE 頻道安全性與可靠性大幅提升
+
+### ⭐ Onboarding local tools.profile 預設值修正
+- **用途**: 未設定 local `tools.profile` 時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
+- **解決問題**: 新本地安裝預設 `messaging` profile，缺少檔案與 runtime 工具
+- **影響**: 本地安裝開箱即有完整工具集
+
+### ⭐ Browser session cleanup ([#36666](https://github.com/openclaw/openclaw/issues/36666))
+- **用途**: 追蹤 session-scoped browser tool 開啟的分頁，在 `sessions.reset`/`sessions.delete` 時關閉
+- **解決問題**: session 結束後瀏覽器分頁殘留，導致記憶體持續增長
+- **影響**: 長時間運行的部署記憶體使用更穩定
+
+### ⭐ iMessage echo loop 強化 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
+- **用途**: 清除 assistant 內部 scaffolding、丟棄反射的 assistant-content 訊息、延長 echo-cache 保留時間、在放大至佇列溢出前抑制重複 loop 流量
+- **解決問題**: iMessage echo loop 可能放大至佇列溢出，導致服務中斷
+- **影響**: iMessage 部署更穩定，防止 echo loop 導致的服務降級
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 4 | 9 | 5 | 18 項 |
+| 安全性 | 3 | 6 | 2 | 11 項 |
+| 錯誤修復 | 6 | 10 | 3 | 19 項 |
+| **總計** | **13** | **25** | **10** | **48 項** |
+
+**發佈日期**: 2026-03-08
+**版本**: 2026.3.7
+**狀態**: Production Ready
+**GitHub Release**: [v2026.3.7](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -12,6 +12,31 @@
 
 ### 功能更新 (Features)
 - ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
+
+```text
+  無插件（預設）                有 ContextEngine 插件
+  ┌─────────────────┐          ┌─────────────────────┐
+  │  LegacyContext  │          │  Plugin 實作         │
+  │  Engine（內建） │          │  (e.g. lossless-claw)│
+  └────────┬────────┘          └──────────┬──────────┘
+           │                              │
+           └──────────┬───────────────────┘
+                      ▼
+           ┌─────────────────────┐
+           │  slot registry      │
+           │  bootstrap → ingest │
+           │  → assemble         │
+           │  → compact          │
+           │  → afterTurn        │
+           └─────────────────────┘
+                      │
+                      ▼
+           ┌─────────────────────┐
+           │  核心邏輯不變        │
+           │  零行為差異（無插件）│
+           └─────────────────────┘
+```
+
 - ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
 - ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
 

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -2,6 +2,12 @@
 
 [GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
 
+## ⚠️ Breaking Change
+
+**Gateway auth 模式強制設定**：同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，**升級前必須在設定檔中明確指定 `gateway.auth.mode: token` 或 `gateway.auth.mode: password`**，否則 gateway 將無法啟動。詳見 [#35094](https://github.com/openclaw/openclaw/pull/35094)。
+
+---
+
 ## 概述
 
 ### 功能更新 (Features)

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -1,645 +1,373 @@
-# OpenClaw v2026.3.7 版本發佈說明
+# OpenClaw v2026.3.8 版本發佈說明
 
-[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
-
-## ⚠️ Breaking Change
-
-**Gateway auth 模式強制設定**：同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，**升級前必須在設定檔中明確指定 `gateway.auth.mode: token` 或 `gateway.auth.mode: password`**，否則 gateway 將無法啟動。詳見 [#35094](https://github.com/openclaw/openclaw/pull/35094)。
-
----
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8)
 
 ## 概述
 
 ### 功能更新 (Features)
-- ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
 
-```text
-  無插件（預設）                有 ContextEngine 插件
-  ┌─────────────────┐          ┌─────────────────────┐
-  │  LegacyContext  │          │  Plugin 實作         │
-  │  Engine（內建） │          │  (e.g. lossless-claw)│
-  └────────┬────────┘          └──────────┬──────────┘
-           │                              │
-           └──────────┬───────────────────┘
-                      ▼
-           ┌─────────────────────┐
-           │  slot registry      │
-           │  bootstrap → ingest │
-           │  → assemble         │
-           │  → compact          │
-           │  → afterTurn        │
-           └─────────────────────┘
-                      │
-                      ▼
-           ┌─────────────────────┐
-           │  核心邏輯不變        │
-           │  零行為差異（無插件）│
-           └─────────────────────┘
-```
-
-- ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
-- ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
-
-```text
-ACP 頻道整合架構（v2026.3.7）
-
-  Discord                        Telegram
-  ┌─────────────────┐            ┌─────────────────────┐
-  │  頻道 #dev      │            │  論壇主題 #backend  │
-  │  /acp spawn     │            │  /acp spawn         │
-  │  --channel here │            │  --thread here      │
-  └────────┬────────┘            └──────────┬──────────┘
-           │                                │
-           ▼                                ▼
-  ┌─────────────────────────────────────────────────────┐
-  │              持久化 Binding 儲存                     │
-  │   channel/topic  ──►  ACP session ID               │
-  │   (跨重啟保存)                                       │
-  └──────────────────────────┬──────────────────────────┘
-                             │
-                             ▼
-  ┌─────────────────────────────────────────────────────┐
-  │              路由解析 resolveBinding()               │
-  │   後續訊息  ──►  綁定的 ACP session                 │
-  │   per-topic agentId override 支援                   │
-  └─────────────────────────────────────────────────────┘
-```
-
-- ⭐⭐⭐ **Gateway auth 模式強制設定（Breaking）**：同時設定 token 與 password 時須明確指定 `gateway.auth.mode` ([#35094](https://github.com/openclaw/openclaw/pull/35094))
-- ⭐⭐ **Telegram 每主題獨立 Agent 路由**：論壇群組各主題可設定不同 agentId ([#33647](https://github.com/openclaw/openclaw/pull/33647))
-- ⭐⭐ **Web UI 西班牙語支援**：Control UI 新增 `es` 語系，含 lazy loading 與語言選擇器 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
-- ⭐⭐ **Onboarding 網路搜尋精靈**：設定精靈新增 provider 選擇步驟，支援 SecretRef ref-mode ([#34009](https://github.com/openclaw/openclaw/pull/34009))
-- ⭐⭐ **Perplexity Search API**：切換至 Search API，支援結構化結果與語言/地區/時間篩選 ([#33822](https://github.com/openclaw/openclaw/pull/33822))
-- ⭐⭐ **Gateway SecretRef auth 支援**：`gateway.auth.token` 支援 SecretRef，含 auth-mode 防護 ([#35094](https://github.com/openclaw/openclaw/pull/35094))
-- ⭐⭐ **Docker/Podman 擴充套件預烘焙**：`OPENCLAW_EXTENSIONS` 環境變數支援容器建置時預安裝依賴 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
-- ⭐⭐ **Plugin `before_prompt_build` 系統 context 欄位**：新增 `prependSystemContext`/`appendSystemContext` 降低 prompt token 成本 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
-- ⭐⭐ **Compaction 生命週期事件**：emit `session:compact:before/after` 事件供自動化監聽 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
-- ⭐⭐ **Google Gemini 3.1 Flash-Lite**：新增 `google/gemini-3.1-flash-lite-preview` 完整支援
-- ⭐ **Gateway `--password-file` CLI 強化**：新增 `--password-file` 參數，避免密碼透過 process listing 洩漏
-- ⭐ **Mattermost 互動式 model picker**：新增 `/oc_model` 互動式 provider/model 瀏覽 ([#38767](https://github.com/openclaw/openclaw/pull/38767))
-- ⭐ **Docker 多階段建置**：重構 Dockerfile 為多階段建置，產生最小化 runtime image ([#38479](https://github.com/openclaw/openclaw/pull/38479))
-- ⭐ **iOS App Store Connect 發佈準備**：對齊 bundle identifier、Fastlane 自動化、Keychain ASC auth ([#38936](https://github.com/openclaw/openclaw/pull/38936))
+- ⭐⭐⭐ **備份工具**：新增 `openclaw backup create` / `backup verify`，支援本地狀態封存與完整性驗證 ([#40163](https://github.com/openclaw/openclaw/pull/40163))
+- ⭐⭐⭐ **ACP Provenance**：新增 ACP ingress 來源元資料與收據注入，可追蹤 ACP 呼叫鏈 ([#40473](https://github.com/openclaw/openclaw/pull/40473))
+- ⭐⭐ **macOS 遠端 Gateway 上線**：新增遠端 gateway token 欄位，保留非明文 token 設定 ([#40187](https://github.com/openclaw/openclaw/pull/40187))
+- ⭐⭐ **Talk 模式靜音逾時**：新增 `talk.silenceTimeoutMs` 設定，可自訂靜音後自動送出的等待時間 ([#39607](https://github.com/openclaw/openclaw/pull/39607))
+- ⭐⭐ **TUI 工作區推斷**：在已設定的 agent workspace 內啟動時，自動推斷當前 agent ([#39591](https://github.com/openclaw/openclaw/pull/39591))
+- ⭐⭐ **Brave LLM Context 搜尋**：新增 `tools.web.search.brave.mode: "llm-context"` 選項，回傳帶來源元資料的摘要片段 ([#33383](https://github.com/openclaw/openclaw/pull/33383))
+- ⭐ **版本號含 git hash**：`openclaw --version` 輸出包含短 git commit hash ([#39712](https://github.com/openclaw/openclaw/pull/39712))
+- ⭐ **Web 搜尋供應商排序**：依字母順序排列供應商，多 key 自動偵測優先選 Grok ([#40259](https://github.com/openclaw/openclaw/pull/40259))
+- ⭐ **Brave 搜尋文件更新**：補回 $5/月免費額度說明，更新方案名稱 ([#40111](https://github.com/openclaw/openclaw/pull/40111))
 
 ### 安全性提升 (Security)
-- ⭐⭐⭐ **Config 載入失敗關閉**：`loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，防止靜默回退至寬鬆預設值 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
-- ⭐⭐⭐ **Config 無效載入 fail-closed**：停止將 `INVALID_CONFIG` 轉換為空 runtime config ([#28140](https://github.com/openclaw/openclaw/issues/28140))
-- ⭐⭐⭐ **Security/archive ZIP 強化**：ZIP 解壓縮使用同目錄 temp + atomic rename，拒絕 hardlink alias race
-- ⭐⭐ **Gateway 安全回應標頭**：新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` ([#30186](https://github.com/openclaw/openclaw/pull/30186))
-- ⭐⭐ **依賴安全性修補**：修補 Hono 漏洞（pin `hono@4.12.5`）；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
-- ⭐⭐ **Cron 檔案權限強化**：cron store/backup/run-log 強制 `0600`，目錄強制 `0700` ([#36078](https://github.com/openclaw/openclaw/pull/36078))
-- ⭐⭐ **Security/Nostr profile mutation 強化**：non-loopback forwarded header fail-closed，拒絕 cross-site 請求
-- ⭐⭐ **Auth 標籤安全**：移除 `/status`/`/models` 中的 token/API key 片段 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
-- ⭐⭐ **ACP sandbox spawn 防護**：封鎖沙箱 session 執行 `/acp spawn`，與 `sessions_spawn` 政策一致
-- ⭐ **Config 驗證日誌清理**：清理 config 驗證訊息中的控制字元與 ANSI escape sequence ([#39116](https://github.com/openclaw/openclaw/pull/39116))
-- ⭐ **SecretRef models.json 持久化強化**：防止 SecretRef 管理的 api key 寫入 models.json ([#38955](https://github.com/openclaw/openclaw/pull/38955))
+
+- ⭐⭐⭐ **Browser/SSRF 防護**：封鎖嚴格瀏覽導航流程中的私有網路中間重導向 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- ⭐⭐⭐ **MS Teams 授權修正**：`groupPolicy: "allowlist"` 在設定路由 allowlist 時仍正確執行寄件者限制 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- ⭐⭐⭐ **system.run 腳本綁定**：將已核准的 `bun`/`deno run` 腳本操作數綁定至磁碟快照，防止核准後腳本被竄改 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- ⭐⭐ **Skills 下載安裝路徑固定**：下載封存前固定每個 skill 的工具根目錄，防止路徑重綁定寫入預期目錄外 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
 
 ### 錯誤修復 (Bug Fixes)
-- ⭐⭐⭐ **Sessions bootstrap cache rollover 失效**：session 重置後正確清除 bootstrap 快取，確保 `AGENTS.md` 等更新即時生效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
-- ⭐⭐⭐ **Cron restart catch-up 語意**：重啟後正確補跑中斷的 recurring job，不重跑 one-shot job ([#34466](https://github.com/openclaw/openclaw/pull/34466))
-- ⭐⭐⭐ **Venice provider 400 錯誤**：對齊 per-model token 限制、停用不支援 function calling 的 tool wiring ([#38168](https://github.com/openclaw/openclaw/issues/38168))
-- ⭐⭐⭐ **Control UI iMessage 重複路由**：修復 Control UI 聊天回覆被重複送至 iMessage 的問題 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
-- ⭐⭐⭐ **Discord DM session key 正規化**：修復 legacy `discord:dm:*` key 導致 DM 無回覆的問題
-- ⭐⭐⭐ **TUI `/new` session 隔離**：`/new` 改為分配唯一 `tui-<uuid>` session key，修復多 TUI 客戶端互相收到對方回覆的問題 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
-- ⭐⭐ **Memory BM25 搜尋排序**：修復 `bm25RankToScore()` 負值排序，強關鍵字匹配正確排在前面 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
-- ⭐⭐ **Telegram polling health monitor**：Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
-- ⭐⭐ **ACP NO_REPLY 抑制**：過濾 ACP `NO_REPLY` lead fragment，console-backed ACP session 不再洩漏佔位符 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
-- ⭐⭐ **Codex CLI sandbox 預設值**：內建 Codex backend 從 `read-only` 改為 `workspace-write` ([#39336](https://github.com/openclaw/openclaw/pull/39336))
-- ⭐⭐ **Routing binding lookup 效能**：預先索引 route binding，修復大型 binding 設定下 `resolveAgentRoute` 多秒延遲 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
-- ⭐⭐ **Slack app_mention race dedupe**：修復 Slack 近乎同時送達導致重複回覆的問題 ([#37033](https://github.com/openclaw/openclaw/pull/37033))
-- ⭐⭐ **Telegram DM draft 重複顯示**：修復串流結束後短暫出現重複回覆的問題 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
-- ⭐⭐ **LINE auth boundary 強化**：統一 LINE webhook authn/z 邊界語意，含 replay/duplication 控制
-- ⭐ **Onboarding local tools.profile 預設值**：未設定時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
-- ⭐ **Browser session cleanup**：session 重置/刪除時關閉追蹤的瀏覽器分頁，防止記憶體洩漏 ([#36666](https://github.com/openclaw/openclaw/issues/36666))
-- ⭐ **iMessage echo loop 強化**：清除 assistant 內部 scaffolding，防止 echo 放大至佇列溢出 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
+
+- ⭐⭐⭐ **Telegram DM 重複回覆**：每個 agent 對 DM 去重，防止同一訊息觸發兩次回覆 ([#40519](https://github.com/openclaw/openclaw/pull/40519))
+- ⭐⭐⭐ **Gateway 重啟逾時復原**：重啟觸發的關機排水逾時時以非零退出，讓 launchd/systemd 正確重啟 ([#40380](https://github.com/openclaw/openclaw/pull/40380))
+- ⭐⭐⭐ **Config 寫入後 secrets 快照保留**：config 寫入後保留 secrets runtime 解析快照，後續讀取仍能取得 file-backed secret 值 ([#37313](https://github.com/openclaw/openclaw/pull/37313))
+- ⭐⭐ **macOS launchd 重生偵測**：以 `XPC_SERVICE_NAME` 作為 launchd 監管提示，避免嘗試分離式自我重生 ([#20555](https://github.com/openclaw/openclaw/pull/20555))
+- ⭐⭐ **Gateway config 重啟防護**：啟動/重啟前驗證 config，防止無效 config 造成重啟迴圈 ([#38699](https://github.com/openclaw/openclaw/pull/38699))
+- ⭐⭐ **Telegram poll 重啟清理**：關機或強制重啟時中止進行中的 Telegram API fetch，防止舊 `getUpdates` 長輪詢與新 runner 衝突 ([#23950](https://github.com/openclaw/openclaw/pull/23950))
+- ⭐⭐ **Cron 重啟補跑節流**：限制啟動時立即補跑的錯過任務數量，防止重啟爆量或靜默跳過逾期任務 ([#18925](https://github.com/openclaw/openclaw/pull/18925))
+- ⭐⭐ **ACP session 歷史記錄**：持久化成功 ACP 子執行的逐字稿，記錄 ACP spawn session 血緣 ([#40137](https://github.com/openclaw/openclaw/pull/40137))
+- ⭐⭐ **macOS 更新 launchd 服務復原**：更新前重新啟用已停用的 LaunchAgent，防止 `openclaw update` 卡在重啟步驟 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- ⭐⭐ **Cron/Telegram 公告投遞**：文字公告任務透過真實輸出 adapter 投遞，修正 `delivered: true` 但訊息未送達的問題 ([#40575](https://github.com/openclaw/openclaw/pull/40575))
+- ⭐ **Matrix DM 路由**：為損壞的 `m.direct` homeserver 新增安全 fallback，優先使用明確 room binding ([#19736](https://github.com/openclaw/openclaw/pull/19736))
+- ⭐ **Feishu plugin 上線快取清除**：安裝 channel plugin 後重新載入 registry 前清除短暫快取 ([#39752](https://github.com/openclaw/openclaw/pull/39752))
+- ⭐ **TUI 淺色主題偵測**：透過 `COLORFGBG` 偵測淺色終端背景，選用符合 WCAG AA 的淺色調色盤 ([#38636](https://github.com/openclaw/openclaw/pull/38636))
+- ⭐ **GPT-5.4 context window 修正**：使用正確的 1,050,000 token context window 與 128,000 max tokens ([#37876](https://github.com/openclaw/openclaw/pull/37876))
+- ⭐ **Perplexity OpenRouter 相容性**：恢復 legacy `OPENROUTER_API_KEY` 與 `sk-or-...` 的 Perplexity 相容性 ([#39937](https://github.com/openclaw/openclaw/pull/39937))
+- ⭐ **Bedrock 配額錯誤偵測**：將 Amazon Bedrock `Too many tokens per day` 識別為速率限制 ([#39377](https://github.com/openclaw/openclaw/pull/39377))
+- ⭐ **Mattermost 執行緒回覆**：在執行緒內回覆時保持 `root_id` 固定於執行緒根 ([#27744](https://github.com/openclaw/openclaw/pull/27744))
+- ⭐ **Browser relay bind host**：新增 `browser.relayBindHost` 供 WSL2 等跨命名空間環境使用 ([#39364](https://github.com/openclaw/openclaw/pull/39364))
+- ⭐ **Podman SELinux 自動偵測**：自動偵測 SELinux 模式並為 bind mount 加上 `:Z` relabel ([#39449](https://github.com/openclaw/openclaw/pull/39449))
 
 ---
 
 ## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ Context Engine 插件介面 ([#22201](https://github.com/openclaw/openclaw/pull/22201))
-- **用途**: 新增 `ContextEngine` 插件槽，支援 `bootstrap`、`ingest`、`assemble`、`compact`、`afterTurn`、`prepareSubagentSpawn`、`onSubagentEnded` 等完整生命週期 hook；提供 `LegacyContextEngine` wrapper 保留現有壓縮行為
-- **解決問題**: 過去無法在不修改核心壓縮邏輯的情況下替換 context 管理策略，社群插件（如 `lossless-claw`）無法提供替代方案
-- **影響**: 未設定 context engine 插件時行為完全不變；設定後可完全接管 context 生命週期，大幅提升可擴充性
+### ⭐⭐⭐ 備份工具：`openclaw backup create` / `backup verify` ([#40163](https://github.com/openclaw/openclaw/pull/40163))
+- **用途**: 新增本地狀態封存指令，支援 `--only-config`、`--no-include-workspace` 選項，並在破壞性操作流程中提示備份建議。
+- **解決問題**: 過去無內建備份機制，升級或重設時容易遺失設定與工作區資料。
+- **影響**: 使用者可在升級或重大變更前快速建立可驗證的備份封存，降低資料遺失風險。
 
 ```text
 ┌─────────────────────┐
-│  Plugin 設定解析     │
-│  (config-driven)    │
-└──────────┬──────────┘
-           │ 找到 ContextEngine plugin
-           ▼
+│  openclaw backup    │
+│  create [options]   │
+└─────────┬───────────┘
+          │
+          ▼
 ┌─────────────────────┐     ┌──────────────────────┐
-│  slot registry 註冊  │────►│  AsyncLocalStorage   │
-│  (bootstrap hook)   │     │  scoped subagent ctx │
-└──────────┬──────────┘     └──────────────────────┘
-           │
-           ▼
-┌─────────────────────┐
-│  每個 turn 執行      │
-│  ingest → assemble  │
-│  → afterTurn        │
-└──────────┬──────────┘
-           │ 需要壓縮時
-           ▼
-┌─────────────────────┐
-│  compact hook       │
-│  (plugin 自訂邏輯)   │
-└─────────────────────┘
+│  收集 config /      │────►│  寫入 manifest +     │
+│  workspace 資料     │     │  payload 封存檔       │
+└─────────────────────┘     └──────────┬───────────┘
+                                        │
+                                        ▼
+                             ┌──────────────────────┐
+                             │  openclaw backup     │
+                             │  verify <archive>    │
+                             └──────────┬───────────┘
+                                        │
+                                        ▼
+                             ┌──────────────────────┐
+                             │  manifest / payload  │
+                             │  驗證通過 ✓          │
+                             └──────────────────────┘
 ```
 
-### ⭐⭐⭐ ACP 持久化頻道綁定 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
-- **用途**: 新增持久化的 Discord 頻道與 Telegram 主題 ACP session 綁定儲存、路由解析，以及 CLI/文件支援
-- **解決問題**: 過去 ACP thread 目標在重啟後消失，無法一致管理
-- **影響**: ACP 綁定跨重啟保存，可透過 CLI 統一管理，大幅提升長期部署的穩定性
+### ⭐⭐⭐ ACP Provenance：ingress 來源元資料與收據注入 ([#40473](https://github.com/openclaw/openclaw/pull/40473))
+- **用途**: 新增 `openclaw acp --provenance off|meta|meta+receipt`，讓 OpenClaw agent 可保留並回報 ACP 呼叫來源，含 session trace ID。
+- **解決問題**: ACP 呼叫鏈缺乏可追蹤性，難以診斷跨 agent 的呼叫來源。
+- **影響**: 可在 ACP session 中注入可見收據，提升多 agent 協作的可觀測性與除錯能力。
 
 ```text
-┌──────────────────┐
-│  /acp spawn      │
-│  --channel here  │
-└────────┬─────────┘
-         │
-         ▼
-┌──────────────────┐     ┌─────────────────────┐
-│  binding 寫入    │────►│  持久化儲存          │
-│  (channel/topic) │     │  (disk-backed)       │
-└──────────────────┘     └──────────┬──────────┘
-                                    │ 重啟後
-                                    ▼
-                         ┌─────────────────────┐
-                         │  路由解析            │
-                         │  resolveBinding()   │
-                         └─────────────────────┘
-                                    │
-                                    ▼
-                         ┌─────────────────────┐
-                         │  ACP session 恢復    │
-                         └─────────────────────┘
+┌──────────────┐   ACP request    ┌──────────────────────┐
+│  呼叫端      │─────────────────►│  OpenClaw ACP ingress│
+│  (agent/CLI) │                  └──────────┬───────────┘
+└──────────────┘                             │ attach provenance
+                                             │ (trace ID, origin)
+                                             ▼
+                                  ┌──────────────────────┐
+                                  │  目標 agent session  │
+                                  │  (meta / receipt 可  │
+                                  │   見於 transcript)   │
+                                  └──────────────────────┘
 ```
 
-### ⭐⭐⭐ Telegram ACP 主題綁定 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
-- **用途**: 支援 Telegram Mac Unicode dash 前綴的 `/acp spawn` 參數解析；新增 `--thread here|auto` 綁定 Telegram 論壇主題；路由後續訊息至 ACP session；新增可操作的 Telegram 核准按鈕；成功綁定後在主題內釘選確認訊息
-- **解決問題**: Telegram Mac 客戶端的 Unicode dash 導致指令解析失敗；論壇主題無法持久綁定 ACP session
-- **影響**: Telegram 論壇群組可為每個主題建立獨立 ACP session，提升多主題工作流程的組織性
+### ⭐⭐ macOS 遠端 Gateway 上線 ([#40187](https://github.com/openclaw/openclaw/pull/40187))
+- **用途**: macOS onboarding 新增遠端 gateway token 欄位，保留現有非明文 token 設定直到明確替換，並在 token 格式無法直接使用時發出警告。
+- **解決問題**: 遠端模式設定流程不完整，非明文 token 可能被意外覆蓋。
+- **影響**: 遠端 gateway 設定更安全、更直覺。
 
-```text
-┌─────────────────────────┐
-│  Telegram 訊息           │
-│  /acp spawn --thread here│
-└───────────┬─────────────┘
-            │ Unicode dash 正規化
-            ▼
-┌─────────────────────────┐
-│  參數解析                │
-│  (--thread here/auto)   │
-└───────────┬─────────────┘
-            │
-            ▼
-┌─────────────────────────┐     ┌──────────────────┐
-│  topic binding 建立      │────►│  釘選確認訊息     │
-└───────────┬─────────────┘     └──────────────────┘
-            │
-            ▼
-┌─────────────────────────┐
-│  後續訊息路由至           │
-│  綁定的 ACP session      │
-└─────────────────────────┘
-```
+### ⭐⭐ Talk 模式靜音逾時設定 ([#39607](https://github.com/openclaw/openclaw/pull/39607))
+- **用途**: 新增頂層 `talk.silenceTimeoutMs` 設定，控制 Talk 模式在靜音後等待多久才自動送出當前逐字稿。
+- **解決問題**: 各平台靜音等待時間固定，無法依使用情境調整。
+- **影響**: 使用者可依說話節奏自訂靜音閾值，提升語音互動體驗。
 
-### ⭐⭐⭐ Gateway auth 模式強制設定 — Breaking Change ([#35094](https://github.com/openclaw/openclaw/pull/35094))
-- **用途**: 同時設定 `gateway.auth.token` 與 `gateway.auth.password`（含 SecretRef）時，須明確設定 `gateway.auth.mode` 為 `token` 或 `password`；同時新增 `gateway.auth.token` 的 SecretRef 支援
-- **解決問題**: 雙重 auth 設定下行為不明確，可能導致啟動/配對/TUI 失敗
-- **影響**: ⚠️ **升級前必須設定 `gateway.auth.mode`**，否則啟動將失敗
+### ⭐⭐ TUI 工作區 Agent 自動推斷 ([#39591](https://github.com/openclaw/openclaw/pull/39591))
+- **用途**: 在已設定的 agent workspace 內啟動 TUI 時，自動推斷當前 agent，同時保留明確 `agent:` session 目標。
+- **解決問題**: 在 agent workspace 目錄內啟動時仍需手動指定 agent，操作繁瑣。
+- **影響**: 減少切換 agent workspace 時的手動步驟。
 
-```text
-┌──────────────────────────┐
-│  gateway 啟動             │
-└────────────┬─────────────┘
-             │
-             ▼
-┌──────────────────────────┐
-│  檢查 auth 設定           │
-│  token + password 都存在? │
-└────────────┬─────────────┘
-             │ 是
-             ▼
-┌──────────────────────────┐
-│  gateway.auth.mode 設定? │
-└──────┬───────────────────┘
-       │ 否                  │ 是 (token/password)
-       ▼                     ▼
-┌──────────────┐    ┌────────────────────┐
-│  啟動失敗     │    │  使用指定 auth 模式 │
-│  (fail-close)│    └────────────────────┘
-└──────────────┘
-```
+### ⭐⭐ Brave LLM Context 搜尋模式 ([#33383](https://github.com/openclaw/openclaw/pull/33383))
+- **用途**: 新增 `tools.web.search.brave.mode: "llm-context"` 選項，讓 `web_search` 呼叫 Brave LLM Context endpoint，回傳帶來源元資料的摘要片段。
+- **解決問題**: 標準搜尋結果缺乏結構化摘要，LLM 需自行解析原始網頁內容。
+- **影響**: 搜尋結果品質提升，grounding 更精確。
 
-### ⭐⭐ Telegram 每主題獨立 Agent 路由 ([#33647](https://github.com/openclaw/openclaw/pull/33647))
-- **用途**: 論壇群組各主題可設定不同 `agentId`，DM 主題亦支援獨立 session
-- **解決問題**: 過去所有主題共用同一 agent，無法為不同主題分配專屬 agent
-- **影響**: 可為不同工作主題（如開發、客服、行銷）分配不同 agent，提升多用途部署彈性
+### ⭐ 版本號含 git commit hash ([#39712](https://github.com/openclaw/openclaw/pull/39712))
+- **用途**: `openclaw --version` 輸出包含短 git commit hash（若元資料可用）。
+- **解決問題**: 難以區分同版本號的不同建置。
+- **影響**: 除錯與回報問題時可精確識別建置來源。
 
-### ⭐⭐ Web UI 西班牙語支援 ([#35038](https://github.com/openclaw/openclaw/pull/35038))
-- **用途**: Control UI 新增 `es` 語系，含語系偵測、lazy loading 與語言選擇器標籤
-- **解決問題**: 西班牙語使用者只能使用英文介面
-- **影響**: 擴大 Control UI 的語言覆蓋範圍，改善西班牙語使用者體驗
+### ⭐ Web 搜尋供應商字母排序 ([#40259](https://github.com/openclaw/openclaw/pull/40259))
+- **用途**: 依字母順序排列 runtime 選擇、onboarding/configure picker 中的供應商，多 key 自動偵測優先選 Grok。
+- **解決問題**: 供應商排序不一致，影響使用者體驗。
+- **影響**: 供應商列表保持中立一致。
 
-### ⭐⭐ Onboarding 網路搜尋精靈 ([#34009](https://github.com/openclaw/openclaw/pull/34009))
-- **用途**: 設定精靈新增 provider 選擇步驟與完整 provider 清單，支援 SecretRef ref-mode
-- **解決問題**: 新使用者設定網路搜尋 provider 時缺乏引導
-- **影響**: 降低初次設定門檻，SecretRef 支援提升安全性
-
-### ⭐⭐ Perplexity Search API ([#33822](https://github.com/openclaw/openclaw/pull/33822))
-- **用途**: 切換 Perplexity provider 至 Search API，支援結構化結果與語言/地區/時間篩選
-- **解決問題**: 舊版 API 不支援結構化輸出與進階篩選
-- **影響**: 搜尋結果更精確，可依語言、地區、時間範圍過濾
-
-### ⭐⭐ Docker/Podman 擴充套件預烘焙 ([#32223](https://github.com/openclaw/openclaw/pull/32223))
-- **用途**: 新增 `OPENCLAW_EXTENSIONS` 環境變數，容器建置時可預安裝選定的 bundled extension npm 依賴
-- **解決問題**: 容器啟動時動態安裝依賴導致啟動慢且不可重現
-- **影響**: 容器部署啟動更快、更可重現
-
-### ⭐⭐ Plugin `before_prompt_build` 系統 context 欄位 ([#35177](https://github.com/openclaw/openclaw/pull/35177))
-- **用途**: 新增 `prependSystemContext`/`appendSystemContext`，讓靜態 plugin 指引放入 system prompt 空間
-- **解決問題**: plugin 指引重複注入 user-prompt 空間，增加 token 成本且影響 provider caching
-- **影響**: 降低重複 prompt token 成本，改善 provider cache 命中率
-
-### ⭐⭐ Compaction 生命週期事件 ([#16788](https://github.com/openclaw/openclaw/pull/16788))
-- **用途**: emit `session:compact:before`/`session:compact:after` 內部事件，含 session/count metadata
-- **解決問題**: 自動化無法一致地監聽 compaction 執行
-- **影響**: 插件與自動化可在 compaction 前後執行自訂邏輯
-
-### ⭐⭐ Google Gemini 3.1 Flash-Lite 支援
-- **用途**: 新增 `google/gemini-3.1-flash-lite-preview` 完整支援，含 model-id 正規化、預設別名、media 查詢
-- **解決問題**: 缺乏對最新 Gemini Flash-Lite 模型的原生支援
-- **影響**: 使用者可直接使用 Gemini 3.1 Flash-Lite，享有更低成本的推理選項
-
-### ⭐ Gateway `--password-file` CLI 強化
-- **用途**: 新增 `openclaw gateway run --password-file`，使用 inline `--password` 時發出警告
-- **解決問題**: inline `--password` 可能透過 process listing 洩漏密碼
-- **影響**: 提升 gateway 啟動時的密碼安全性
-
-### ⭐ Mattermost 互動式 model picker ([#38767](https://github.com/openclaw/openclaw/pull/38767))
-- **用途**: 新增 `/oc_model`/`/oc_models` 互動式 provider/model 瀏覽，修復 picker callback 更新
-- **解決問題**: Mattermost 缺乏 Telegram 風格的互動式 model 選擇介面
-- **影響**: 改善 Mattermost 使用者切換模型的體驗
-
-### ⭐ Docker 多階段建置 ([#38479](https://github.com/openclaw/openclaw/pull/38479))
-- **用途**: 重構 Dockerfile 為多階段建置，產生不含 build tools、source code 或 Bun 的最小化 runtime image；新增 `OPENCLAW_VARIANT=slim` build arg
-- **解決問題**: 單階段建置產生的 image 過大，包含不必要的建置工具
-- **影響**: 容器 image 更小、更安全，部署更快
-
-### ⭐ iOS App Store Connect 發佈準備 ([#38936](https://github.com/openclaw/openclaw/pull/38936))
-- **用途**: 對齊 iOS bundle identifier 至 `ai.openclaw.client`、更新 Watch app 圖示、Fastlane metadata/截圖自動化、Keychain ASC auth
-- **解決問題**: iOS 發佈流程缺乏自動化，bundle identifier 不一致
-- **影響**: 簡化 App Store 發佈流程，提升 CI/CD 可靠性
+### ⭐ Brave 搜尋文件更新 ([#40111](https://github.com/openclaw/openclaw/pull/40111))
+- **用途**: 補回 $5/月免費額度說明，更新已停用的方案名稱，並說明舊訂閱的有效性。
+- **解決問題**: 文件資訊過時，使用者難以判斷目前可用方案。
+- **影響**: 降低 Brave 搜尋設定的困惑。
 
 ---
 
 ## 安全性提升 (Security) - by Star Rating
 
-### ⭐⭐⭐ Config 載入失敗關閉 ([#9040](https://github.com/openclaw/openclaw/pull/9040))
-- **用途**: `loadConfig()` 遇到驗證或讀取錯誤時 fail-closed，不再靜默回退至寬鬆 runtime 預設值
-- **解決問題**: 無效設定可能靜默使用寬鬆預設值，導致安全設定失效
-- **影響**: 設定錯誤時系統明確拒絕啟動，防止意外暴露
+### ⭐⭐⭐ Browser/SSRF 私有網路重導向封鎖 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- **用途**: 在嚴格瀏覽導航流程中封鎖私有網路中間重導向，無法檢查重導向鏈時直接失敗。
+- **解決問題**: 攻擊者可透過公開 URL 重導向至私有網路端點，繞過 SSRF 防護。
+- **影響**: 防止透過瀏覽器工具進行的 SSRF 攻擊，提升多租戶與公開部署的安全性。
 
 ```text
-┌──────────────────────┐
-│  loadConfig() 呼叫   │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  讀取 + 驗證設定      │
-└──────────┬───────────┘
-           │ 錯誤?
-     ┌─────┴──────┐
-     │ 是          │ 否
-     ▼             ▼
-┌──────────┐  ┌──────────────────┐
-│ 拋出錯誤  │  │  正常載入 config  │
-│(fail-close)│  └──────────────────┘
-└──────────┘
+┌──────────────────┐   navigate    ┌──────────────────────┐
+│  Browser tool    │──────────────►│  URL 重導向鏈檢查    │
+│  request         │               └──────────┬───────────┘
+└──────────────────┘                          │
+                                              ▼
+                               ┌──────────────────────────┐
+                               │  中間跳轉是私有網路？    │
+                               └──────┬───────────┬───────┘
+                                      │ 是         │ 否
+                                      ▼            ▼
+                               ┌──────────┐  ┌──────────┐
+                               │  拒絕 ✗  │  │  允許 ✓  │
+                               └──────────┘  └──────────┘
 ```
 
-### ⭐⭐⭐ Config 無效載入 fail-closed ([#28140](https://github.com/openclaw/openclaw/issues/28140))
-- **用途**: 停止將 `INVALID_CONFIG` 轉換為空 runtime config；有效設定僅透過明確的 best-effort 診斷讀取提供
-- **解決問題**: 未知 key 可能靜默丟棄安全敏感設定
-- **影響**: 設定驗證失敗時系統 fail-closed，防止安全設定被靜默忽略
+### ⭐⭐⭐ MS Teams `groupPolicy: "allowlist"` 授權修正 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- **用途**: 確保 `groupPolicy: "allowlist"` 在設定 team/channel 路由 allowlist 時仍正確執行寄件者 allowlist，路由匹配不再擴大群組存取權限。
+- **解決問題**: 路由 allowlist 設定時，群組層級的寄件者限制被意外繞過。
+- **影響**: MS Teams 部署的存取控制更嚴謹，防止未授權寄件者透過路由匹配取得存取權。
 
 ```text
-┌──────────────────────┐
-│  config 驗證          │
-└──────────┬───────────┘
-           │ INVALID_CONFIG?
-     ┌─────┴──────┐
-     │ 是          │ 否
-     ▼             ▼
-┌──────────────┐  ┌──────────────────┐
-│ fail-closed  │  │  正常 runtime    │
-│ (不轉空 cfg) │  └──────────────────┘
+┌──────────────────┐
+│  Teams 訊息      │
+│  (sender: X)     │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  route allowlist 匹配？      │
+└──────┬───────────────┬───────┘
+       │ 匹配           │ 不匹配
+       ▼               ▼
+┌──────────────┐  ┌──────────┐
+│ 仍檢查       │  │  拒絕    │
+│ groupPolicy  │  └──────────┘
+│ allowlist    │
 └──────┬───────┘
-       │ 診斷讀取
+       │ sender 在 allowlist？
        ▼
-┌──────────────┐
-│ best-effort  │
-│ 診斷路徑     │
-└──────────────┘
+┌──────────────┐  ┌──────────┐
+│  允許 ✓      │  │  拒絕 ✗  │
+└──────────────┘  └──────────┘
 ```
 
-### ⭐⭐⭐ Security/archive ZIP 強化
-- **用途**: ZIP 解壓縮改用同目錄 temp file + atomic rename，解壓後重新開啟並拒絕 destination root 外的 hardlink alias race
-- **解決問題**: ZIP 解壓縮存在 hardlink path traversal 風險
-- **影響**: 防止惡意 ZIP 檔案透過 hardlink race 逃逸至目標目錄外
+### ⭐⭐⭐ system.run 腳本執行前快照綁定 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- **用途**: 將已核准的 `bun`/`deno run` 腳本操作數綁定至磁碟上的檔案快照，核准後的腳本竄改在執行前即被拒絕。
+- **解決問題**: 使用者核准腳本後，攻擊者可在執行前竄改腳本內容，繞過核准機制。
+- **影響**: 防止 TOCTOU（Time-of-check Time-of-use）攻擊，確保執行的腳本與核准時一致。
 
 ```text
-┌──────────────────────┐
-│  ZIP 解壓縮請求       │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  同目錄 temp file 寫入│
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  atomic rename       │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  重新開啟驗證         │
-│  hardlink alias 檢查  │
-└──────────┬───────────┘
-           │ 逃逸?
-     ┌─────┴──────┐
-     │ 是          │ 否
-     ▼             ▼
-┌──────────┐  ┌──────────────┐
-│  拒絕     │  │  解壓縮完成  │
-└──────────┘  └──────────────┘
+┌──────────────────┐   核准    ┌──────────────────────┐
+│  使用者核准      │──────────►│  建立磁碟快照        │
+│  bun/deno 腳本   │           │  (snapshot binding)  │
+└──────────────────┘           └──────────┬───────────┘
+                                           │
+                                           ▼
+                                ┌──────────────────────┐
+                                │  執行前比對快照      │
+                                └──────┬───────┬───────┘
+                                       │ 一致   │ 不一致
+                                       ▼        ▼
+                                ┌──────────┐ ┌──────────┐
+                                │  執行 ✓  │ │  拒絕 ✗  │
+                                └──────────┘ └──────────┘
 ```
 
-### ⭐⭐ Gateway 安全回應標頭 ([#30186](https://github.com/openclaw/openclaw/pull/30186))
-- **用途**: 所有 gateway HTTP 回應新增 `Permissions-Policy: camera=(), microphone=(), geolocation=()` 基線安全標頭
-- **解決問題**: 缺乏 Permissions-Policy 標頭，瀏覽器可能允許不必要的硬體存取
-- **影響**: 強化 Control UI 的瀏覽器安全邊界
-
-### ⭐⭐ 依賴安全性修補
-- **用途**: pin `hono@4.12.5`/`@hono/node-server@1.19.10` 修補 Hono 漏洞；`tar` 升至 `7.5.10` 修復高危 hardlink path traversal (`GHSA-qffp-2rhf-9h96`)
-- **解決問題**: 上游依賴存在已知安全漏洞
-- **影響**: 消除已知 CVE，降低供應鏈攻擊風險
-
-### ⭐⭐ Cron 檔案權限強化 ([#36078](https://github.com/openclaw/openclaw/pull/36078))
-- **用途**: cron store/backup/run-log 強制 `0600` 權限，目錄強制 `0700`，包含舊版安裝的既有目錄
-- **解決問題**: cron 相關檔案權限過寬，可能被其他使用者讀取
-- **影響**: 防止本機多使用者環境下的 cron 資料洩漏
-
-### ⭐⭐ Security/Nostr profile mutation 強化
-- **用途**: non-loopback forwarded client header (`x-forwarded-for`/`x-real-ip`) fail-closed；拒絕 `sec-fetch-site: cross-site` 請求
-- **解決問題**: proxy 轉發或瀏覽器跨站請求可能繞過 loopback 防護
-- **影響**: 防止 proxy 環境下的 Nostr profile 偽造攻擊
-
-### ⭐⭐ Auth 標籤安全 ([#33262](https://github.com/openclaw/openclaw/pull/33262))
-- **用途**: 移除 `/status`/`/models` 輸出中的 token 與 API key 片段
-- **解決問題**: 狀態輸出可能洩漏憑證片段
-- **影響**: 降低憑證意外暴露於日誌或螢幕截圖的風險
-
-### ⭐⭐ ACP sandbox spawn 防護
-- **用途**: 封鎖沙箱 requester session 執行 `/acp spawn`，與 `sessions_spawn({ runtime: "acp" })` 的 host-runtime 防護一致
-- **解決問題**: 沙箱 session 可透過 `/acp spawn` 指令路徑繞過沙箱邊界
-- **影響**: 關閉沙箱邊界的指令路徑政策缺口
-
-### ⭐ Config 驗證日誌清理 ([#39116](https://github.com/openclaw/openclaw/pull/39116))
-- **用途**: 清理 config 驗證 issue 路徑/訊息中的控制字元與 ANSI escape sequence
-- **解決問題**: 惡意設定內容可能透過 ANSI escape 注入誤導性終端輸出
-- **影響**: 防止設定驗證日誌被用於終端注入攻擊
-
-### ⭐ SecretRef models.json 持久化強化 ([#38955](https://github.com/openclaw/openclaw/pull/38955))
-- **用途**: 防止 SecretRef 管理的 api key 與 headers 寫入 models.json；擴大 audit/apply 覆蓋範圍
-- **解決問題**: SecretRef 管理的憑證可能以明文形式持久化至磁碟
-- **影響**: 確保 SecretRef 憑證不會意外寫入設定檔案
+### ⭐⭐ Skills 下載安裝路徑固定 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- **用途**: 下載封存前固定每個 skill 的工具根目錄，防止路徑重綁定將下載寫入預期目錄外。
+- **解決問題**: 詞法路徑重綁定可能將 skill 工具下載重導向至任意目錄。
+- **影響**: 防止惡意 skill 透過路徑操控寫入系統敏感位置。
 
 ---
 
 ## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐⭐ Sessions bootstrap cache rollover 失效 ([#38494](https://github.com/openclaw/openclaw/issues/38494))
-- **用途**: session 重置（daily/idle/forced）後正確清除 workspace bootstrap 快取，確保 `AGENTS.md`/`MEMORY.md`/`USER.md` 更新即時生效
-- **解決問題**: session 重置後 bootstrap 快取未清除，`AGENTS.md` 等更新直到 gateway 重啟才生效
-- **影響**: 設定更新後立即反映，不再需要重啟 gateway
+### ⭐⭐⭐ Telegram DM 重複回覆修正 ([#40519](https://github.com/openclaw/openclaw/pull/40519))
+- **用途**: 每個 agent 對 DM 進行去重（而非每個 session key），防止同一 DM 觸發兩次回覆。
+- **解決問題**: `agent:main:main` 與 `agent:main:telegram:direct:<id>` 同時解析時，同一訊息會觸發重複回覆。
+- **影響**: 修正 Telegram DM 重複回覆問題，提升使用者體驗。
 
 ```text
-┌──────────────────────┐
-│  session reset 觸發   │
-│  (daily/idle/forced) │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  等待 embedded run   │
-│  shutdown 完成        │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  清除 bootstrap      │
-│  cache snapshot      │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  下次 session 啟動    │
-│  重新載入 AGENTS.md  │
-│  MEMORY.md / USER.md │
-└──────────────────────┘
-```
-
-### ⭐⭐⭐ Cron restart catch-up 語意修正
-- **用途**: 重啟後補跑中斷的 recurring job 與錯過的 immediate cron slot；不重跑中斷的 one-shot job；防護 malformed schedule 導致啟動中止
-- **解決問題**: 重啟後 recurring job 不補跑，或 one-shot job 被錯誤重跑；malformed schedule 導致啟動失敗
-- **影響**: cron 重啟後行為符合預期，不再遺漏或重複執行
-
-```text
-┌──────────────────────┐
-│  gateway 重啟         │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  掃描中斷的 cron jobs │
-└──────────┬───────────┘
-           │
-     ┌─────┴──────────────┐
-     │ recurring job?      │ one-shot job?
-     ▼                     ▼
-┌──────────┐         ┌──────────────┐
-│  補跑    │         │  跳過        │
-│  missed  │         │  (不重跑)    │
-│  slots   │         └──────────────┘
-└──────────┘
-```
-
-### ⭐⭐⭐ Venice provider 400 錯誤修復 ([#38168](https://github.com/openclaw/openclaw/issues/38168))
-- **用途**: 對齊 per-model Venice completion-token 限制與 discovery metadata；停用不支援 function calling 的 Venice model 的 tool wiring；同步靜態 fallback catalog
-- **解決問題**: 預設 Venice 設定因 `max_completion_tokens` 超限或 unsupported-tools 導致 400 錯誤
-- **影響**: Venice provider 開箱即用，不再需要手動調整 token 限制
-
-```text
-┌──────────────────────┐
-│  Venice model 請求    │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  discovery metadata  │
-│  token limit 對齊    │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  支援 function call? │
-└──────┬───────────────┘
-       │ 否              │ 是
-       ▼                 ▼
+┌──────────────────┐
+│  Telegram DM     │
+│  (inbound)       │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────────┐
+│  per-agent 去重檢查              │
+│  (agent:main:main vs             │
+│   agent:main:telegram:direct:X)  │
+└──────┬───────────────────────────┘
+       │ 已處理？
+       ▼
 ┌──────────────┐  ┌──────────────────┐
-│  停用 tool   │  │  正常 tool wiring │
-│  wiring      │  └──────────────────┘
-└──────────────┘
+│  略過 (dedup)│  │  派送至 agent    │
+└──────────────┘  │  (僅一次)        │
+                  └──────────────────┘
 ```
 
-### ⭐⭐⭐ Control UI iMessage 重複路由修復 ([#33483](https://github.com/openclaw/openclaw/issues/33483))
-- **用途**: 保持 internal webchat turn 在 dispatcher delivery，不進行 origin-channel reroute，防止 Control UI 聊天回覆被重複送至 iMessage
-- **解決問題**: Control UI 聊天回覆被錯誤路由至 iMessage，導致重複訊息
-- **影響**: Control UI 與 iMessage 頻道路由正確隔離
+### ⭐⭐⭐ Gateway 重啟逾時非零退出 ([#40380](https://github.com/openclaw/openclaw/pull/40380))
+- **用途**: 重啟觸發的關機排水逾時時以非零退出，讓 launchd/systemd 正確重啟 gateway，而非將失敗重啟視為正常停止。
+- **解決問題**: 排水逾時時 gateway 以零退出，launchd/systemd 不會重啟服務。
+- **影響**: 提升 gateway 在異常重啟情境下的可靠性。
 
 ```text
+┌──────────────────┐
+│  重啟觸發關機    │
+└────────┬─────────┘
+         │
+         ▼
 ┌──────────────────────┐
-│  Control UI 聊天回覆  │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  internal webchat?   │
+│  排水逾時？          │
 └──────┬───────────────┘
        │ 是              │ 否
        ▼                 ▼
-┌──────────────┐  ┌──────────────────────┐
-│  dispatcher  │  │  origin-channel route │
-│  delivery    │  │  (外部頻道)           │
-│  (不 reroute)│  └──────────────────────┘
+┌──────────────┐  ┌──────────────────┐
+│  exit(非零)  │  │  正常 exit(0)    │
+│  → systemd   │  └──────────────────┘
+│    重啟 ✓    │
 └──────────────┘
 ```
 
-### ⭐⭐⭐ Discord DM session key 正規化
-- **用途**: 將 legacy `discord:dm:*` 與 phantom `discord:channel:<user>` session key 重寫為 `discord:direct:*`，修復多 agent Discord DM 無回覆問題
-- **解決問題**: legacy session key 格式導致 DM 落入空的 channel-shaped session，無法正確回覆
-- **影響**: Discord DM 路由正確，多 agent 設定下 DM 不再靜默失敗
+### ⭐⭐⭐ Config 寫入後 secrets 快照保留 ([#37313](https://github.com/openclaw/openclaw/pull/37313))
+- **用途**: config 寫入後保留 secrets runtime 解析快照與 auth-profile 快照，後續讀取仍能取得 file-backed secret 值，同時套用持久化的 config 更新。
+- **解決問題**: config 寫入後快照被清除，後續讀取無法取得 secrets，導致 hot-reload 失敗。
+- **影響**: 修正 config 更新後 secrets 遺失的問題，提升 hot-reload 穩定性。
 
 ```text
-┌──────────────────────┐
-│  Discord DM 入站      │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  session key 偵測     │
-│  discord:dm:* ?      │
-└──────┬───────────────┘
-       │ 是
-       ▼
-┌──────────────────────┐
-│  重寫為               │
-│  discord:direct:*    │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  正確路由至 DM session│
-└──────────────────────┘
+┌──────────────────┐
+│  config 寫入     │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  保留 secrets runtime 快照   │
+│  + auth-profile 快照         │
+└──────────────┬───────────────┘
+               │
+               ▼
+┌──────────────────────────────┐
+│  後續讀取仍可取得            │
+│  file-backed secret 值 ✓     │
+└──────────────────────────────┘
 ```
 
-### ⭐⭐⭐ TUI `/new` session 隔離 ([#39238](https://github.com/openclaw/openclaw/pull/39238))
-- **用途**: `/new` 改為分配唯一 `tui-<uuid>` session key，不再重置共用 agent session；同時清理 `/new`/`/reset` 失敗文字的終端渲染
-- **解決問題**: 多個 TUI 客戶端連接同一 agent 時，`/new` 重置共用 session 導致互相收到對方的回覆
-- **影響**: 多 TUI 客戶端可獨立使用，不再互相干擾
+### ⭐⭐ macOS launchd 重生偵測 ([#20555](https://github.com/openclaw/openclaw/pull/20555))
+- **用途**: 以 `XPC_SERVICE_NAME` 作為 launchd 監管提示，macOS 重啟時直接乾淨退出，不嘗試分離式自我重生。
+- **解決問題**: 在 launchd 監管下嘗試自我重生導致行為異常。
+- **影響**: macOS 服務重啟更可靠。
 
-```text
-┌──────────────────────┐
-│  TUI 客戶端 A: /new  │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  分配 tui-<uuid-A>   │
-│  session key         │
-└──────────────────────┘
+### ⭐⭐ Gateway config 重啟防護 ([#38699](https://github.com/openclaw/openclaw/pull/38699))
+- **用途**: 啟動/重啟前驗證 config，防止 SIGUSR1 後的啟動失敗造成 gateway 程序崩潰，減少無效 config 重啟迴圈與 macOS 權限遺失。
+- **解決問題**: 無效 config 導致 gateway 反覆重啟崩潰。
+- **影響**: 提升 gateway 對無效 config 的容錯能力。
 
-┌──────────────────────┐
-│  TUI 客戶端 B: /new  │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  分配 tui-<uuid-B>   │
-│  session key (獨立)  │
-└──────────────────────┘
-```
+### ⭐⭐ Telegram poll 重啟清理 ([#23950](https://github.com/openclaw/openclaw/pull/23950))
+- **用途**: 關機或強制重啟時中止進行中的 Telegram API fetch，防止舊 `getUpdates` 長輪詢與新 runner 衝突。
+- **解決問題**: 舊輪詢未中止，與新 runner 產生競爭條件。
+- **影響**: Telegram 輪詢重啟更乾淨，減少重複處理訊息的風險。
 
-### ⭐⭐ Memory BM25 搜尋排序修復 ([#33757](https://github.com/openclaw/openclaw/pull/33757))
-- **用途**: 修復 `bm25RankToScore()` 中 FTS5 BM25 負值排序，確保強關鍵字匹配排在弱匹配前面
-- **解決問題**: BM25 負值排序邏輯錯誤，導致搜尋結果排序反轉或崩潰
-- **影響**: memory 關鍵字搜尋結果排序正確，最相關結果優先顯示
+### ⭐⭐ Cron 重啟補跑節流 ([#18925](https://github.com/openclaw/openclaw/pull/18925))
+- **用途**: 限制啟動時立即補跑的錯過任務數量，將剩餘延遲任務從補跑後的時鐘重新排程。
+- **解決問題**: 重啟後大量補跑任務同時執行，造成 gateway 過載或靜默跳過逾期任務。
+- **影響**: 重啟後 cron 任務執行更平穩。
 
-### ⭐⭐ Telegram polling health monitor 修復 ([#38395](https://github.com/openclaw/openclaw/issues/38395))
-- **用途**: Telegram long-polling 頻道不再被 WebSocket stale-socket 啟發式重啟；透過共用 health evaluation 串接頻道身份
-- **解決問題**: Telegram polling 連線因長時間運行被誤判為 stale，觸發不必要的重啟/配對風暴
-- **影響**: Telegram polling 連線穩定，不再因長時間運行而被誤重啟
+### ⭐⭐ ACP session 歷史記錄持久化 ([#40137](https://github.com/openclaw/openclaw/pull/40137))
+- **用途**: 持久化成功 ACP 子執行的逐字稿，保留精確逐字稿文字，記錄 ACP spawn session 血緣，歷史儲存失敗不阻斷執行。
+- **解決問題**: ACP 子執行的逐字稿未被保留，難以追蹤執行歷史。
+- **影響**: 提升 ACP 多 agent 協作的可追蹤性。
 
-### ⭐⭐ ACP NO_REPLY 抑制修復 ([#38436](https://github.com/openclaw/openclaw/pull/38436))
-- **用途**: 在 `openclaw agent` logging/delivery 前過濾 ACP `NO_REPLY` lead fragment 與 silent-only final
-- **解決問題**: console-backed ACP session 在日誌/輸出中洩漏 `NO`/`NO_REPLY` 佔位符
-- **影響**: ACP session 輸出乾淨，不再出現無意義的佔位符文字
+### ⭐⭐ macOS 更新 launchd 服務復原 ([v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8))
+- **用途**: 更新前重新啟用已停用的 LaunchAgent 服務，讓 `openclaw update` 可從停用的 gateway 服務中復原。
+- **解決問題**: 服務停用時 `openclaw update` 的重啟步驟卡住。
+- **影響**: 更新流程更可靠，不受服務停用狀態影響。
 
-### ⭐⭐ Codex CLI sandbox 預設值修正 ([#39336](https://github.com/openclaw/openclaw/pull/39336))
-- **用途**: 內建 Codex backend 從 `read-only` 改為 `workspace-write`，讓 coding run 開箱即可編輯檔案
-- **解決問題**: 預設 `read-only` sandbox 導致 Codex coding run 無法寫入檔案
-- **影響**: Codex coding agent 開箱即用，不再需要手動調整 sandbox 設定
+### ⭐⭐ Cron/Telegram 公告投遞修正 ([#40575](https://github.com/openclaw/openclaw/pull/40575))
+- **用途**: 文字公告任務在完成後代輸出後透過真實輸出 adapter 投遞，修正純文字 Telegram 目標回報 `delivered: true` 但訊息未實際送達的問題。
+- **解決問題**: Cron 公告任務假報投遞成功。
+- **影響**: Cron 公告投遞狀態更可信。
 
-### ⭐⭐ Routing binding lookup 效能修復 ([#36915](https://github.com/openclaw/openclaw/issues/36915))
-- **用途**: 預先以 channel/account 索引 route binding，避免 channel-account cache rollover 時全量重掃
-- **解決問題**: 大型 binding 設定下 `resolveAgentRoute` 每次呼叫需多秒
-- **影響**: 大型部署的訊息路由延遲大幅降低
+### ⭐ Matrix DM 路由改善 ([#19736](https://github.com/openclaw/openclaw/pull/19736))
+- **用途**: 為損壞的 `m.direct` homeserver 新增安全 fallback 偵測，優先使用明確 room binding，保留 Matrix DM room 的 room-bound agent 選擇。
+- **解決問題**: 部分 homeserver 的 `m.direct` 資料損壞導致 DM 路由失敗。
+- **影響**: Matrix DM 路由更穩健。
 
-### ⭐⭐ Slack app_mention race dedupe ([#37033](https://github.com/openclaw/openclaw/pull/37033))
-- **用途**: `app_mention` dispatch 勝出時，抑制同 `ts` 的 `message` dispatch，防止近乎同時送達的 Slack 事件產生重複回覆
-- **解決問題**: Slack 同時送達 `app_mention` 與 `message` 事件導致重複回覆
-- **影響**: Slack 提及不再產生重複回覆
+### ⭐ Feishu plugin 上線快取清除 ([#39752](https://github.com/openclaw/openclaw/pull/39752))
+- **用途**: 安裝 channel plugin 後重新載入 registry 前清除短暫 plugin 探索快取，修正成功安裝後立即重新提示下載 Feishu 的問題。
+- **解決問題**: 快取未清除導致 onboarding 重複提示。
+- **影響**: Feishu plugin 安裝流程更順暢。
 
-### ⭐⭐ Telegram DM draft 重複顯示修復 ([#36746](https://github.com/openclaw/openclaw/pull/36746))
-- **用途**: 最終訊息實體化後清除 stale DM draft preview，包含 DM topic lookup 失敗時的 threadless fallback
-- **解決問題**: 串流結束後短暫出現重複回覆（preview + final 同時顯示）
-- **影響**: Telegram DM 串流回覆顯示乾淨，不再出現短暫重複
+### ⭐ TUI 淺色終端主題自動偵測 ([#38636](https://github.com/openclaw/openclaw/pull/38636))
+- **用途**: 透過 `COLORFGBG` 偵測淺色終端背景，選用符合 WCAG AA 的淺色調色盤，支援 `OPENCLAW_THEME=light|dark` 手動覆蓋。
+- **解決問題**: 淺色終端背景下 TUI 文字對比度不足，難以閱讀。
+- **影響**: 提升淺色終端使用者的可讀性與無障礙體驗。
 
-### ⭐⭐ LINE auth boundary 強化
-- **用途**: 統一 LINE webhook authn/z 邊界語意，含 pairing-store account scoping、DM/group allowlist 分離、fail-closed webhook auth、replay/duplication 控制
-- **解決問題**: LINE webhook 認證邊界不一致，存在 replay 與重複處理風險
-- **影響**: LINE 頻道安全性與可靠性大幅提升
+### ⭐ GPT-5.4 context window 修正 ([#37876](https://github.com/openclaw/openclaw/pull/37876))
+- **用途**: 為 `openai-codex/gpt-5.4` 使用正確的 1,050,000 token context window 與 128,000 max tokens，取代繼承自舊 Codex 的錯誤限制。
+- **解決問題**: GPT-5.4 繼承舊 Codex 的過小 context 限制，無法充分利用模型能力。
+- **影響**: GPT-5.4 可正確處理長上下文任務。
 
-### ⭐ Onboarding local tools.profile 預設值修正
-- **用途**: 未設定 local `tools.profile` 時預設為 `coding` 而非 `messaging`，恢復本地安裝的檔案/runtime 工具
-- **解決問題**: 新本地安裝預設 `messaging` profile，缺少檔案與 runtime 工具
-- **影響**: 本地安裝開箱即有完整工具集
+### ⭐ Perplexity OpenRouter 相容性恢復 ([#39937](https://github.com/openclaw/openclaw/pull/39937))
+- **用途**: 恢復 legacy `OPENROUTER_API_KEY`、`sk-or-...` 與明確 `perplexity.baseUrl`/`model` 設定的 Perplexity 相容性，直接 Perplexity key 仍走原生 Search API。
+- **解決問題**: 舊版 OpenRouter 設定無法使用 Perplexity。
+- **影響**: 舊版設定無需修改即可繼續使用。
 
-### ⭐ Browser session cleanup ([#36666](https://github.com/openclaw/openclaw/issues/36666))
-- **用途**: 追蹤 session-scoped browser tool 開啟的分頁，在 `sessions.reset`/`sessions.delete` 時關閉
-- **解決問題**: session 結束後瀏覽器分頁殘留，導致記憶體持續增長
-- **影響**: 長時間運行的部署記憶體使用更穩定
+### ⭐ Amazon Bedrock 配額錯誤識別 ([#39377](https://github.com/openclaw/openclaw/pull/39377))
+- **用途**: 將 Amazon Bedrock `Too many tokens per day` 識別為速率限制，在 fallback、cron retry 與 memory embeddings 中正確處理，不與 context-window 錯誤混淆。
+- **解決問題**: Bedrock 每日配額錯誤被誤判為 context-window 錯誤，導致 fallback 行為不正確。
+- **影響**: Bedrock 配額耗盡時 fallback 行為更正確。
 
-### ⭐ iMessage echo loop 強化 ([#33295](https://github.com/openclaw/openclaw/pull/33295))
-- **用途**: 清除 assistant 內部 scaffolding、丟棄反射的 assistant-content 訊息、延長 echo-cache 保留時間、在放大至佇列溢出前抑制重複 loop 流量
-- **解決問題**: iMessage echo loop 可能放大至佇列溢出，導致服務中斷
-- **影響**: iMessage 部署更穩定，防止 echo loop 導致的服務降級
+### ⭐ Mattermost 執行緒回覆 root_id 固定 ([#27744](https://github.com/openclaw/openclaw/pull/27744))
+- **用途**: 在執行緒內回覆時保持 `root_id` 固定於執行緒根，頂層貼文仍使用回覆目標執行緒。
+- **解決問題**: 執行緒內回覆時 `root_id` 未正確固定，導致回覆結構錯誤。
+- **影響**: Mattermost 執行緒結構更正確。
+
+### ⭐ Browser relay bind host 設定 ([#39364](https://github.com/openclaw/openclaw/pull/39364))
+- **用途**: 新增 `browser.relayBindHost`，讓 Chrome relay 可綁定至非 loopback 位址，適用於 WSL2 等跨命名空間環境，預設仍為 loopback-only。
+- **解決問題**: WSL2 等環境無法使用 Chrome relay。
+- **影響**: 擴大 browser relay 的適用環境。
+
+### ⭐ Podman SELinux bind mount 自動設定 ([#39449](https://github.com/openclaw/openclaw/pull/39449))
+- **用途**: 自動偵測 SELinux enforcing/permissive 模式，為 bind mount 加上 `:Z` relabel，支援 `OPENCLAW_BIND_MOUNT_OPTIONS` 覆蓋。
+- **解決問題**: Fedora/RHEL 主機上 Podman bind mount 因 SELinux 產生 `EACCES` 錯誤。
+- **影響**: Podman 在 SELinux 環境下開箱即用。
 
 ---
 
@@ -647,12 +375,12 @@ ACP 頻道整合架構（v2026.3.7）
 
 | 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
 |------|--------|--------|--------|------|
-| 功能更新 | 4 | 9 | 5 | 18 項 |
-| 安全性 | 3 | 6 | 2 | 11 項 |
-| 錯誤修復 | 6 | 10 | 3 | 19 項 |
-| **總計** | **13** | **25** | **10** | **48 項** |
+| 功能更新 | 2 | 3 | 4 | 備份工具、ACP Provenance、Talk/TUI 改善、Brave LLM Context |
+| 安全性提升 | 3 | 1 | 0 | SSRF 防護、Teams 授權、腳本快照綁定、Skills 路徑固定 |
+| 錯誤修復 | 3 | 7 | 9 | DM 去重、Gateway 重啟、Secrets 快照、Telegram/Cron/Browser 修正 |
+| **總計** | **8** | **11** | **13** | **32 項** |
 
 **發佈日期**: 2026-03-08
-**版本**: 2026.3.7
+**版本**: 2026.3.8
 **狀態**: Production Ready
-**GitHub Release**: [v2026.3.7](https://github.com/openclaw/openclaw/releases/tag/v2026.3.7)
+**GitHub Release**: [https://github.com/openclaw/openclaw/releases/tag/v2026.3.8](https://github.com/openclaw/openclaw/releases/tag/v2026.3.8)

--- a/release-notes/2026-03-08.md
+++ b/release-notes/2026-03-08.md
@@ -14,6 +14,32 @@
 - ⭐⭐⭐ **Context Engine 插件介面**：新增可替換的 context 管理插件槽，支援完整生命週期 hook ([#22201](https://github.com/openclaw/openclaw/pull/22201))
 - ⭐⭐⭐ **ACP 持久化頻道綁定**：Discord 頻道與 Telegram 主題的 ACP session 綁定可跨重啟保存 ([#34873](https://github.com/openclaw/openclaw/pull/34873))
 - ⭐⭐⭐ **Telegram ACP 主題綁定**：`/acp spawn --thread here|auto` 動態綁定、Unicode dash 修正、釘選確認訊息 ([#36683](https://github.com/openclaw/openclaw/pull/36683))
+
+```text
+ACP 頻道整合架構（v2026.3.7）
+
+  Discord                        Telegram
+  ┌─────────────────┐            ┌─────────────────────┐
+  │  頻道 #dev      │            │  論壇主題 #backend  │
+  │  /acp spawn     │            │  /acp spawn         │
+  │  --channel here │            │  --thread here      │
+  └────────┬────────┘            └──────────┬──────────┘
+           │                                │
+           ▼                                ▼
+  ┌─────────────────────────────────────────────────────┐
+  │              持久化 Binding 儲存                     │
+  │   channel/topic  ──►  ACP session ID               │
+  │   (跨重啟保存)                                       │
+  └──────────────────────────┬──────────────────────────┘
+                             │
+                             ▼
+  ┌─────────────────────────────────────────────────────┐
+  │              路由解析 resolveBinding()               │
+  │   後續訊息  ──►  綁定的 ACP session                 │
+  │   per-topic agentId override 支援                   │
+  └─────────────────────────────────────────────────────┘
+```
+
 - ⭐⭐⭐ **Gateway auth 模式強制設定（Breaking）**：同時設定 token 與 password 時須明確指定 `gateway.auth.mode` ([#35094](https://github.com/openclaw/openclaw/pull/35094))
 - ⭐⭐ **Telegram 每主題獨立 Agent 路由**：論壇群組各主題可設定不同 agentId ([#33647](https://github.com/openclaw/openclaw/pull/33647))
 - ⭐⭐ **Web UI 西班牙語支援**：Control UI 新增 `es` 語系，含 lazy loading 與語言選擇器 ([#35038](https://github.com/openclaw/openclaw/pull/35038))


### PR DESCRIPTION
關閉 #293

新增 OpenClaw 2026.3.8 版本發佈說明（zh-TW），涵蓋：

- 功能更新 9 項（含備份工具、ACP Provenance 等 ⭐⭐⭐ 項目）
- 安全性提升 4 項（SSRF 防護、Teams 授權、腳本快照綁定等）
- 錯誤修復 19 項（Telegram DM 去重、Gateway 重啟、Secrets 快照等）
- 共 32 項，含所有 ⭐⭐⭐ 項目的 ASCII flowchart
