### PR TITLE
usecases: Human-in-the-Loop 審批閘門 + Context Overflow 防護協議

### DIFF
--- a/usecases/context-overflow-prevention.md
+++ b/usecases/context-overflow-prevention.md
@@ -1,0 +1,188 @@
+# Context Overflow 防護協議：避免 Agent Session 撐爆
+
+> 一次真實事故的教訓：browser tool 如何把 session context 推到崩潰邊緣，以及怎麼不讓它發生。
+
+---
+
+## TL;DR
+
+- **context 是 agent 的記憶上限**，超過就崩潰——`prompt too large` 或回應品質劇降
+- **browser tool 是最大風險**：每次 snapshot 可能帶入數萬 token，且無法撤回
+- **web_fetch + r.jina.ai** 是輕量替代：只取目標內容，單次 ≤ 3000 字
+- **每次 browser/web_fetch 前先查 context 水位**：> 50% 立即停止
+- **長任務每 5 步自動檢查一次**，不要等到崩才知道
+- **出問題時用 `/reset`**，不要在已撐爆的 session 裡繼續掙扎
+
+---
+
+## 這個問題是怎麼發生的
+
+2026-02-24，一個使用 `agent-browser` 的 session 任務途中 context 持續膨脹，反覆觸發 `prompt too large` 錯誤，需要手動介入才能救場。
+
+根本原因：
+
+1. browser snapshot 把完整 DOM 帶進 context
+2. 每次操作都加一層，context 線性增長
+3. 問題發現時已無法在同一 session 繼續
+
+這不是小概率事件。任何需要讀多個頁面的任務都會遇到。
+
+---
+
+## 核心概念：Context 水位
+
+```
+Context 使用率
+     0%  ────────────────────────────────────── 100%
+          │          │           │              │
+         正常        ⚠️ 警告     🛑 停止        💥 崩潰
+         < 30%    30%-50%     > 50%
+                              不再用
+                              browser/
+                              web_fetch
+```
+
+**關鍵原則**：context 不能回收。一旦寫進去的 token 就佔著，只有 `/reset` 能清空。
+
+---
+
+## 工具選擇：輕量 vs 重量
+
+### 優先用 web_fetch + r.jina.ai
+
+```bash
+# ✅ 輕量：只取頁面的可讀文字，單次限 3000 字
+web_fetch("https://r.jina.ai/https://example.com/page", maxChars=3000)
+```
+
+`r.jina.ai` 會把目標頁面轉成純文字 Markdown，剝掉 HTML/JS/CSS，大幅壓縮 token 使用。
+
+### 什麼情況才用 browser
+
+只有以下情況才需要 browser：
+
+- 需要操作 UI（點擊、填表、登入）
+- 頁面是 SPA，內容靠 JS 渲染，web_fetch 拿不到
+- 需要截圖給人看
+
+用 browser 時的限制：
+
+```
+每次 snapshot maxChars ≤ 3000
+每次只提取目標欄位，不返回完整 DOM
+```
+
+---
+
+## 操作規程
+
+### 每次使用前：查水位
+
+```
+呼叫 session_status 確認 context 使用率
+
+< 30%  → 繼續
+30-50% → 警告使用者，建議 /reset 後繼續
+> 50%  → 立即停止 browser/web_fetch 操作，告知使用者
+```
+
+### 長任務（> 5 次工具呼叫）：每 5 步自動檢查
+
+```
+Step 1 → Step 2 → Step 3 → Step 4 → Step 5
+                                          │
+                                          ▼
+                                    查 context 水位
+                                          │
+                              ┌───────────┴───────────┐
+                              │                       │
+                           安全（< 30%）           警戒（≥ 30%）
+                              │                       │
+                           繼續                  告知使用者
+```
+
+### 分段提取長頁面
+
+```bash
+# ❌ 錯誤：一次拿整頁
+web_fetch("https://r.jina.ai/very-long-page.com")
+
+# ✅ 正確：分段，每段存到中間變數
+web_fetch("https://r.jina.ai/very-long-page.com", maxChars=3000)
+# 處理第一段，存下需要的資訊
+# 繼續取下一段（若需要）
+web_fetch("https://r.jina.ai/very-long-page.com?offset=3000", maxChars=3000)
+```
+
+---
+
+## Session 急救
+
+### 症狀識別
+
+| 症狀 | 診斷 |
+|------|------|
+| `prompt too large` 錯誤 | context 已超限 |
+| 回應開始重複、矛盾 | context 接近上限，模型開始「忘記」 |
+| 工具呼叫無故失敗 | 可能是 context 過長導致指令被截斷 |
+| 任務越做越慢 | token 計費增加，也是水位信號 |
+
+### 救援步驟
+
+```
+1. 停止所有 browser/web_fetch 操作
+2. 把當前進度摘要寫到檔案（memory/YYYY-MM-DD.md）
+3. 通知使用者執行 /reset
+4. Reset 後從摘要檔案恢復上下文繼續任務
+```
+
+### 最後手段（session 無法正常運作時）
+
+```bash
+# 清理僵尸 session 條目
+python3 /root/clean_openclaw_session.py
+
+# 歸檔超大 .jsonl 文件
+bash /root/clean_openclaw_session.sh
+```
+
+---
+
+## 最佳實務
+
+**把需要記住的東西寫進檔案，不要靠 context 記**
+
+```
+# ❌ 依賴 context 記住中間結果
+# （5步之後模型可能已經「忘了」）
+
+# ✅ 重要中間結果寫到檔案
+write("memory/task-progress.md", "目前進度：已完成步驟 1-3，下一步是...")
+```
+
+**任務開始前估算 context 消耗**
+
+一個 web_fetch 大概消耗多少 token？粗略估算：
+- 純文字 1000 字 ≈ 1500 token
+- maxChars=3000 ≈ 4500 token
+- browser snapshot（無限制）≈ 10000~50000 token
+
+長任務需要讀 5 個頁面？先算好：5 × 4500 = 22500 token，再決定要不要 reset 後再開始。
+
+---
+
+## Anti-patterns
+
+| 做法 | 問題 |
+|------|------|
+| 不限 maxChars 直接 web_fetch | 頁面可能幾萬字，全進 context |
+| browser snapshot 後不 reset 繼續下一個任務 | context 帶著上個任務的 DOM 殘留 |
+| 在已 > 50% 的 session 裡繼續長任務 | 遲早崩，而且崩的時候進度全丟 |
+| 出錯後繼續在同一 session 裡重試 | 每次重試都加 token，加速崩潰 |
+
+---
+
+## 相關連結
+
+- `docs/cron.md`：Cron isolated session 的 context 管理
+- `usecases/cron-automated-workflows.md`：自動化任務設計

