### PR TITLE
release-notes: OpenClaw 2026.3.11

### DIFF
--- a/release-notes/2026-03-11.md
+++ b/release-notes/2026-03-11.md
@@ -1,0 +1,984 @@
+# OpenClaw v2026.3.11 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.11)
+
+## 概述
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ Gateway/WebSocket 跨站 WebSocket 劫持修復 ([GHSA-5wcw-8jjv-m286](https://github.com/advisories/GHSA-5wcw-8jjv-m286))
+- ⭐⭐⭐ Secret files 路徑競爭強化（拒絕符號連結型憑證輸入）
+- ⭐⭐⭐ Archive extraction 沙箱逃逸修復（TAR 先解壓至暫存區再合併）
+- ⭐⭐⭐ Secrets/SecretRef exec traversal 拒絕 ([#42370](https://github.com/openclaw/openclaw/pull/42370))
+- ⭐⭐⭐ Sandbox/fs bridge 寫入釘定（暫存寫入釘定至已驗證父目錄）
+- ⭐⭐⭐ Gateway/auth fail-closed ([#42672](https://github.com/openclaw/openclaw/pull/42672))
+- ⭐⭐⭐ Commands/config writes 帳號範圍強制（防止兄弟帳號竄改）
+- ⭐⭐⭐ Security/system.run fail-closed（approval-backed 指令無法綁定檔案時拒絕）
+- ⭐⭐⭐ Gateway/session reset auth 分離（/new、/reset 與管理員 RPC 分離）
+- ⭐⭐⭐ Security/plugin runtime 未驗證路由隔離（不繼承合成管理員 scope）
+- ⭐⭐⭐ Security/session_status 沙箱可見性強制（子代理無法讀取父 session）
+- ⭐⭐⭐ Security/nodes owner-only fallback（非擁有者無法觸及節點路徑）
+- ⭐⭐⭐ Security/external content 邊界標記強化 ([#35983](https://github.com/openclaw/openclaw/pull/35983))
+- ⭐⭐⭐ Subagents/authority 控制範圍持久化（防止 leaf session 重獲協調特權）
+- ⭐⭐ Telegram/exec approvals 強化 ([#37233](https://github.com/openclaw/openclaw/pull/37233))
+- ⭐⭐ Gateway/auth token drift 容錯 ([#42507](https://github.com/openclaw/openclaw/pull/42507))
+
+### 功能更新 (Features)
+- ⭐⭐⭐ iOS/Home canvas 全面翻新（歡迎畫面、停靠工具列）([#42456](https://github.com/openclaw/openclaw/pull/42456))
+- ⭐⭐⭐ macOS/chat UI 模型選擇器與 thinking-level 持久化 ([#42314](https://github.com/openclaw/openclaw/pull/42314))
+- ⭐⭐⭐ Onboarding/Ollama 一流支援 ([#41529](https://github.com/openclaw/openclaw/pull/41529))
+- ⭐⭐⭐ ACP/sessions_spawn resumeSessionId ([#41847](https://github.com/openclaw/openclaw/pull/41847))
+- ⭐⭐⭐ Memory 多模態圖片與音訊索引 ([#43460](https://github.com/openclaw/openclaw/pull/43460))
+- ⭐⭐ OpenCode/onboarding Go provider ([#42313](https://github.com/openclaw/openclaw/pull/42313))
+- ⭐⭐ Memory/Gemini gemini-embedding-2-preview ([#42501](https://github.com/openclaw/openclaw/pull/42501))
+- ⭐⭐ macOS/onboarding 遠端 gateway token 偵測 ([#43100](https://github.com/openclaw/openclaw/pull/43100))
+- ⭐⭐ iOS/TestFlight 本地 beta 發佈流程 ([#42991](https://github.com/openclaw/openclaw/pull/42991))
+- ⭐⭐ Gateway/node pending work 佇列原語 ([#41409](https://github.com/openclaw/openclaw/pull/41409))
+- ⭐ OpenRouter/models Hunter & Healer Alpha ([#43642](https://github.com/openclaw/openclaw/pull/43642))
+- ⭐ Discord/auto threads autoArchiveDuration ([#35065](https://github.com/openclaw/openclaw/pull/35065))
+- ⭐ iOS/TestFlight watch-app archive 修復 ([#42991](https://github.com/openclaw/openclaw/pull/42991))
+- ⭐ Git/runtime state .dev-state 忽略 ([#41848](https://github.com/openclaw/openclaw/pull/41848))
+- ⭐ Exec/child commands OPENCLAW_CLI 標記 ([#41411](https://github.com/openclaw/openclaw/pull/41411))
+
+### 重大變更 (Breaking)
+- ⭐⭐⭐ Cron/doctor 隔離交付收緊，新增 `openclaw doctor --fix` 遷移 ([#40998](https://github.com/openclaw/openclaw/pull/40998))
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ Agents/text sanitization 清除 GLM-5/DeepSeek 控制 token ([#42173](https://github.com/openclaw/openclaw/pull/42173))
+- ⭐⭐⭐ Gateway/macOS launchd 重啟修復 (fixes [#43311](https://github.com/openclaw/openclaw/issues/43311), [#43406](https://github.com/openclaw/openclaw/issues/43406))
+- ⭐⭐⭐ Gateway/Control UI session-scoped token 儲存 ([#40892](https://github.com/openclaw/openclaw/pull/40892))
+- ⭐⭐ iOS/gateway foreground recovery 立即重連 ([#41384](https://github.com/openclaw/openclaw/pull/41384))
+- ⭐⭐ Agents/Azure OpenAI Responses store override ([#42934](https://github.com/openclaw/openclaw/pull/42934))
+- ⭐⭐ ACP/sessions_spawn implicit streaming 恢復 ([#42404](https://github.com/openclaw/openclaw/pull/42404))
+- ⭐⭐ ACP/main session aliases 正規化 ([#43285](https://github.com/openclaw/openclaw/pull/43285))
+- ⭐⭐ Models/Kimi Coding tool calls 原生格式恢復 ([#38669](https://github.com/openclaw/openclaw/pull/38669))
+- ⭐⭐ Telegram/outbound HTML 分塊 ([#42240](https://github.com/openclaw/openclaw/pull/42240))
+- ⭐⭐ Discord/reply chunking maxLinesPerMessage ([#40133](https://github.com/openclaw/openclaw/pull/40133))
+- ⭐⭐ macOS/LaunchAgent install 權限收緊
+- ⭐ Agents/fallback HTTP 499 視為暫時性 ([#41468](https://github.com/openclaw/openclaw/pull/41468))
+- ⭐ Agents/fallback Venice 402 識別 ([#43205](https://github.com/openclaw/openclaw/pull/43205))
+- ⭐ Agents/fallback Poe 402 識別 ([#42278](https://github.com/openclaw/openclaw/pull/42278))
+- ⭐ Agents/failover Gemini MALFORMED_RESPONSE ([#42292](https://github.com/openclaw/openclaw/pull/42292))
+- ⭐ Agents/cooldowns unknown 預設值 ([#42911](https://github.com/openclaw/openclaw/pull/42911))
+- ⭐ Auth/cooldowns 過期計數器重置 ([#41028](https://github.com/openclaw/openclaw/pull/41028))
+- ⭐ Agents/error rendering 過時 errorMessage 忽略 ([#40616](https://github.com/openclaw/openclaw/pull/40616))
+- ⭐ Agents/billing recovery 無需重啟 gateway ([#41422](https://github.com/openclaw/openclaw/pull/41422))
+- ⭐ Feishu/local image auto-convert ([#40623](https://github.com/openclaw/openclaw/pull/40623))
+- ⭐ Telegram/final preview delivery 修復 ([#41662](https://github.com/openclaw/openclaw/pull/41662))
+- ⭐ ACP/sessions.patch lineage fields (fixes [#40971](https://github.com/openclaw/openclaw/issues/40971))
+- ⭐ CLI/skills JSON ANSI 清除 (fixes [#27530](https://github.com/openclaw/openclaw/issues/27530))
+- ⭐ CLI/tables ASCII borders on legacy Windows (fixes [#40853](https://github.com/openclaw/openclaw/issues/40853))
+- ⭐ Channels/allowlists stale matcher 快取清除
+- ⭐ Tools/web search Brave llm-context ([#41387](https://github.com/openclaw/openclaw/pull/41387))
+- ⭐ Tools/web search OpenRouter Perplexity citations ([#40881](https://github.com/openclaw/openclaw/pull/40881))
+- ⭐ Signal/config schema accountUuid ([#35578](https://github.com/openclaw/openclaw/pull/35578))
+- ⭐ Telegram/config schema editMessage/createForumTopic ([#35498](https://github.com/openclaw/openclaw/pull/35498))
+- ⭐ Discord/config typing autoThread ([#35608](https://github.com/openclaw/openclaw/pull/35608))
+- ⭐ Models/Alibaba Cloud ModelStudio MODELSTUDIO_API_KEY ([#40634](https://github.com/openclaw/openclaw/pull/40634))
+- ⭐ Mattermost/Markdown formatting 首行縮排 ([#18655](https://github.com/openclaw/openclaw/pull/18655))
+- ⭐ MS Teams/allowlist resolution General channel ID ([#41838](https://github.com/openclaw/openclaw/pull/41838))
+- ⭐ Cron/subagent 空回應誤判修復 ([#41383](https://github.com/openclaw/openclaw/pull/41383))
+- ⭐ Browser/Browserbase 429 處理 ([#40491](https://github.com/openclaw/openclaw/pull/40491))
+- ⭐ Sandbox/subagents workspace 傳遞 ([#40757](https://github.com/openclaw/openclaw/pull/40757))
+- ⭐ Agents/fallback cooldown probing 上限 ([#41711](https://github.com/openclaw/openclaw/pull/41711))
+- ⭐ Telegram/polling restarts 計時器清除 ([#43188](https://github.com/openclaw/openclaw/pull/43188))
+- ⭐ CLI/memory teardown ([#40389](https://github.com/openclaw/openclaw/pull/40389))
+- ⭐ Control UI/Sessions 窄視窗單欄折疊 ([#12175](https://github.com/openclaw/openclaw/pull/12175))
+
+---
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Gateway/WebSocket 跨站 WebSocket 劫持修復 ([GHSA-5wcw-8jjv-m286](https://github.com/advisories/GHSA-5wcw-8jjv-m286))
+- **用途**: 對所有瀏覽器來源的 WebSocket 連線強制執行 Origin 驗證，無論是否存在 proxy 標頭
+- **解決問題**: `trusted-proxy` 模式下，不受信任的來源可繞過驗證取得 `operator.admin` 存取權（跨站 WebSocket 劫持）
+- **影響**: 封閉高危安全漏洞，防止惡意網站透過受害者瀏覽器劫持 gateway 管理員權限
+
+```text
+┌─────────────────────┐     ┌──────────────────────────┐
+│  瀏覽器 WebSocket   │────►│  Gateway Origin 驗證     │
+│  連線請求           │     │  (所有連線，含 proxy 模式) │
+└─────────────────────┘     └──────────────────────────┘
+                                         │
+                    ┌────────────────────┴────────────────────┐
+                    ▼                                         ▼
+         ┌──────────────────┐                    ┌──────────────────┐
+         │ Origin 在白名單  │                    │ Origin 不在白名單 │
+         └──────────────────┘                    └──────────────────┘
+                    │                                         │
+                    ▼                                         ▼
+         ┌──────────────────┐                    ┌──────────────────┐
+         │  允許連線        │                    │  拒絕連線 (403)  │
+         └──────────────────┘                    └──────────────────┘
+```
+
+### ⭐⭐⭐ Secret files 路徑競爭強化
+- **用途**: 要求 `*File` 型憑證輸入必須為直接的正規檔案，拒絕符號連結
+- **解決問題**: 攻擊者可在讀取前置換符號連結目標，使 gateway 讀取非預期的憑證檔案（路徑競爭攻擊）
+- **影響**: 消除憑證讀取的路徑競爭攻擊面
+
+```text
+┌──────────────────────┐
+│  *File 憑證讀取請求  │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  檔案類型檢查        │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 正規檔 │   │ 符號連結 │
+└────────┘   └──────────┘
+    │             │
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 允許   │   │ 拒絕存取 │
+└────────┘   └──────────┘
+```
+
+### ⭐⭐⭐ Archive extraction 沙箱逃逸修復
+- **用途**: TAR 及外部 `tar.bz2` 安裝先解壓至暫存區，再安全合併至目標目錄
+- **解決問題**: 惡意壓縮檔可透過目的地符號連結或預先存在的子符號連結逃逸至沙箱外
+- **影響**: 防止壓縮檔解壓時的路徑逃逸攻擊，保護系統檔案完整性
+
+```text
+┌──────────────────┐
+│  TAR 解壓請求    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  解壓至暫存區    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  符號連結逃逸    │
+│  安全性檢查      │
+└──────────────────┘
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌────────┐ ┌────────┐
+│ 安全   │ │ 危險   │
+└────────┘ └────────┘
+    │         │
+    ▼         ▼
+┌────────┐ ┌────────┐
+│ 合併至 │ │ 中止   │
+│ 目標   │ └────────┘
+└────────┘
+```
+
+### ⭐⭐⭐ Secrets/SecretRef exec traversal 拒絕 ([#42370](https://github.com/openclaw/openclaw/pull/42370))
+- **用途**: 在 schema、runtime、gateway 三層拒絕 exec SecretRef 跨越 traversal id
+- **解決問題**: exec SecretRef 可能被用於跨越 secret 邊界存取非授權憑證
+- **影響**: 多層防禦確保 exec 型 SecretRef 無法繞過授權邊界
+
+```text
+┌──────────────────────┐
+│  exec SecretRef 請求 │
+└──────────────────────┘
+         │
+    ┌────┴──────────────┐
+    ▼        ▼          ▼
+┌────────┐ ┌────────┐ ┌────────┐
+│ Schema │ │Runtime │ │Gateway │
+│ 驗證   │ │ 驗證   │ │ 驗證   │
+└────────┘ └────────┘ └────────┘
+    │
+任一層拒絕 ──► 拒絕執行
+```
+
+### ⭐⭐⭐ Sandbox/fs bridge 寫入釘定
+- **用途**: 暫存寫入檔案釘定至已驗證的父目錄，原子替換前不允許逸出
+- **解決問題**: 暫存寫入檔案可能在原子替換前被移動至允許掛載點外
+- **影響**: 防止沙箱檔案系統橋接的寫入逃逸攻擊
+
+```text
+┌──────────────────┐
+│  沙箱寫入請求    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  驗證父目錄      │
+│  在允許掛載內    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  釘定暫存檔案    │
+│  至驗證父目錄    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  原子替換至      │
+│  最終目標        │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/auth fail-closed ([#42672](https://github.com/openclaw/openclaw/pull/42672))
+- **用途**: 本地 `gateway.auth.*` SecretRef 設定但不可用時，拒絕靜默回退至 `gateway.remote.*` 憑證
+- **解決問題**: 本地 SecretRef 失敗時靜默降級可能導致使用錯誤的憑證集進行驗證
+- **影響**: 確保憑證設定錯誤時明確失敗，而非靜默使用備用憑證
+
+```text
+┌──────────────────────────┐
+│  本地 SecretRef 驗證請求 │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  嘗試解析本地 SecretRef  │
+└──────────────────────────┘
+              │
+       ┌──────┴──────┐
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  解析成功  │  │  解析失敗  │
+└────────────┘  └────────────┘
+       │             │
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  使用本地  │  │ Fail Closed│
+│  憑證驗證  │  │ (不回退)   │
+└────────────┘  └────────────┘
+```
+
+### ⭐⭐⭐ Commands/config writes 帳號範圍強制
+- **用途**: `/config` 及 `/allowlist` 編輯同時驗證發起帳號與目標帳號範圍
+- **解決問題**: 兄弟帳號可透過 config 寫入路徑竄改其他帳號的設定
+- **影響**: 防止橫向帳號竄改，同時保留 gateway `operator.admin` 正常流程
+
+```text
+┌──────────────────────┐
+│  /config 寫入請求    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  驗證發起帳號範圍    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  驗證目標帳號範圍    │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 同帳號 │   │ 兄弟帳號 │
+│ /管理員│   │ 竄改     │
+└────────┘   └──────────┘
+    │             │
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 允許   │   │  拒絕    │
+└────────┘   └──────────┘
+```
+
+### ⭐⭐⭐ Security/system.run fail-closed
+- **用途**: approval-backed interpreter/runtime 指令無法綁定單一具體本地檔案時拒絕執行
+- **解決問題**: 模糊的檔案操作數可能繞過 approval 機制執行非預期指令
+- **影響**: 確保需要核准的系統指令只在明確綁定本地檔案時執行
+
+```text
+┌──────────────────────────┐
+│  system.run 指令請求     │
+│  (approval-backed)       │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  嘗試綁定具體本地檔案    │
+└──────────────────────────┘
+              │
+       ┌──────┴──────┐
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  綁定成功  │  │  無法綁定  │
+└────────────┘  └────────────┘
+       │             │
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  執行指令  │  │ Fail Closed│
+└────────────┘  └────────────┘
+```
+
+### ⭐⭐⭐ Gateway/session reset auth 分離
+- **用途**: 將 `/new`、`/reset` 對話指令從管理員專用 `sessions.reset` control-plane RPC 分離
+- **解決問題**: write-scope gateway 呼叫者可透過 `agent` 觸及特權 reset 路徑
+- **影響**: 一般使用者的對話重置與管理員的 session 控制平面完全隔離
+
+```text
+┌──────────────────────┐     ┌──────────────────────┐
+│  /reset 或 /new      │     │  sessions.reset RPC  │
+│  (write-scope 可用)  │     │  (operator.admin 限定)│
+└──────────────────────┘     └──────────────────────┘
+           │                            │
+           ▼                            ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  對話層處理          │     │  管理員控制平面      │
+│  (完全隔離)          │     │  (完全隔離)          │
+└──────────────────────┘     └──────────────────────┘
+```
+
+### ⭐⭐⭐ Security/plugin runtime 未驗證路由隔離
+- **用途**: 未驗證插件 HTTP 路由不再繼承合成管理員 gateway scope
+- **解決問題**: 未驗證插件路由呼叫 `runtime.subagent.*` 時可繼承管理員 scope，存取 `sessions.delete` 等特權方法
+- **影響**: 插件 HTTP 端點的權限與 gateway 驗證狀態正確隔離
+
+```text
+┌──────────────────────────┐
+│  未驗證插件 HTTP 請求    │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  runtime.subagent.* 呼叫 │
+│  Scope 不繼承管理員      │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  sessions.delete 等      │
+│  特權方法 → 拒絕         │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Security/session_status 沙箱可見性強制
+- **用途**: 讀取或修改目標 session 狀態前強制執行沙箱 session 樹可見性與共享代理存取守衛
+- **解決問題**: 沙箱子代理可透過 `session_status` 讀取父 session 元資料或寫入父模型覆蓋
+- **影響**: 沙箱隔離邊界得到強化，子代理無法越權存取父 session
+
+```text
+┌──────────────────────────┐
+│  沙箱子代理              │
+│  session_status 請求     │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  沙箱 session 樹         │
+│  可見性檢查              │
+└──────────────────────────┘
+              │
+       ┌──────┴──────┐
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  可見範圍  │  │  父/外部   │
+│  內        │  │  session   │
+└────────────┘  └────────────┘
+       │             │
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  允許存取  │  │  拒絕存取  │
+└────────────┘  └────────────┘
+```
+
+### ⭐⭐⭐ Security/nodes owner-only fallback
+- **用途**: `nodes` 代理工具設為 owner-only fallback policy
+- **解決問題**: 非擁有者發送者可透過共享工具集觸及配對節點核准或呼叫路徑
+- **影響**: 節點管理操作限制於擁有者，防止未授權的節點控制
+
+```text
+┌──────────────────────┐
+│  nodes 工具呼叫      │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Owner-only 政策檢查 │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 擁有者 │   │ 非擁有者 │
+└────────┘   └──────────┘
+    │             │
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 允許   │   │  拒絕    │
+└────────┘   └──────────┘
+```
+
+### ⭐⭐⭐ Security/external content 邊界標記強化 ([#35983](https://github.com/openclaw/openclaw/pull/35983))
+- **用途**: 空白分隔的 `EXTERNAL UNTRUSTED CONTENT` 邊界標記與底線分隔變體同等處理
+- **解決問題**: prompt wrapper 可使用空白分隔變體繞過標記清理，注入惡意外部內容
+- **影響**: 外部內容邊界標記的清理更加完整，防止 prompt injection 繞過
+
+```text
+┌──────────────────────────────────┐
+│  外部內容輸入（含邊界標記）      │
+└──────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────┐
+│  標記正規化                      │
+│  EXTERNAL_UNTRUSTED_CONTENT      │
+│  EXTERNAL UNTRUSTED CONTENT      │
+│  → 統一處理                      │
+└──────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────┐
+│  清理邊界標記                    │
+│  防止 prompt injection           │
+└──────────────────────────────────┘
+```
+
+### ⭐⭐⭐ Subagents/authority 控制範圍持久化
+- **用途**: spawn 時持久化 leaf vs orchestrator 控制範圍，透過共享所有權檢查路由工具與 slash-command 控制
+- **解決問題**: leaf session 在還原或 flat-key 查找後可重獲協調特權
+- **影響**: 子代理的權限邊界在 session 生命週期內保持一致，防止特權升級
+
+```text
+┌──────────────────────┐
+│  sessions_spawn      │
+│  (leaf session)      │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  持久化控制範圍      │
+│  leaf / orchestrator │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Session 還原後      │
+│  仍從持久化狀態      │
+│  載入 (leaf=leaf)    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  工具/指令路由       │
+│  依範圍授權          │
+└──────────────────────┘
+```
+
+### ⭐⭐ Telegram/exec approvals 強化 ([#37233](https://github.com/openclaw/openclaw/pull/37233))
+- **用途**: 拒絕針對其他 bot 的 `/approve` 指令，保持確定性核准提示，停止精確 ID 前綴匹配其他待核准項目
+- **解決問題**: 惡意使用者可偽造 `/approve` 指令劫持其他 bot 的核准流程
+- **影響**: Telegram exec 核准流程更加安全，防止跨 bot 核准劫持
+
+### ⭐⭐ Gateway/auth token drift 容錯 ([#42507](https://github.com/openclaw/openclaw/pull/42507))
+- **用途**: shared-token 不符時允許一次受信任裝置 token 重試，並提供恢復提示
+- **解決問題**: token drift 導致不必要的重連循環
+- **影響**: 減少 token 漂移時的重連干擾，同時保持安全性
+
+---
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ iOS/Home canvas 全面翻新 ([#42456](https://github.com/openclaw/openclaw/pull/42456))
+- **用途**: 新增內建歡迎畫面含即時代理概覽（連線、重連、前景返回時刷新）；停靠工具列取代浮動控制項；聊天在已解析的 main session 中開啟
+- **解決問題**: 浮動控制項遮擋畫布內容；連線狀態膠囊位置不佳；聊天開啟於合成 `ios` session
+- **影響**: iOS 使用者獲得更清晰的首頁體驗，代理狀態一目了然
+
+```text
+┌──────────────────────────────────┐
+│  iOS App 啟動 / 前景返回         │
+└──────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────┐
+│  歡迎畫面                        │
+│  即時代理概覽刷新                │
+└──────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────┐
+│  停靠工具列（底部）              │
+│  取代浮動控制項                  │
+└──────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────┐
+│  開啟聊天                        │
+│  → 已解析的 main session         │
+└──────────────────────────────────┘
+```
+
+### ⭐⭐⭐ macOS/chat UI 模型選擇器 ([#42314](https://github.com/openclaw/openclaw/pull/42314))
+- **用途**: 新增聊天模型選擇器、跨重啟持久化明確 thinking-level 選擇、強化 provider-aware session 模型同步
+- **解決問題**: 使用者每次重啟後需重新選擇模型與 thinking level；session 模型同步不穩定
+- **影響**: macOS 使用者可持久化模型偏好，提升工作流程連貫性
+
+```text
+┌──────────────────────┐
+│  macOS 聊天介面      │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  模型選擇器          │
+│  (含 thinking level) │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  持久化至本地儲存    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  重啟後自動恢復      │
+│  模型與 thinking     │
+│  level 設定          │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Onboarding/Ollama 一流支援 ([#41529](https://github.com/openclaw/openclaw/pull/41529))
+- **用途**: 新增 Local 或 Cloud+Local 模式、瀏覽器雲端登入、精選模型建議、雲端模型處理跳過不必要的本地拉取
+- **解決問題**: Ollama 設定流程繁瑣，缺乏引導；雲端模型誤觸發本地拉取
+- **影響**: 新使用者可透過精簡的 onboarding 快速設定 Ollama，降低入門門檻
+
+```text
+┌──────────────────────┐
+│  Ollama Onboarding   │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌──────────────┐
+│ Local  │   │ Cloud+Local  │
+│ 模式   │   │ 模式         │
+└────────┘   └──────────────┘
+    │             │
+    └──────┬──────┘
+           ▼
+┌──────────────────────┐
+│  精選模型建議        │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  雲端模型            │
+│  → 跳過本地拉取      │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ ACP/sessions_spawn resumeSessionId ([#41847](https://github.com/openclaw/openclaw/pull/41847))
+- **用途**: `runtime: "acp"` 的 `sessions_spawn` 支援可選的 `resumeSessionId`，恢復既有 ACPX/Codex 對話
+- **解決問題**: ACP spawn 每次都建立全新 session，無法延續既有對話上下文
+- **影響**: IDE 客戶端可恢復中斷的 ACP 對話，保持上下文連貫性
+
+```text
+┌──────────────────────────┐
+│  sessions_spawn          │
+│  runtime: "acp"          │
+└──────────────────────────┘
+              │
+       ┌──────┴──────┐
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  有        │  │  無        │
+│  resumeId  │  │  resumeId  │
+└────────────┘  └────────────┘
+       │             │
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  恢復既有  │  │  建立新    │
+│  ACP 對話  │  │  Session   │
+└────────────┘  └────────────┘
+```
+
+### ⭐⭐⭐ Memory 多模態圖片與音訊索引 ([#43460](https://github.com/openclaw/openclaw/pull/43460))
+- **用途**: opt-in 圖片與音訊索引，使用 Gemini `gemini-embedding-2-preview`，嚴格 fallback 閘控，scope-based 重新索引
+- **解決問題**: 記憶搜尋僅支援文字，無法索引圖片與音訊內容
+- **影響**: 多模態內容可納入記憶搜尋，擴展 AI 記憶能力
+
+```text
+┌──────────────────────────┐
+│  memorySearch.extraPaths │
+│  (含圖片/音訊)           │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  多模態索引              │
+│  Gemini embedding-2      │
+└──────────────────────────┘
+              │
+       ┌──────┴──────┐
+       ▼             ▼
+┌────────────┐  ┌────────────┐
+│  索引成功  │  │  Fallback  │
+│            │  │  閘控      │
+└────────────┘  └────────────┘
+       │
+       ▼
+┌────────────┐
+│  記憶搜尋  │
+│  含多模態  │
+└────────────┘
+```
+
+### ⭐⭐ OpenCode/onboarding Go provider ([#42313](https://github.com/openclaw/openclaw/pull/42313))
+- **用途**: 新增 OpenCode Go provider，Zen 與 Go 在 wizard/docs 中視為同一 OpenCode 設定，共用一組 key
+- **解決問題**: OpenCode Go 缺乏一流 onboarding 支援；Zen 與 Go 設定分散
+- **影響**: OpenCode 使用者設定更簡化，一組 key 同時支援兩個 profile
+
+### ⭐⭐ Memory/Gemini gemini-embedding-2-preview ([#42501](https://github.com/openclaw/openclaw/pull/42501))
+- **用途**: `gemini-embedding-2-preview` 記憶搜尋支援，可設定輸出維度，維度變更時自動重新索引
+- **解決問題**: 缺乏 Gemini embedding 支援；維度變更後需手動重新索引
+- **影響**: 使用者可選用 Gemini embedding 模型，維度設定更靈活
+
+### ⭐⭐ macOS/onboarding 遠端 gateway token 偵測 ([#43100](https://github.com/openclaw/openclaw/pull/43100))
+- **用途**: 偵測遠端 gateway 需要 shared auth token，說明在 gateway 主機上的取得位置，並區分配對裝置驗證
+- **解決問題**: 使用者不清楚遠端 gateway 需要 shared token 及如何取得
+- **影響**: 降低遠端 gateway 設定的困惑，提升 onboarding 成功率
+
+### ⭐⭐ iOS/TestFlight 本地 beta 發佈流程 ([#42991](https://github.com/openclaw/openclaw/pull/42991))
+- **用途**: Fastlane prepare/archive/upload 支援，正式 beta bundle ID，watch-app archive 修復
+- **解決問題**: 缺乏標準化的 TestFlight 發佈流程
+- **影響**: iOS 開發者可透過 Fastlane 自動化 beta 發佈
+
+### ⭐⭐ Gateway/node pending work 佇列原語 ([#41409](https://github.com/openclaw/openclaw/pull/41409))
+- **用途**: 新增 `node.pending.enqueue` / `node.pending.drain` 記憶體佇列原語與 wake-helper 重用
+- **解決問題**: 缺乏休眠節點工作交付的基礎設施
+- **影響**: 為休眠節點工作交付奠定基礎，提升節點管理能力
+
+### ⭐ OpenRouter/models Hunter & Healer Alpha ([#43642](https://github.com/openclaw/openclaw/pull/43642))
+- **用途**: 新增臨時免費隱身模型目錄條目（約一週可用期）
+- **解決問題**: OpenRouter 使用者無法在內建目錄中找到新免費模型
+- **影響**: 使用者可在可用期間試用新隱身模型
+
+### ⭐ Discord/auto threads autoArchiveDuration ([#35065](https://github.com/openclaw/openclaw/pull/35065))
+- **用途**: 可設定自動建立討論串的封存時間（1小時/1天/3天/1週）
+- **解決問題**: 自動建立的討論串固定使用 1 小時封存，無法自訂
+- **影響**: Discord 管理員可依需求設定討論串封存時間
+
+### ⭐ Git/runtime state .dev-state 忽略 ([#41848](https://github.com/openclaw/openclaw/pull/41848))
+- **用途**: gateway 產生的 `.dev-state` 檔案加入 git ignore
+- **解決問題**: 本地 runtime 狀態出現於 git untracked 清單，造成干擾
+- **影響**: 開發者的 git 工作區更整潔
+
+### ⭐ Exec/child commands OPENCLAW_CLI 標記 ([#41411](https://github.com/openclaw/openclaw/pull/41411))
+- **用途**: 子程序環境標記 `OPENCLAW_CLI`，子程序可偵測是否由 OpenClaw CLI 啟動
+- **解決問題**: 子程序無法判斷自身是否在 OpenClaw 環境中執行
+- **影響**: 插件與工具可依啟動環境調整行為
+
+---
+
+## 重大變更 (Breaking Changes)
+
+### ⭐⭐⭐ Cron/doctor 隔離交付收緊 ([#40998](https://github.com/openclaw/openclaw/pull/40998))
+- **用途**: cron 工作不再透過臨時代理發送或 fallback main-session 摘要通知；新增 `openclaw doctor --fix` 遷移舊版 cron 儲存與通知/webhook 交付元資料
+- **解決問題**: cron 工作透過非隔離路徑通知，導致交付行為不一致
+- **影響**: **需執行 `openclaw doctor --fix` 遷移**，否則舊版 cron 設定可能無法正常運作
+
+```text
+┌──────────────────────┐
+│  升級至 2026.3.11    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  執行遷移            │
+│  openclaw doctor     │
+│  --fix               │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Cron 工作           │
+│  僅透過隔離路徑      │
+│  交付通知            │
+└──────────────────────┘
+```
+
+---
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Agents/text sanitization 清除控制 token ([#42173](https://github.com/openclaw/openclaw/pull/42173))
+- **用途**: 清除洩漏至使用者端的模型控制 token（`<|...|>` 及全形 `<｜...｜>` 變體）
+- **解決問題**: GLM-5 和 DeepSeek 的內部分隔符洩漏至使用者可見的助理文字
+- **影響**: 使用者不再看到模型內部控制符號，輸出更乾淨
+
+```text
+┌──────────────────────────┐
+│  模型輸出文字            │
+│  (含控制 token)          │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  sanitization 過濾       │
+│  <|...|> 及 <｜...｜>   │
+└──────────────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│  乾淨的使用者可見文字    │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/macOS launchd 重啟修復
+- **用途**: 明確重啟時保持 LaunchAgent 已註冊，透過 detached launchd helper 自我重啟，恢復 config/hot reload 重啟路徑
+- **解決問題**: 明確重啟時 LaunchAgent 被取消註冊，導致 gateway 無法自動重啟 (fixes [#43311](https://github.com/openclaw/openclaw/issues/43311), [#43406](https://github.com/openclaw/openclaw/issues/43406), [#43035](https://github.com/openclaw/openclaw/issues/43035), [#43049](https://github.com/openclaw/openclaw/issues/43049))
+- **影響**: macOS 使用者的 gateway 重啟更加可靠，不再需要手動重新載入 LaunchAgent
+
+```text
+┌──────────────────────┐
+│  Gateway 重啟請求    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  保持 LaunchAgent    │
+│  已註冊              │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  透過 detached       │
+│  launchd helper      │
+│  自我重啟            │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Gateway 重啟完成    │
+│  LaunchAgent 仍有效  │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/Control UI session-scoped token 儲存 ([#40892](https://github.com/openclaw/openclaw/pull/40892))
+- **用途**: dashboard auth token 改存 session-scoped browser storage，同分頁重新整理保留遠端 token 驗證，不再恢復 localStorage 長期持久化
+- **解決問題**: dashboard token 長期存於 localStorage，存在安全風險；token 未依 gateway URL 範圍隔離
+- **影響**: 提升 Control UI 的 token 安全性，token 隨分頁關閉自動清除
+
+```text
+┌──────────────────────┐
+│  Dashboard 登入      │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Token 存入          │
+│  Session Storage     │
+│  (非 localStorage)   │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 同分頁 │   │ 分頁關閉 │
+│ 重整   │   │          │
+└────────┘   └──────────┘
+    │             │
+    ▼             ▼
+┌────────┐   ┌──────────┐
+│ 保留   │   │ Token    │
+│ Token  │   │ 自動清除 │
+└────────┘   └──────────┘
+```
+
+### ⭐⭐ iOS/gateway foreground recovery ([#41384](https://github.com/openclaw/openclaw/pull/41384))
+- **用途**: 前景返回時立即重連，不再等待後續喚醒路徑
+- **解決問題**: 背景 socket 被清除後，app 返回前景仍保持斷線狀態
+- **影響**: iOS 使用者返回 app 後立即恢復連線，無需等待
+
+### ⭐⭐ Agents/Azure OpenAI Responses store override ([#42934](https://github.com/openclaw/openclaw/pull/42934))
+- **用途**: Azure OpenAI provider 加入 Responses API store override
+- **解決問題**: Azure OpenAI 多輪 cron 工作和嵌入式代理執行失敗，回傳 HTTP 400 "store is set to false" (fixes [#42800](https://github.com/openclaw/openclaw/issues/42800))
+- **影響**: Azure OpenAI 使用者的 cron 工作和嵌入式代理可正常執行
+
+### ⭐⭐ ACP/sessions_spawn implicit streaming 恢復 ([#42404](https://github.com/openclaw/openclaw/pull/42404))
+- **用途**: `mode="run"` ACP spawn 恢復向符合條件的父 session 串流進度
+- **解決問題**: ACP spawn 進度不再傳遞至父 session
+- **影響**: IDE 客戶端可再次看到子代理的執行進度
+
+### ⭐⭐ ACP/main session aliases 正規化 ([#43285](https://github.com/openclaw/openclaw/pull/43285))
+- **用途**: `main` 在 ACP session 查找前先正規化
+- **解決問題**: 重啟的 ACP main session 失敗，回傳 `Session is not ACP-enabled: main` (fixes [#25692](https://github.com/openclaw/openclaw/issues/25692))
+- **影響**: ACP main session 重啟後可正常恢復
+
+### ⭐⭐ Models/Kimi Coding tool calls 原生格式恢復 ([#38669](https://github.com/openclaw/openclaw/pull/38669))
+- **用途**: 恢復以原生 Anthropic 格式發送 `anthropic-messages` 工具
+- **解決問題**: `kimi-coding` 將工具呼叫降級為 XML/plain-text 偽呼叫，而非真正的 `tool_use` blocks
+- **影響**: Kimi Coding 使用者的工具呼叫功能恢復正常
+
+### ⭐⭐ Telegram/outbound HTML 分塊 ([#42240](https://github.com/openclaw/openclaw/pull/42240))
+- **用途**: 長 HTML 訊息分塊，保留 plain-text fallback 與 silent-delivery 參數
+- **解決問題**: 長 HTML 訊息無法正常發送
+- **影響**: Telegram 使用者可收到完整的長 HTML 訊息
+
+### ⭐⭐ Discord/reply chunking maxLinesPerMessage ([#40133](https://github.com/openclaw/openclaw/pull/40133))
+- **用途**: 解析有效 `maxLinesPerMessage` 設定，在快速發送路徑保留 `chunkMode`
+- **解決問題**: 長 Discord 回覆意外在預設 17 行限制處分割
+- **影響**: Discord 訊息依設定正確分塊，不再意外截斷
+
+### ⭐⭐ macOS/LaunchAgent install 權限收緊
+- **用途**: 安裝時收緊 LaunchAgent 目錄與 plist 權限
+- **解決問題**: 目標 home path 或 plist 繼承 group/world-writable 模式時 launchd bootstrap 失敗
+- **影響**: macOS LaunchAgent 安裝更加可靠
+
+### ⭐ Agents/fallback HTTP 499 ([#41468](https://github.com/openclaw/openclaw/pull/41468))
+- **用途**: 將 HTTP 499 視為暫時性錯誤觸發 model fallback
+- **解決問題**: Anthropic-style client-closed 過載回應未觸發 fallback
+- **影響**: 過載時自動切換備用模型，提升可用性
+
+### ⭐ Agents/fallback Venice 402 ([#43205](https://github.com/openclaw/openclaw/pull/43205))
+- **用途**: 識別 Venice `402 Insufficient USD or Diem balance` 錯誤觸發 fallback
+- **解決問題**: Venice 餘額不足時顯示原始 provider 錯誤而非切換備用模型
+- **影響**: Venice 餘額不足時自動切換備用模型
+
+### ⭐ Agents/fallback Poe 402 ([#42278](https://github.com/openclaw/openclaw/pull/42278))
+- **用途**: 識別 Poe `402 You've used up your points!` 錯誤觸發 fallback
+- **解決問題**: Poe 點數用盡時顯示原始 provider 錯誤
+- **影響**: Poe 點數用盡時自動切換備用模型
+
+### ⭐ Agents/failover Gemini MALFORMED_RESPONSE ([#42292](https://github.com/openclaw/openclaw/pull/42292))
+- **用途**: 將 Gemini `MALFORMED_RESPONSE` stop reason 視為可重試 timeout
+- **解決問題**: preview-model enum drift 導致執行崩潰而非 fallback
+- **影響**: Gemini 模型格式問題時優雅 fallback，不再崩潰
+
+### ⭐ Agents/cooldowns unknown 預設值 ([#42911](https://github.com/openclaw/openclaw/pull/42911))
+- **用途**: 無失敗歷史的 cooldown 視窗預設為 `unknown` 而非 `rate_limit`
+- **解決問題**: 無歷史記錄時顯示誤導性的 API rate-limit 警告
+- **影響**: cooldown 狀態顯示更準確
+
+### ⭐ Auth/cooldowns 過期計數器重置 ([#41028](https://github.com/openclaw/openclaw/pull/41028))
+- **用途**: 過期 auth-profile cooldown 錯誤計數器在計算下次退避前先重置
+- **解決問題**: 過期的磁碟計數器在過期後重新升級為長時間 cooldown 循環
+- **影響**: cooldown 過期後正確恢復，不再陷入長時間循環
+
+### ⭐ Agents/error rendering 過時 errorMessage 忽略 ([#40616](https://github.com/openclaw/openclaw/pull/40616))
+- **用途**: 成功回合忽略過時的助理 `errorMessage` 欄位
+- **解決問題**: 背景/工具端失敗在有效回覆前前置合成帳單錯誤
+- **影響**: 使用者不再看到誤導性的錯誤訊息
+
+### ⭐ Agents/billing recovery ([#41422](https://github.com/openclaw/openclaw/pull/41422))
+- **用途**: 在現有 throttle 上探測單一 provider 帳單 cooldown
+- **解決問題**: 充值後需手動重啟 gateway 才能恢復
+- **影響**: 充值後自動恢復，無需重啟 gateway
+
+### ⭐ Feishu/local image auto-convert ([#40623](https://github.com/openclaw/openclaw/pull/40623))
+- **用途**: 透過 `sendText` local-image shim 傳遞 `mediaLocalRoots`
+- **解決問題**: 允許的本地圖片路徑回退為原始路徑文字而非上傳為 Feishu 圖片
+- **影響**: Feishu 本地圖片自動轉換功能恢復正常
+
+### ⭐ Telegram/final preview delivery ([#41662](https://github.com/openclaw/openclaw/pull/41662))
+- **用途**: 分離 active preview 生命週期與清理保留，避免重複 fallback 發送
+- **解決問題**: 缺少封存 preview 編輯導致重複 fallback 發送
+- **影響**: Telegram 使用者不再收到重複的最終回覆
+
+### ⭐ ACP/sessions.patch lineage fields ([#40995](https://github.com/openclaw/openclaw/pull/40995))
+- **用途**: 允許 `spawnedBy`、`spawnDepth` lineage 欄位於 ACP session keys
+- **解決問題**: `sessions_spawn` with `runtime: "acp"` 在子 session 建立時失敗 (fixes [#40971](https://github.com/openclaw/openclaw/issues/40971))
+- **影響**: ACP spawn 子 session 建立恢復正常
+
+### ⭐ CLI/skills JSON ANSI 清除 ([#27530](https://github.com/openclaw/openclaw/issues/27530))
+- **用途**: `skills list/info/check --json` 輸出清除 ANSI 及 C1 控制字元
+- **解決問題**: 機器可讀輸出因嵌入控制字元而無效
+- **影響**: JSON 輸出可被程式正確解析
+
+### ⭐ CLI/tables ASCII borders on legacy Windows ([#40853](https://github.com/openclaw/openclaw/issues/40853))
+- **用途**: 舊版 Windows 主控台預設 ASCII 邊框，現代 Windows 終端機保留 Unicode 邊框
+- **解決問題**: GBK/936 主控台下 `openclaw skills` 等指令顯示亂碼
+- **影響**: Windows 使用者在舊版主控台下可正常顯示表格
+
+### ⭐ Channels/allowlists stale matcher 快取清除
+- **用途**: 移除過時的 matcher 快取，同陣列 allowlist 編輯與萬用字元替換立即生效
+- **解決問題**: in-place 陣列修改後 allowlist 變更未立即套用
+- **影響**: allowlist 設定變更即時生效
+
+### ⭐ Tools/web search Brave llm-context ([#41387](https://github.com/openclaw/openclaw/pull/41387))
+- **用途**: 將 Brave `llm-context` grounding snippets 視為純字串
+- **解決問題**: LLM Context 模式下 `web_search` 回傳空 snippet 陣列
+- **影響**: Brave 搜尋結果在 LLM Context 模式下正常顯示
+
+### ⭐ Tools/web search OpenRouter Perplexity citations ([#40881](https://github.com/openclaw/openclaw/pull/40881))
+- **用途**: 從 `message.annotations` 恢復 OpenRouter Perplexity 引用提取
+- **解決問題**: chat-completions 回應省略頂層 citations 時引用提取失敗
+- **影響**: Perplexity 搜尋引用正常顯示
+
+### ⭐ Signal/config schema accountUuid ([#35578](https://github.com/openclaw/openclaw/pull/35578))
+- **用途**: 嚴格設定驗證接受 `channels.signal.accountUuid`
+- **解決問題**: loop-protection 設定因未識別 key 錯誤而失敗
+- **影響**: Signal 設定驗證不再誤報錯誤
+
+### ⭐ Telegram/config schema editMessage/createForumTopic ([#35498](https://github.com/openclaw/openclaw/pull/35498))
+- **用途**: 嚴格驗證接受 `channels.telegram.actions.editMessage` 和 `createForumTopic`
+- **解決問題**: 現有 Telegram 動作設定因未識別 key 錯誤而失敗
+- **影響**: Telegram 動作設定驗證不再誤報錯誤
+
+### ⭐ Discord/config typing autoThread ([#35608](https://github.com/openclaw/openclaw/pull/35608))
+- **用途**: 在正式 guild-channel 設定型別上暴露頻道層級 `autoThread`
+- **解決問題**: 嚴格設定載入與現有 Discord schema 不符
+- **影響**: Discord autoThread 設定驗證正常
+
+### ⭐ Models/Alibaba Cloud ModelStudio MODELSTUDIO_API_KEY ([#40634](https://github.com/openclaw/openclaw/pull/40634))
+- **用途**: `MODELSTUDIO_API_KEY` 透過 shared env auth、implicit provider discovery 和 shell-env fallback 連線
+- **解決問題**: wizard 外的 onboarding 無法正常運作
+- **影響**: Alibaba Cloud Model Studio 設定更靈活
+
+### ⭐ Mattermost/Markdown formatting ([#18655](https://github.com/openclaw/openclaw/pull/18655))
+- **用途**: 清除 bot mentions 時保留首行縮排；預設原生渲染 Mattermost 表格
+- **解決問題**: 巢狀清單項目和縮排程式碼區塊結構被破壞；表格以 fenced-code fallback 顯示
+- **影響**: Mattermost 訊息格式更正確
+
+### ⭐ MS Teams/allowlist resolution ([#41838](https://github.com/openclaw/openclaw/pull/41838))
+- **用途**: 使用 General channel conversation ID 作為已解析的 team key（含 Graph GUID fallback）
+- **解決問題**: Bot Framework runtime `channelData.team.id` 匹配對 team 和 team/channel allowlist 條目失敗
+- **影響**: MS Teams allowlist 設定正常運作
+
+### ⭐ Cron/subagent 空回應誤判修復 ([#41383](https://github.com/openclaw/openclaw/pull/41383))
+- **用途**: 空或 `NO_REPLY` cron 回應不再被誤判為需重跑的臨時確認
+- **解決問題**: 刻意靜默的 cron 工作被不必要地重試
+- **影響**: 靜默 cron 工作行為符合預期
+
+### ⭐ Browser/Browserbase 429 處理 ([#40491](https://github.com/openclaw/openclaw/pull/40491))
+- **用途**: 穩定呈現不重試的速率限制提示，不緩衝丟棄的 HTTP 429 回應 body
+- **解決問題**: 遠端瀏覽器服務速率限制時處理不當
+- **影響**: Browserbase 速率限制時提供清晰的錯誤提示
+
+### ⭐ Sandbox/subagents workspace 傳遞 ([#40757](https://github.com/openclaw/openclaw/pull/40757))
+- **用途**: `sessions_spawn` 繼承時傳遞真實設定的 workspace
+- **解決問題**: 父代理在複製 workspace 沙箱中執行時，子代理 `/agent` 掛載指向父沙箱副本而非設定的 workspace
+- **影響**: 沙箱子代理可存取正確的 workspace
+
+### ⭐ Agents/fallback cooldown probing 上限 ([#41711](https://github.com/openclaw/openclaw/pull/41711))
+- **用途**: 每次 fallback 每 provider 最多一次 cooldown bypass 探測
+- **解決問題**: 多模型同 provider cooldown 鏈重複停滯於重複的 cooldown 探測，無法繼續跨 provider fallback
+- **影響**: fallback 鏈更有效率，不再卡在同 provider 重複探測
+
+### ⭐ Telegram/polling restarts 計時器清除 ([#43188](https://github.com/openclaw/openclaw/pull/43188))
+- **用途**: `runner.stop()` 和 `bot.stop()` 完成後清除 cleanup timeout handle
+- **解決問題**: 乾淨關閉後留下 15 秒計時器殘留
+- **影響**: Telegram polling 重啟後不再有殘留計時器
+
+### ⭐ CLI/memory teardown ([#40389](https://github.com/openclaw/openclaw/pull/40389))
+- **用途**: one-shot CLI 關閉路徑中關閉快取記憶體搜尋/索引管理器
+- **解決問題**: watcher-backed 記憶體快取在 CLI 執行完成後保持程序存活
+- **影響**: CLI 執行完成後程序正確退出
+
+### ⭐ Control UI/Sessions 窄視窗單欄折疊 ([#12175](https://github.com/openclaw/openclaw/pull/12175))
+- **用途**: 移動響應式表格覆蓋規則至基礎 grid 規則旁，啟用 inline-size container queries
+- **解決問題**: 窄視窗或容器寬度下 session 表格無法正確折疊為單欄
+- **影響**: Control UI 在窄視窗下顯示正常
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 安全性提升 | 14 | 2 | 0 | 多項高危漏洞修復，含 WebSocket 劫持、沙箱逃逸、特權升級防護 |
+| 功能更新 | 5 | 5 | 5 | iOS/macOS UI 翻新、Ollama 一流支援、ACP 恢復對話、多模態記憶 |
+| 重大變更 | 1 | 0 | 0 | Cron 隔離交付收緊，需執行 `openclaw doctor --fix` 遷移 |
+| 錯誤修復 | 3 | 7 | 27 | 廣泛修復 ACP、Agents、Telegram、Discord、CLI 等各模組 |
+| **總計** | **23** | **14** | **32** | **共 69 項變更** |
+
+**發佈日期**: 2026-03-11
+**版本**: 2026.3.11
+**狀態**: Production Ready
+**GitHub Release**: [https://github.com/openclaw/openclaw/releases/tag/v2026.3.11](https://github.com/openclaw/openclaw/releases/tag/v2026.3.11)


### PR DESCRIPTION
Closes #318

## Release Notes: OpenClaw 2026.3.11

新增 `release-notes/2026-03-11.md`，涵蓋：

- **安全性提升 16 項**（14 項 ⭐⭐⭐）：WebSocket 跨站劫持、沙箱逃逸、特權升級防護等高危漏洞修復
- **功能更新 15 項**（5 項 ⭐⭐⭐）：iOS/macOS UI 翻新、Ollama 一流支援、ACP resumeSessionId、多模態記憶索引
- **重大變更 1 項**（⭐⭐⭐）：Cron 隔離交付收緊，需執行 `openclaw doctor --fix`
- **錯誤修復 37 項**（3 項 ⭐⭐⭐）：ACP、Agents、Telegram、Discord、CLI 等廣泛修復

共 69 項變更，所有 ⭐⭐⭐ 項目均附 ASCII 流程圖。