--- a/usecases/human-in-the-loop-openfeedback.md
+++ b/usecases/human-in-the-loop-openfeedback.md
@@ -1,0 +1,242 @@
+# Human-in-the-Loop 審批閘門：openfeedback 實戰指南
+
+> 讓自動化腳本在執行高風險操作前，先用 Telegram 向人類請示。
+
+---
+
+## TL;DR
+
+- **問題**：自動化腳本跑起來就停不住，沒有人工審批的插槽
+- **解法**：`openfeedback` 工具——自動化腳本暫停、發 Telegram 訊息給你、等你按核准或拒絕、根據回應決定繼續或中止
+- **適合**：Coding agent 提交 PR 前確認、部署腳本執行前、任何「做了就難回頭」的操作
+- **核心原理**：靠 exit code——approved → `exit 0`，rejected → `exit 1`，腳本用 `&&` 或 `if` 接住
+- **安裝**：需從源碼編譯（Rust），設定一次之後透明使用
+
+---
+
+## 解決的問題
+
+自動化流水線（cron 任務、coding agent、CI/CD）有時會做出難以撤銷的操作：
+
+- 提交並 push commit
+- 開 PR、發 issue 留言
+- 部署到生產環境
+- 刪除資料或覆蓋設定
+
+沒有人工閘門，出錯就是出錯。`openfeedback` 在這些操作前插入一個 Telegram 確認步驟，讓人類保持最終決定權。
+
+---
+
+## 核心概念
+
+### 工作流程
+
+```
+自動化腳本
+     │
+     │ 執行到高風險操作前
+     ▼
+┌─────────────────────────────┐
+│  openfeedback "操作描述"     │
+│  → 發 Telegram 訊息給你      │
+│  → 等待你的回應              │
+└────────────┬────────────────┘
+             │
+    ┌────────┴────────┐
+    │                 │
+    ▼                 ▼
+ 核准（✅）         拒絕（❌）
+ exit 0            exit 1
+    │                 │
+    ▼                 ▼
+繼續執行          中止，可附帶
+                  拒絕原因文字
+```
+
+### Exit Code 語義
+
+| 結果 | Exit Code | 腳本行為（用 `&&`） |
+|------|-----------|-------------------|
+| 核准 | 0 | 繼續執行後續指令 |
+| 拒絕 | 1 | 後續指令不執行 |
+| 超時 | 1 | 視為拒絕，安全預設 |
+
+---
+
+## 安裝步驟
+
+### 前置條件
+
+- Rust 工具鏈（`rustup`）
+- 一個 Telegram Bot Token（`BotFather` 申請）
+- 你的 Telegram chat_id
+
+### 1. 編譯安裝
+
+```bash
+# 從 GitHub 取得源碼
+git clone https://github.com/antx-code/openfeedback /tmp/openfeedback
+cd /tmp/openfeedback
+
+# 編譯並安裝到 ~/.cargo/bin/
+cargo install --path .
+
+# 確認安裝成功
+openfeedback --version
+```
+
+未來更新：
+
+```bash
+cd /tmp/openfeedback && git pull && cargo install --path .
+```
+
+### 2. 建立設定檔
+
+```bash
+mkdir -p ~/.config/openfeedback
+cat > ~/.config/openfeedback/config.toml << 'EOF'
+bot_token = "<YOUR_BOT_TOKEN>"
+chat_id = <YOUR_CHAT_ID>
+trusted_user_ids = [<YOUR_CHAT_ID>]
+locale = "zh-TW"
+default_timeout = 60  # 秒，超時視為拒絕
+
+[audit_log]
+path = "~/.local/share/openfeedback/audit.jsonl"
+EOF
+```
+
+> ⚠️ `bot_token` 與 `chat_id` 是敏感資訊，不要 commit 進 repo。
+
+### 3. 驗證設定
+
+```bash
+# 測試審批流程（你應該會收到 Telegram 訊息）
+openfeedback "測試：這是一個審批請求"
+echo "exit code: $?"
+```
+
+核准後應看到 `exit code: 0`，拒絕後 `exit code: 1`。
+
+---
+
+## 使用方式
+
+### 基本用法
+
+```bash
+# 在高風險指令前插入審批
+openfeedback "即將執行：git push origin main（共 3 個 commit）" && \
+  git push origin main
+```
+
+### 在 Shell 腳本中使用
+
+```bash
+#!/bin/bash
+set -e
+
+# 準備工作（無需審批）
+git add .
+git commit -m "feat: 新功能實作"
+
+# 審批閘門
+if openfeedback "準備 push 到 main，確認要繼續？"; then
+  git push origin main
+  echo "Push 完成"
+else
+  echo "已拒絕，push 取消"
+  exit 1
+fi
+```
+
+### 在 Coding Agent 流程中使用
+
+讓 agent 在提交 PR 前請示：
+
+```bash
+# agent 的執行腳本片段
+openfeedback "Agent 準備開 PR：${PR_TITLE}
+分支：${BRANCH}
+變更檔案數：${CHANGED_FILES}
+是否核准？" && \
+  gh pr create --title "${PR_TITLE}" --body "${PR_BODY}"
+```
+
+### 自訂 Timeout
+
+```bash
+# 重要操作給更長的等待時間（秒）
+openfeedback --timeout 300 "生產環境部署確認" && deploy.sh
+```
+
+---
+
+## 最佳實務
+
+**審批訊息要寫清楚**：「繼續？」沒有意義。寫清楚「做什麼、影響什麼、有沒有退路」。
+
+```bash
+# ❌ 沒用的審批訊息
+openfeedback "繼續執行？"
+
+# ✅ 有用的審批訊息
+openfeedback "準備刪除 S3 bucket: my-prod-backups-2024
+此操作不可逆。
+確認要繼續？"
+```
+
+**超時預設為拒絕**：這是安全的預設值。如果你不在、沒看到訊息，操作不會自動繼續。
+
+**保留 audit log**：`config.toml` 裡設定 `audit_log.path`，所有審批記錄（包含拒絕原因）都會寫入，方便事後追蹤。
+
+**不要在循環裡審批**：如果一個操作要審批 100 次，設計就錯了。批次操作應該一次審批整個計劃，而不是逐項確認。
+
+---
+
+## Anti-patterns
+
+| 做法 | 問題 | 替代方案 |
+|------|------|---------|
+| 在 cron 排程的無人值守任務裡插 openfeedback | timeout 後一律拒絕，任務永遠無法完成 | 分開：需人工確認的用 cron 觸發後等待，純自動化的不插閘門 |
+| 審批訊息不帶上下文 | 收到訊息不知道在問什麼 | 把操作描述、影響範圍都寫進訊息 |
+| hardcode timeout 為極短值 | 手邊沒手機就超時 | config 裡設合理預設，高風險操作用 `--timeout` 延長 |
+
+---
+
+## Troubleshooting
+
+**症狀**：`openfeedback` 發出訊息但按鈕沒有反應
+- **可能原因**：Bot Token 設定錯誤，或 bot 未加入對話
+- **處理方式**：先對 bot 發 `/start`，確認 bot 回應後再試
+
+**症狀**：`exit code: 1` 但沒有收到 Telegram 訊息
+- **可能原因**：`chat_id` 設定錯誤，或網路問題
+- **處理方式**：`openfeedback --debug "test"` 查看連線狀態
+
+**症狀**：想在 CI 環境中使用，但沒有辦法互動
+- **可能原因**：CI runner 無法接收 webhook 回應
+- **處理方式**：openfeedback 需要有人在 Telegram 端回應，純 CI 環境不適用；改用環境變數控制是否啟用閘門
+
+---
+
+## 安全注意事項
+
+- `trusted_user_ids` 只填你自己的 chat_id，防止其他人審批你的操作
+- Bot Token 不要出現在任何 log 或版本控制中
+- audit log 檔案包含操作內容，注意存放路徑的權限
+
+---
+
+## 版本與依賴
+
+- 從源碼編譯，無版本號管理，以 git commit 追蹤
+- 依賴：Rust stable、Telegram Bot API
+
+---
+
+## 相關連結
+
+- `usecases/cron-automated-workflows.md`：OpenClaw cron 與自動化排程
+- `docs/cron.md`：Cron 系統深度解析


### PR DESCRIPTION
## 概述

兩份來自真實事故與實踐的實戰指南，均以繁體中文撰寫，使用 ASCII flowchart，符合 STYLE_GUIDE 規範。

---

## 新增文件

### usecases/human-in-the-loop-openfeedback.md

說明如何用 `openfeedback` 工具在自動化腳本中插入 Telegram 審批閘門，讓 agent 在執行高風險操作前請示人類。

涵蓋：
- 安裝（從源碼編譯）與設定
- Shell 腳本 / Coding Agent 流程整合方式
- Exit code 語義（approved → 0，rejected/timeout → 1）
- Anti-patterns：審批訊息不帶上下文、在無人值守 cron 裡插閘門
- Troubleshooting 三條

### usecases/context-overflow-prevention.md

說明 agent session context 是如何被撐爆的，以及一套防護規程。

涵蓋：
- 根本原因分析（browser snapshot 的 token 成本）
- web_fetch + r.jina.ai 輕量替代方案
- Context 水位 < 30% / 30-50% / > 50% 的操作規程
- 長任務每 5 步自動檢查機制
- 崩潰症狀識別 + 急救步驟
- Anti-patterns

---

## 動機

這兩個主題目前在 claw-info 沒有對應文件，但都是 OpenClaw 使用者實際會遇到的坑。openfeedback 適合任何需要 human oversight 的自動化場景；context overflow 是 browser-heavy 任務的通病。

---

## 自查清單

- [x] 繁體中文
- [x] ASCII solid-line flowchart（無 mermaid）
- [x] 敏感資訊已遮罩（bot_token、chat_id 用佔位符）
- [x] 每篇有 TL;DR、操作步驟、Anti-patterns、Troubleshooting、See also
- [x] 指令區塊可複製
- [x] 兩份文件各自獨立，主題不混包