### PR TITLE
docs: add release notes for OpenClaw v2026.3.12 (zh-TW)

### DIFF
--- a/release-notes/2026-03-12.md
+++ b/release-notes/2026-03-12.md
@@ -1,0 +1,707 @@
+# OpenClaw v2026.3.12 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.12)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Control UI/Dashboard v2 全面翻新**：模組化概覽、聊天、設定、Agent 與 Session 視圖，新增命令面板、行動裝置底部分頁及豐富聊天工具 ([#41503](https://github.com/openclaw/openclaw/pull/41503))
+- ⭐⭐⭐ **OpenAI/GPT-5.4 Fast Mode**：新增可設定的 session 層級 fast 切換，跨 `/fast`、TUI、Control UI 與 ACP，含 per-model 預設與 OpenAI/Codex request shaping
+- ⭐⭐⭐ **Anthropic/Claude Fast Mode**：將共用 `/fast` 切換與 `params.fastMode` 對應至 Anthropic API `service_tier` 請求，含即時驗證
+- ⭐⭐⭐ **Models/Plugins 架構重構**：將 Ollama、vLLM、SGLang 遷移至 provider-plugin 架構，provider 自主 onboarding、discovery 與 model-picker
+- ⭐⭐ **Agents/Subagents sessions_yield**：新增 `sessions_yield` 讓 orchestrator 可立即結束當前 turn 並攜帶隱藏 payload 至下一 turn ([#36537](https://github.com/openclaw/openclaw/pull/36537))
+- ⭐⭐ **Slack/Agent Block Kit 回覆**：支援 `channelData.slack.blocks` 讓 agent 可透過標準 Slack 傳送 Block Kit 訊息 ([#44592](https://github.com/openclaw/openclaw/pull/44592))
+- ⭐⭐ **Docs/Kubernetes 部署**：新增 K8s 入門安裝路徑，含 raw manifests、Kind 設定與部署文件
+- ⭐ **Memory/Session 同步**：新增 mode-aware post-compaction session reindexing 設定 ([#25561](https://github.com/openclaw/openclaw/pull/25561))
+- ⭐ **Context Engine/Session 路由**：轉發 `sessionKey` 至 context-engine 生命週期呼叫 ([#44157](https://github.com/openclaw/openclaw/pull/44157))
+- ⭐ **Native Chat/macOS**：新增 `/new`、`/reset`、`/clear` 重設觸發器 ([#10898](https://github.com/openclaw/openclaw/pull/10898))
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Security/Device Pairing**：`/pair` 與 `openclaw qr` 改用短效 bootstrap token，不再嵌入共用 gateway 憑證
+- ⭐⭐⭐ **Security/Plugin 自動載入停用**：停用隱式 workspace plugin auto-load，防止 clone 的 repo 未經信任決策即執行 plugin 程式碼 ([#44174](https://github.com/openclaw/openclaw/pull/44174))
+- ⭐⭐⭐ **Security/Exec 偵測強化**：正規化相容 Unicode 並剝離不可見格式碼，防止零寬度與全形命令繞過偵測 ([#44091](https://github.com/openclaw/openclaw/pull/44091))
+- ⭐⭐⭐ **Security/Exec Allowlist**：保持 POSIX 大小寫敏感性，`?` 限制在單一路徑段內，防止 allowlist 過度匹配 ([#43798](https://github.com/openclaw/openclaw/pull/43798))
+- ⭐⭐⭐ **Security/Exec Approvals 多重強化**：封堵 inline loader、shell-payload、pnpm/npm exec/npx 腳本繞過 ([#44247](https://github.com/openclaw/openclaw/pull/44247))
+- ⭐⭐⭐ **Security/Session Status 沙箱隔離**：強制沙箱 session-tree 可見性與 agent-to-agent 存取防護 ([#43754](https://github.com/openclaw/openclaw/pull/43754))
+- ⭐⭐ **Security/Commands 權限**：`/config` 與 `/debug` 需 owner 身份 ([#44305](https://github.com/openclaw/openclaw/pull/44305))
+- ⭐⭐ **Security/Gateway Auth**：清除 shared-token WebSocket 連線的未綁定 client-declared scopes ([#44306](https://github.com/openclaw/openclaw/pull/44306))
+- ⭐⭐ **Security/Browser.request**：封鎖持久化 browser profile 建立/刪除路由 ([#43800](https://github.com/openclaw/openclaw/pull/43800))
+- ⭐⭐ **Security/Agent 邊界**：拒絕外部 `agent` 呼叫者覆寫 gateway workspace 邊界 ([#43801](https://github.com/openclaw/openclaw/pull/43801))
+- ⭐⭐ **Security/Exec Approvals Unicode**：跳脫不可見 Unicode 格式字元，防止零寬度命令偽裝 ([#43687](https://github.com/openclaw/openclaw/pull/43687))
+- ⭐⭐ **Security/Device Pairing Scopes**：限制已發行與已驗證 device-token scopes 至核准基線 ([#43686](https://github.com/openclaw/openclaw/pull/43686))
+- ⭐ **Security/WebSocket Preauth**：縮短未認證握手保留時間，拒絕超大 pre-auth frames ([#44089](https://github.com/openclaw/openclaw/pull/44089))
+- ⭐ **Security/Proxy Attachments**：恢復共用 media-store 大小上限 ([#43684](https://github.com/openclaw/openclaw/pull/43684))
+- ⭐ **Security/Host Env**：封鎖繼承的 `GIT_EXEC_PATH` ([#43685](https://github.com/openclaw/openclaw/pull/43685))
+- ⭐ **Security/Feishu Webhook**：要求 `encryptKey` 搭配 `verificationToken` ([#44087](https://github.com/openclaw/openclaw/pull/44087))
+- ⭐ **Security/LINE Webhook**：空事件 POST 探測也需簽名 ([#44090](https://github.com/openclaw/openclaw/pull/44090))
+- ⭐ **Security/Zalo Webhook**：rate limit 無效 secret 猜測 ([#44173](https://github.com/openclaw/openclaw/pull/44173))
+- ⭐ **Security/Hooks Loader**：無法 realpath 的 workspace hook 路徑 fail closed ([#44437](https://github.com/openclaw/openclaw/pull/44437))
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Models/Kimi Coding 工具格式修復**：恢復以原生 Anthropic 格式傳送工具，修復 `kimi-coding` 工具呼叫退化為 XML/純文字 ([#38669](https://github.com/openclaw/openclaw/issues/38669))
+- ⭐⭐⭐ **Sandbox/Write 修復**：保留 pinned mutation-helper payload stdin，修復沙箱 `write` 建立空檔案問題 ([#43876](https://github.com/openclaw/openclaw/pull/43876))
+- ⭐⭐⭐ **ACP/Client 最終訊息傳遞**：保留終端 assistant 文字快照再解析 `end_turn`，修復 ACP client 丟失最後回覆 ([#17615](https://github.com/openclaw/openclaw/pull/17615))
+- ⭐⭐ **TUI/Chat Log 重複修復**：重用同一 streaming run 的 active assistant message component ([#35364](https://github.com/openclaw/openclaw/pull/35364))
+- ⭐⭐ **Telegram/Model Picker 持久化**：inline model 按鈕選擇正確持久化 session model ([#40105](https://github.com/openclaw/openclaw/pull/40105))
+- ⭐⭐ **Cron/Proactive 重複訊息**：隔離 direct cron sends 不進入 write-ahead resend queue ([#40646](https://github.com/openclaw/openclaw/pull/40646))
+- ⭐⭐ **Gateway/Main-Session 路由**：TUI 與 `mode:UI` main-session 保持在 internal surface ([#43918](https://github.com/openclaw/openclaw/pull/43918))
+- ⭐⭐ **Mattermost/Block Streaming 重複**：排除 `replyToId` 於 block reply dedup key ([#41362](https://github.com/openclaw/openclaw/pull/41362))
+- ⭐⭐ **Subagents/Completion Announce 重試**：提高預設 announce timeout 至 90 秒，停止重試 gateway-timeout ([#41235](https://github.com/openclaw/openclaw/issues/41235))
+- ⭐⭐ **Doctor/Gateway Service 審計**：正規化 service entrypoint 路徑，修復 symlink 誤報 ([#43882](https://github.com/openclaw/openclaw/pull/43882))
+- ⭐ **Models/Kimi Coding User-Agent**：預設傳送 `User-Agent: claude-code/0.1.0` header ([#30099](https://github.com/openclaw/openclaw/issues/30099))
+- ⭐ **Ollama/Kimi Cloud**：套用 Moonshot Kimi payload 相容性包裝至 Ollama-hosted Kimi models ([#41519](https://github.com/openclaw/openclaw/issues/41519))
+- ⭐ **Moonshot CN API**：尊重明確 `baseUrl` (api.moonshot.cn) ([#33637](https://github.com/openclaw/openclaw/issues/33637))
+- ⭐ **Agents/Failover**：將 z.ai `network_error` 分類為可重試 timeout ([#43884](https://github.com/openclaw/openclaw/pull/43884))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Control UI/Dashboard v2 全面翻新 ([#41503](https://github.com/openclaw/openclaw/pull/41503))
+- **用途**: 以模組化架構重新設計 gateway dashboard，包含概覽、聊天、設定、Agent 與 Session 視圖，新增命令面板、行動裝置底部分頁，以及斜線命令、搜尋、匯出、釘選訊息等聊天工具
+- **解決問題**: 舊版 dashboard 功能分散、行動裝置體驗不佳，缺乏進階聊天管理功能
+- **影響**: 使用者獲得統一且功能豐富的管理介面，行動裝置可用性大幅提升
+
+```text
+┌──────────────────┐
+│  Dashboard v2    │
+│  (模組化入口)     │
+└──────────────────┘
+         │
+    ┌────┼────┬────────┬──────────┐
+    ▼    ▼    ▼        ▼          ▼
+┌──────┐┌────┐┌──────┐┌───────┐┌────────┐
+│概覽  ││聊天││設定  ││Agent ││Session │
+└──────┘└────┘└──────┘└───────┘└────────┘
+              │
+         ┌────┼────┬──────────┐
+         ▼    ▼    ▼          ▼
+      ┌─────┐┌──┐┌────┐┌──────────┐
+      │搜尋 ││/ ││匯出││釘選訊息  │
+      └─────┘└──┘└────┘└──────────┘
+```
+
+### ⭐⭐⭐ OpenAI/GPT-5.4 Fast Mode
+- **用途**: 新增可設定的 session 層級 fast 切換，跨 `/fast` 指令、TUI、Control UI 與 ACP，含 per-model config 預設與 OpenAI/Codex request shaping
+- **解決問題**: 使用者無法在 session 層級快速切換 fast mode，需手動調整每個介面
+- **影響**: 統一的 fast mode 體驗，所有介面一致切換，降低延遲並提升回應速度
+
+```text
+┌──────────────┐
+│  使用者觸發   │
+│  /fast 切換   │
+└──────────────┘
+        │
+        ▼
+┌──────────────────┐
+│  Session Config  │
+│  fastMode=true   │
+└──────────────────┘
+        │
+   ┌────┼────┬──────┐
+   ▼    ▼    ▼      ▼
+┌────┐┌───┐┌────┐┌─────┐
+│TUI ││CUI││ACP ││/fast│
+└────┘└───┘└────┘└─────┘
+   │    │    │      │
+   └────┼────┼──────┘
+        ▼
+┌──────────────────┐
+│  OpenAI/Codex    │
+│  Request Shaping │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Anthropic/Claude Fast Mode
+- **用途**: 將共用 `/fast` 切換與 `params.fastMode` 對應至 Anthropic API-key `service_tier` 請求，含即時驗證
+- **解決問題**: Anthropic 模型無法使用統一的 fast mode 切換機制
+- **影響**: Anthropic 與 OpenAI fast mode 行為一致，使用者可無縫切換
+
+```text
+┌──────────────┐     ┌─────────────────┐
+│  /fast 切換   │────►│  params.fastMode │
+└──────────────┘     └─────────────────┘
+                              │
+                    ┌─────────┼─────────┐
+                    ▼                   ▼
+           ┌───────────────┐   ┌───────────────┐
+           │  OpenAI       │   │  Anthropic    │
+           │  request      │   │  service_tier │
+           │  shaping      │   │  mapping      │
+           └───────────────┘   └───────────────┘
+                                       │
+                                       ▼
+                               ┌───────────────┐
+                               │  即時驗證 tier │
+                               │  可用性        │
+                               └───────────────┘
+```
+
+### ⭐⭐⭐ Models/Plugins 架構重構
+- **用途**: 將 Ollama、vLLM、SGLang 遷移至 provider-plugin 架構，provider 自主管理 onboarding、discovery、model-picker 設定與 post-selection hooks
+- **解決問題**: 核心 provider 接線耦合度高，新增 provider 需修改核心程式碼
+- **影響**: provider 模組化程度大幅提升，第三方 provider 整合更容易，核心程式碼更精簡
+
+```text
+┌─────────────────────┐
+│  Core Provider Wire │
+│  (舊架構 - 耦合)     │
+└─────────────────────┘
+          │ 重構
+          ▼
+┌─────────────────────┐
+│  Provider-Plugin    │
+│  Architecture       │
+└─────────────────────┘
+     │         │         │
+     ▼         ▼         ▼
+┌────────┐┌────────┐┌────────┐
+│ Ollama ││ vLLM   ││ SGLang │
+│ Plugin ││ Plugin ││ Plugin │
+└────────┘└────────┘└────────┘
+     │         │         │
+     ▼         ▼         ▼
+┌─────────────────────────────┐
+│  自主 Onboarding/Discovery  │
+│  Model-Picker/Post-Select   │
+└─────────────────────────────┘
+```
+
+### ⭐⭐ Agents/Subagents sessions_yield ([#36537](https://github.com/openclaw/openclaw/pull/36537))
+- **用途**: 新增 `sessions_yield` 讓 orchestrator 可立即結束當前 turn、跳過排隊中的工具工作，並攜帶隱藏 follow-up payload 至下一 session turn
+- **解決問題**: orchestrator 無法在 turn 中途中斷並傳遞後續指令
+- **影響**: 多 agent 協作流程更靈活，可實現更精細的 turn 控制
+
+### ⭐⭐ Slack/Agent Block Kit 回覆 ([#44592](https://github.com/openclaw/openclaw/pull/44592))
+- **用途**: 支援 `channelData.slack.blocks` 讓 agent 可透過標準 Slack outbound delivery 傳送 Block Kit 訊息
+- **解決問題**: agent 無法在 Slack 中傳送結構化 Block Kit 訊息
+- **影響**: Slack 整合體驗更豐富，agent 可傳送互動式訊息
+
+### ⭐⭐ Docs/Kubernetes 部署
+- **用途**: 新增 K8s 入門安裝路徑，含 raw manifests、Kind 設定與部署文件
+- **解決問題**: 缺乏官方 Kubernetes 部署指引
+- **影響**: 降低 K8s 部署門檻，社群可更快上手容器化部署
+
+### ⭐ Memory/Session 同步 ([#25561](https://github.com/openclaw/openclaw/pull/25561))
+- **用途**: 新增 mode-aware post-compaction session reindexing，含 `agents.defaults.compaction.postIndexSync` 與 `agents.defaults.memorySearch.sync.sessions.postCompactionForce` 設定
+- **解決問題**: compacted session memory 需等待下次同步才能搜尋
+- **影響**: 可選擇性啟用即時 reindexing，不強制所有部署同步
+
+### ⭐ Context Engine/Session 路由 ([#44157](https://github.com/openclaw/openclaw/pull/44157))
+- **用途**: 轉發可選 `sessionKey` 至 context-engine 生命週期呼叫（bootstrap、assembly、post-turn ingestion、compaction）
+- **解決問題**: plugin 在 context-engine 生命週期中無法取得結構化路由 metadata
+- **影響**: plugin 可根據 session 路由資訊做更精確的處理
+
+### ⭐ Native Chat/macOS ([#10898](https://github.com/openclaw/openclaw/pull/10898))
+- **用途**: 新增 `/new`、`/reset`、`/clear` 重設觸發器，保持共用 main-session 別名對齊，忽略過期 model-selection completions
+- **解決問題**: native chat 狀態在 reset 與快速 model 切換後不同步
+- **影響**: macOS native chat 重設體驗更穩定
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Security/Device Pairing Bootstrap Token
+- **用途**: 將 `/pair` 與 `openclaw qr` 設定碼改為短效 bootstrap token，下一版本不再於聊天或 QR pairing payload 中嵌入共用 gateway 憑證
+- **解決問題**: 共用 gateway 憑證嵌入 pairing payload 中，存在憑證洩漏風險
+- **影響**: pairing 流程安全性大幅提升，token 短效過期降低被濫用風險
+
+```text
+┌──────────────────┐     ┌──────────────────┐
+│  /pair 或 QR     │────►│  產生短效         │
+│  pairing 請求    │     │  Bootstrap Token  │
+└──────────────────┘     └──────────────────┘
+                                  │
+                                  ▼
+                         ┌──────────────────┐
+                         │  Token 過期驗證   │
+                         │  (短效自動失效)   │
+                         └──────────────────┘
+                                  │
+                                  ▼
+                         ┌──────────────────┐
+                         │  配對完成         │
+                         │  (不嵌入 gateway  │
+                         │   共用憑證)       │
+                         └──────────────────┘
+```
+
+### ⭐⭐⭐ Security/Plugin 自動載入停用 ([#44174](https://github.com/openclaw/openclaw/pull/44174))
+- **用途**: 停用隱式 workspace plugin auto-load，clone 的 repository 無法在未經明確信任決策下執行 workspace plugin 程式碼 (`GHSA-99qw-6mr3-36qr`)
+- **解決問題**: 惡意 repo 可透過 workspace plugin 自動載入執行任意程式碼
+- **影響**: 防止供應鏈攻擊，使用者需明確授權才能載入 workspace plugin
+
+```text
+┌──────────────────┐     ┌──────────────────┐
+│  Clone Repo      │────►│  偵測 Workspace  │
+│  (含 plugin)     │     │  Plugin          │
+└──────────────────┘     └──────────────────┘
+                                  │
+                         ┌────────┼────────┐
+                         ▼                 ▼
+                  ┌────────────┐   ┌────────────┐
+                  │  舊：自動   │   │  新：需明確 │
+                  │  載入 ✗    │   │  信任決策 ✓ │
+                  └────────────┘   └────────────┘
+                                          │
+                                          ▼
+                                  ┌────────────┐
+                                  │  使用者授權 │
+                                  │  後才載入   │
+                                  └────────────┘
+```
+
+### ⭐⭐⭐ Security/Exec 偵測強化 ([#44091](https://github.com/openclaw/openclaw/pull/44091))
+- **用途**: 正規化相容 Unicode 並剝離不可見格式碼，防止零寬度與全形命令繞過啟發式偵測 (`GHSA-9r3v-37xh-2cf6`)
+- **解決問題**: 攻擊者可使用零寬度或全形 Unicode 字元偽裝命令，繞過安全偵測
+- **影響**: 命令偵測更可靠，封堵 Unicode 混淆攻擊向量
+
+```text
+┌──────────────────┐
+│  命令輸入         │
+│  (可能含不可見    │
+│   Unicode 字元)  │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Unicode 正規化  │
+│  + 剝離不可見    │
+│  格式碼          │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  啟發式偵測      │
+│  (正規化後文字)  │
+└──────────────────┘
+         │
+    ┌────┼────┐
+    ▼         ▼
+┌───────┐ ┌───────┐
+│ 安全  │ │ 阻擋  │
+│ 放行  │ │ 執行  │
+└───────┘ └───────┘
+```
+
+### ⭐⭐⭐ Security/Exec Allowlist ([#43798](https://github.com/openclaw/openclaw/pull/43798))
+- **用途**: 保持 POSIX 大小寫敏感性，`?` 限制在單一路徑段內，防止精確 allowlist pattern 跨大小寫或目錄邊界過度匹配 (`GHSA-f8r2-vg7x-gh8m`)
+- **解決問題**: allowlist pattern 可能意外匹配不同大小寫或不同目錄的執行檔
+- **影響**: allowlist 匹配更精確，降低意外授權風險
+
+```text
+┌──────────────────┐
+│  Exec Allowlist  │
+│  Pattern 比對    │
+└──────────────────┘
+         │
+    ┌────┼────────────────┐
+    ▼                     ▼
+┌────────────────┐ ┌────────────────┐
+│  POSIX 大小寫  │ │  ? 限制單一    │
+│  敏感比對      │ │  路徑段        │
+└────────────────┘ └────────────────┘
+    │                     │
+    └──────────┬──────────┘
+               ▼
+       ┌───────────────┐
+       │  精確匹配結果  │
+       │  (無跨界匹配)  │
+       └───────────────┘
+```
+
+### ⭐⭐⭐ Security/Exec Approvals 多重強化 ([#44247](https://github.com/openclaw/openclaw/pull/44247))
+- **用途**: 封堵 inline loader、shell-payload 腳本執行、POSIX shell value-taking flags 後綁定真實腳本，並解包 `pnpm`/`npm exec`/`npx` 腳本 runner (`GHSA-57jw-9722-6rf2`, `GHSA-jvqh-rfmh-jh27`, `GHSA-x7pp-23xv-mmr4`, `GHSA-jc5j-vg4r-j5jx`)
+- **解決問題**: 多種繞過 exec approval 的攻擊路徑，包括 inline loader 注入與 npm 腳本 runner 偽裝
+- **影響**: exec approval 機制全面強化，封堵多個已知繞過向量
+
+```text
+┌──────────────────┐
+│  命令提交審批    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  解包 pnpm/npm   │
+│  exec/npx runner │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  偵測 inline     │
+│  loader/shell    │
+│  payload         │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  POSIX flags 後  │
+│  綁定真實腳本    │
+└──────────────────┘
+         │
+    ┌────┼────┐
+    ▼         ▼
+┌───────┐ ┌────────┐
+│ 核准  │ │ fail   │
+│ 執行  │ │ closed │
+└───────┘ └────────┘
+```
+
+### ⭐⭐⭐ Security/Session Status 沙箱隔離 ([#43754](https://github.com/openclaw/openclaw/pull/43754))
+- **用途**: 在讀取或變更目標 session 狀態前，強制沙箱 session-tree 可見性與共用 agent-to-agent 存取防護 (`GHSA-wcxr-59v9-rxr8`)
+- **解決問題**: 沙箱 subagent 可透過 `session_status` 檢視 parent session metadata 或寫入 parent model overrides
+- **影響**: 沙箱隔離完整性獲得保障，防止跨 session 資訊洩漏
+
+```text
+┌──────────────────┐
+│  session_status  │
+│  請求            │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  沙箱 session-   │
+│  tree 可見性檢查 │
+└──────────────────┘
+         │
+    ┌────┼────┐
+    ▼         ▼
+┌───────┐ ┌────────────┐
+│ 同樹  │ │ 跨樹/parent│
+│ → 允許│ │ → 拒絕     │
+└───────┘ └────────────┘
+```
+
+### ⭐⭐ Security/Commands 權限 ([#44305](https://github.com/openclaw/openclaw/pull/44305))
+- **用途**: `/config` 與 `/debug` 需 sender ownership 驗證，授權的非 owner sender 無法存取 owner-only 設定與 runtime debug 介面 (`GHSA-r7vr-gr74-94p8`)
+- **解決問題**: 非 owner 的授權 sender 可存取 owner-only 的 config 與 debug 介面
+- **影響**: 權限分離更嚴格，降低設定被未授權修改的風險
+
+### ⭐⭐ Security/Gateway Auth ([#44306](https://github.com/openclaw/openclaw/pull/44306))
+- **用途**: 清除 shared-token WebSocket 連線上未綁定的 client-declared scopes，防止 device-less shared-token operator 自行宣告提升的 scopes (`GHSA-rqpp-rjj8-7wv8`)
+- **解決問題**: shared-token 連線可自行宣告超出授權的 scopes
+- **影響**: WebSocket 認證更嚴謹，防止權限提升
+
+### ⭐⭐ Security/Browser.request ([#43800](https://github.com/openclaw/openclaw/pull/43800))
+- **用途**: 封鎖 write-scoped `browser.request` 的持久化 browser profile 建立/刪除路由 (`GHSA-vmhq-cqm9-6p7q`)
+- **解決問題**: 呼叫者可透過 browser control surface 持久化 admin-only browser profile 變更
+- **影響**: browser profile 管理限制在 admin 層級
+
+### ⭐⭐ Security/Agent 邊界 ([#43801](https://github.com/openclaw/openclaw/pull/43801))
+- **用途**: 拒絕公開的 spawned-run lineage 欄位，保持 workspace 繼承在內部 spawned-session 路徑上 (`GHSA-2rqg-gjgv-84jm`)
+- **解決問題**: 外部 `agent` 呼叫者可覆寫 gateway workspace 邊界
+- **影響**: workspace 隔離完整性獲得保障
+
+### ⭐⭐ Security/Exec Approvals Unicode ([#43687](https://github.com/openclaw/openclaw/pull/43687))
+- **用途**: 跳脫 approval prompts 中的不可見 Unicode 格式字元，零寬度命令文字以 `\u{...}` 顯示 (`GHSA-pcqg-f7rg-xfvv`)
+- **解決問題**: 零寬度字元可偽裝審核中的命令文字
+- **影響**: 審核提示更透明，使用者可看到實際命令內容
+
+### ⭐⭐ Security/Device Pairing Scopes ([#43686](https://github.com/openclaw/openclaw/pull/43686))
+- **用途**: 限制已發行與已驗證 device-token scopes 至每個配對裝置的核准 scope 基線 (`GHSA-2pwv-x786-56f8`)
+- **解決問題**: 過期或過寬的 token 可能超出核准存取範圍
+- **影響**: device token 權限更精確，降低 token 濫用風險
+
+### ⭐ Security/WebSocket Preauth ([#44089](https://github.com/openclaw/openclaw/pull/44089))
+- **用途**: 縮短未認證握手保留時間，在應用層解析前拒絕超大 pre-auth frames (`GHSA-jv4g-m82p-2j93`, `GHSA-xwx2-ppv2-wx98`)
+- **解決問題**: 未認證連線可長時間佔用資源或傳送超大 frames
+- **影響**: 降低 pre-pairing 暴露面
+
+### ⭐ Security/Proxy Attachments ([#43684](https://github.com/openclaw/openclaw/pull/43684))
+- **用途**: 恢復共用 media-store 的持久化 browser proxy 檔案大小上限 (`GHSA-6rph-mmhp-h7h9`)
+- **解決問題**: 超大 payload 可繞過 5 MB 限制
+- **影響**: 恢復預期的大小限制
+
+### ⭐ Security/Host Env ([#43685](https://github.com/openclaw/openclaw/pull/43685))
+- **用途**: 封鎖繼承的 `GIT_EXEC_PATH` 進入已清理的 host exec 環境 (`GHSA-jf5v-pqgw-gm5m`)
+- **解決問題**: Git helper 解析可被 host 環境狀態導向
+- **影響**: Git 執行環境更安全
+
+### ⭐ Security/Feishu Webhook ([#44087](https://github.com/openclaw/openclaw/pull/44087))
+- **用途**: webhook mode 要求 `encryptKey` 搭配 `verificationToken`，拒絕未簽名的偽造事件 (`GHSA-g353-mgv3-8pcj`)
+- **解決問題**: 僅 token 設定下可處理未簽名偽造事件
+- **影響**: Feishu webhook 認證更完整
+
+### ⭐ Security/Feishu Reactions ([#44088](https://github.com/openclaw/openclaw/pull/44088))
+- **用途**: 保留群組聊天 typing 查詢結果，對模糊 reaction context fail closed (`GHSA-m69h-jm2f-2pv8`)
+- **解決問題**: 合成 `p2p` reactions 可繞過群組授權與 mention gating
+- **影響**: Feishu 群組授權更嚴謹
+
+### ⭐ Security/LINE Webhook ([#44090](https://github.com/openclaw/openclaw/pull/44090))
+- **用途**: 空事件 POST 探測也需簽名驗證 (`GHSA-mhxh-9pjm-w7q5`)
+- **解決問題**: 未簽名請求可確認 webhook 可達性
+- **影響**: 防止 webhook 探測
+
+### ⭐ Security/Zalo Webhook ([#44173](https://github.com/openclaw/openclaw/pull/44173))
+- **用途**: 在認證前 rate limit 無效 secret 猜測 (`GHSA-5m9r-p9g7-679c`)
+- **解決問題**: 弱 webhook secret 可被暴力破解
+- **影響**: 新增 pre-auth `429` 回應防止暴力破解
+
+### ⭐ Security/Zalo 群組 ID
+- **用途**: 預設要求穩定群組 ID 進行 allowlist 認證，可變群組名稱匹配需透過 `dangerouslyAllowNameMatching` 啟用
+- **解決問題**: 可變群組名稱可能導致 allowlist 繞過
+- **影響**: Zalo 群組認證更可靠
+
+### ⭐ Security/Slack 與 Teams 路由
+- **用途**: 預設要求穩定 channel 與 team ID 進行 allowlist 路由，可變名稱匹配需透過 `dangerouslyAllowNameMatching` 啟用
+- **解決問題**: 可變名稱可能導致路由繞過
+- **影響**: Slack 與 Teams 路由認證更可靠
+
+### ⭐ Security/Hooks Loader ([#44437](https://github.com/openclaw/openclaw/pull/44437))
+- **用途**: 無法以 `realpath` 解析的 workspace hook 路徑 fail closed，跳過而非 fallback 至未解析的 imports
+- **解決問題**: 不可讀或損壞的 hook 路徑可能 fallback 至未解析的 imports
+- **影響**: hook 載入更安全
+
+### ⭐ Security/Hooks Agent Deliveries ([#44438](https://github.com/openclaw/openclaw/pull/44438))
+- **用途**: 以可選 idempotency key 去重複重複的 hook 請求，webhook 重試可重用首次執行結果
+- **解決問題**: webhook 重試可能啟動重複的 agent 執行
+- **影響**: 防止重複 agent 執行
+
+### ⭐ Security/Exec Approvals Ruby
+- **用途**: 對使用 `-r`、`--require` 或 `-I` 的 Ruby approval 流程 fail closed，防止額外本地程式碼載入 flags 繞過審核
+- **解決問題**: Ruby 命令的額外 code-loading flags 不在審核範圍內
+- **影響**: Ruby exec approval 更完整
+
+### ⭐ Security/Agent Tools
+- **用途**: 將 `nodes` 標記為明確 owner-only，記錄 `canvas` 為共用 trusted-operator surface
+- **解決問題**: agent tools 權限邊界不明確
+- **影響**: 權限文件更清晰
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Models/Kimi Coding 工具格式修復 ([#38669](https://github.com/openclaw/openclaw/issues/38669), [#39907](https://github.com/openclaw/openclaw/issues/39907), [#40552](https://github.com/openclaw/openclaw/issues/40552))
+- **用途**: 恢復以原生 Anthropic `anthropic-messages` 格式傳送工具至 `kimi-coding`，修復工具呼叫退化為 XML/純文字偽呼叫
+- **解決問題**: `kimi-coding` 將 tool calls 降級為 XML/plain-text pseudo invocations 而非真正的 `tool_use` blocks
+- **影響**: Kimi Coding 工具呼叫恢復正常，不再產生格式錯誤的偽呼叫
+
+```text
+┌──────────────────┐
+│  Kimi Coding     │
+│  工具呼叫請求    │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  格式偵測        │
+│  anthropic-      │
+│  messages?       │
+└──────────────────┘
+         │
+    ┌────┼────┐
+    ▼         ▼
+┌────────┐ ┌──────────────┐
+│ 舊：   │ │ 新：原生      │
+│ XML/   │ │ Anthropic    │
+│ 純文字 │ │ tool_use     │
+│ ✗      │ │ blocks ✓     │
+└────────┘ └──────────────┘
+```
+
+### ⭐⭐⭐ Sandbox/Write 修復 ([#43876](https://github.com/openclaw/openclaw/pull/43876))
+- **用途**: 保留 pinned mutation-helper payload stdin，修復沙箱 `write` 回報成功但實際建立空檔案的問題
+- **解決問題**: sandboxed `write` 回報成功但建立空檔案
+- **影響**: 沙箱寫入操作恢復正確行為
+
+```text
+┌──────────────────┐
+│  Sandbox Write   │
+│  請求            │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Mutation Helper │
+│  Payload         │
+└──────────────────┘
+         │
+    ┌────┼────┐
+    ▼         ▼
+┌────────┐ ┌──────────────┐
+│ 舊：   │ │ 新：保留      │
+│ stdin  │ │ pinned stdin  │
+│ 遺失   │ │ payload ✓     │
+│ → 空檔 │ └──────────────┘
+└────────┘        │
+                  ▼
+          ┌──────────────┐
+          │  正確寫入    │
+          │  檔案內容    │
+          └──────────────┘
+```
+
+### ⭐⭐⭐ ACP/Client 最終訊息傳遞 ([#17615](https://github.com/openclaw/openclaw/pull/17615))
+- **用途**: 在解析 `end_turn` 前保留終端 assistant 文字快照，修復 ACP client 在 gateway 於 terminal chat event 傳送最終訊息 body 時丟失最後可見回覆
+- **解決問題**: ACP client 丟失最後一則 assistant 回覆
+- **影響**: ACP client 可完整接收所有 assistant 回覆
+
+```text
+┌──────────────────┐
+│  Gateway 傳送    │
+│  Terminal Chat   │
+│  Event           │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  保留 Assistant  │
+│  文字快照        │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  解析 end_turn   │
+└──────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  ACP Client      │
+│  完整接收回覆 ✓  │
+└──────────────────┘
+```
+
+### ⭐⭐ TUI/Chat Log 重複修復 ([#35364](https://github.com/openclaw/openclaw/pull/35364))
+- **用途**: 重用同一 streaming run 的 active assistant message component，修復 `openclaw tui` 渲染重複 assistant 回覆
+- **解決問題**: TUI 顯示重複的 assistant 回覆
+- **影響**: TUI 聊天記錄顯示正確
+
+### ⭐⭐ Telegram/Model Picker 持久化 ([#40105](https://github.com/openclaw/openclaw/pull/40105))
+- **用途**: inline model 按鈕選擇正確持久化 session model，選擇預設時清除 overrides，`/models` 按鈕驗證包含有效 fallback models
+- **解決問題**: Telegram inline model 選擇未正確持久化
+- **影響**: Telegram model 選擇體驗更可靠
+
+### ⭐⭐ Cron/Proactive 重複訊息 ([#40646](https://github.com/openclaw/openclaw/pull/40646))
+- **用途**: 隔離 direct cron sends 不進入 write-ahead resend queue，防止 transient-send 重試在重啟後重播重複的 proactive 訊息
+- **解決問題**: 重啟後重播重複的 proactive 訊息
+- **影響**: 消除重複訊息
+
+### ⭐⭐ Gateway/Main-Session 路由 ([#43918](https://github.com/openclaw/openclaw/pull/43918))
+- **用途**: 保持 TUI 與其他 `mode:UI` main-session sends 在 internal surface，回覆不再繼承 session 持久化的 Telegram/WhatsApp 路由
+- **解決問題**: TUI 回覆意外路由至 Telegram/WhatsApp
+- **影響**: TUI 回覆正確保持在內部介面
+
+### ⭐⭐ Mattermost/Block Streaming 重複 ([#41362](https://github.com/openclaw/openclaw/pull/41362))
+- **用途**: 排除 `replyToId` 於 block reply dedup key，新增明確 `threading` dock 至 Mattermost plugin
+- **解決問題**: block streaming 啟用時產生重複訊息（一則 threaded、一則 top-level）
+- **影響**: Mattermost 訊息傳遞不再重複
+
+### ⭐⭐ Subagents/Completion Announce 重試 ([#41235](https://github.com/openclaw/openclaw/issues/41235))
+- **用途**: 提高預設 announce timeout 至 90 秒，停止重試 gateway-timeout 失敗的外部 completion announces
+- **解決問題**: 慢速 gateway 回應後產生重複的使用者可見 completion 訊息
+- **影響**: 消除重複 completion 訊息
+
+### ⭐⭐ Doctor/Gateway Service 審計 ([#43882](https://github.com/openclaw/openclaw/pull/43882))
+- **用途**: 正規化 service entrypoint 路徑後再比對，修復 symlink-vs-realpath 安裝觸發的誤報修復提示
+- **解決問題**: symlink 安裝觸發 "entrypoint does not match" 誤報
+- **影響**: doctor 診斷更準確
+
+### ⭐⭐ BlueBubbles/Self-Chat Echo 去重 ([#38442](https://github.com/openclaw/openclaw/pull/38442))
+- **用途**: 僅在同一 chat、body 與 timestamp 剛看到匹配的 `fromMe` 事件時才丟棄反射重複 webhook 副本
+- **解決問題**: self-chat 迴圈，但過度抑制 webhook
+- **影響**: 防止 self-chat 迴圈且不影響正常 webhook
+
+### ⭐⭐ iMessage/Self-Chat Echo 去重 ([#38440](https://github.com/openclaw/openclaw/pull/38440))
+- **用途**: 僅在同一 chat、text 與 `created_at` 剛看到匹配的 `is_from_me` 事件時才丟棄反射重複副本
+- **解決問題**: iMessage self-chat 迴圈
+- **影響**: 防止 self-chat 迴圈且不影響正常訊息
+
+### ⭐⭐ Mattermost/Reply Media 傳遞 ([#44021](https://github.com/openclaw/openclaw/pull/44021))
+- **用途**: 透過共用 reply delivery 傳遞 agent-scoped `mediaLocalRoots`，允許本地檔案從 button、slash-command 與 model-picker 回覆正確上傳
+- **解決問題**: 本地檔案無法從 Mattermost 回覆正確上傳
+- **影響**: Mattermost 媒體傳遞恢復正常
+
+### ⭐⭐ Models/OpenAI Codex Spark
+- **用途**: 透過 resolver fallbacks 與更清晰的 Codex-only 處理保持 `gpt-5.3-codex-spark` 在 `openai-codex/*` 路徑上運作，同時繼續抑制 OpenAI 拒絕的過期 direct `openai/*` Spark row
+- **解決問題**: Codex Spark 模型路由不穩定
+- **影響**: Codex Spark 模型可靠運作
+
+### ⭐ Models/Kimi Coding User-Agent ([#30099](https://github.com/openclaw/openclaw/issues/30099))
+- **用途**: 預設傳送 `User-Agent: claude-code/0.1.0` header 至 `kimi-coding`，允許明確 provider headers 覆寫
+- **解決問題**: Kimi Code 訂閱認證需 header-injection proxy
+- **影響**: 無需本地 proxy 即可認證
+
+### ⭐ Ollama/Kimi Cloud ([#41519](https://github.com/openclaw/openclaw/issues/41519))
+- **用途**: 套用 Moonshot Kimi payload 相容性包裝至 Ollama-hosted Kimi models（如 `kimi-k2.5:cloud`）
+- **解決問題**: thinking 啟用時工具路由中斷
+- **影響**: Ollama-hosted Kimi models 工具路由恢復正常
+
+### ⭐ Moonshot CN API ([#33637](https://github.com/openclaw/openclaw/issues/33637))
+- **用途**: 在隱式 provider 解析中尊重明確 `baseUrl` (api.moonshot.cn)
+- **解決問題**: platform.moonshot.cn API keys 回傳 HTTP 401
+- **影響**: Moonshot CN API 認證恢復正常
+
+### ⭐ Kimi Coding/Provider Config ([#36353](https://github.com/openclaw/openclaw/issues/36353))
+- **用途**: 解析隱式 provider 時尊重明確 `models.providers["kimi-coding"].baseUrl`
+- **解決問題**: 自訂 Kimi Coding endpoints 被內建預設覆寫
+- **影響**: 自訂 endpoint 設定正確生效
+
+### ⭐ macOS/Reminders ([#8559](https://github.com/openclaw/openclaw/pull/8559))
+- **用途**: 新增缺失的 `NSRemindersUsageDescription` 至 bundled app
+- **解決問題**: `apple-reminders` 無法觸發系統權限提示
+- **影響**: macOS Reminders 整合恢復正常
+
+### ⭐ Models/OpenRouter Native IDs
+- **用途**: 正規化原生 OpenRouter model keys，跨 config writes、runtime lookups、fallback management 與 `models list --plain`，並遷移 legacy `openrouter/openrouter/...` config entries
+- **解決問題**: OpenRouter model key 不一致導致重複與查詢失敗
+- **影響**: OpenRouter model 管理更一致
+
+### ⭐ Windows/Native Update
+- **用途**: 使 package installs 使用 npm update 路徑，攜帶 portable Git 至 native Windows updates，鏡像安裝程式的 Windows npm env
+- **解決問題**: `openclaw update` 因缺少 `git` 或 `node-llama-cpp` 下載設定而提前失敗
+- **影響**: Windows 更新流程恢復正常
+
+### ⭐ Agents/Failover ([#43884](https://github.com/openclaw/openclaw/pull/43884))
+- **用途**: 將 z.ai `network_error` stop reasons 分類為可重試 timeouts
+- **解決問題**: provider 連線失敗觸發 raw unhandled-stop-reason 錯誤而非 fallback
+- **影響**: provider 連線失敗時正確觸發 fallback
+
+### ⭐ Agents/Compaction ([#28548](https://github.com/openclaw/openclaw/pull/28548))
+- **用途**: 同一 attempt 完成 compaction 時跳過 post-compaction `cache-ttl` marker write
+- **解決問題**: 下一 turn 立即觸發第二次小型 compaction
+- **影響**: 減少不必要的 compaction
+
+### ⭐ Cron/Doctor ([#44012](https://github.com/openclaw/openclaw/pull/44012))
+- **用途**: 停止將 canonical `agentTurn` 與 `systemEvent` payload kinds 標記為 legacy cron storage
+- **解決問題**: 正常 payload kinds 被誤標為 legacy
+- **影響**: doctor 診斷更準確
+
+### ⭐ Telegram/Discord Status Reactions ([#35474](https://github.com/openclaw/openclaw/pull/35474))
+- **用途**: auto-compaction 暫停時顯示暫時 compacting reaction，完成後恢復 thinking
+- **解決問題**: bot 在 context compaction 期間看起來凍結
+- **影響**: 使用者體驗更好，可看到 bot 正在處理
+
+### ⭐ Gateway/Session Stores ([#44266](https://github.com/openclaw/openclaw/pull/44266))
+- **用途**: 重新產生 Swift push-test protocol models，對齊 Windows native session-store realpath 處理
+- **解決問題**: protocol checks 與 sync session discovery 在 Windows 上漂移
+- **影響**: 跨平台 session store 更穩定
+
+### ⭐ Plugins/Env-Scoped Roots ([#44046](https://github.com/openclaw/openclaw/pull/44046))
+- **用途**: 修復 plugin discovery/load caches 與 provenance tracking，同 process 的 `HOME`/`OPENCLAW_HOME` 變更不再重用過期 plugin 狀態
+- **解決問題**: 環境變數變更後 plugin 狀態過期
+- **影響**: plugin 載入更可靠
+
+### ⭐ Gateway/Session Discovery ([#44176](https://github.com/openclaw/openclaw/pull/44176))
+- **用途**: 在自訂 templated `session.store` roots 下發現 disk-only 與 retired ACP session stores
+- **解決問題**: ACP reconciliation 與 session targeting 在重啟後失效
+- **影響**: session discovery 在重啟後恢復正常
+
+### ⭐ Models/Secrets ([#43759](https://github.com/openclaw/openclaw/pull/43759))
+- **用途**: 在產生的 `models.json` 中強制 source-managed SecretRef markers
+- **解決問題**: runtime-resolved provider secrets 在跳過 runtime projection 時被持久化
+- **影響**: 防止 secret 意外持久化
+
+### ⭐ Docs/Onboarding ([#43473](https://github.com/openclaw/openclaw/pull/43473))
+- **用途**: 對齊 legacy wizard 參考與 `openclaw onboard` 命令文件至 Ollama onboarding 流程
+- **解決問題**: onboarding 文件與實際流程不一致
+- **影響**: 文件更準確
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 4 | 3 | 3 | Dashboard v2 全面翻新、GPT-5.4/Claude Fast Mode、Provider-Plugin 架構重構 |
+| 安全性 | 6 | 6 | 11 | Device Pairing Token、Plugin Auto-load 停用、Exec 偵測/Allowlist/Approvals 多重強化、Session 沙箱隔離 |
+| 錯誤修復 | 3 | 11 | 14 | Kimi Coding 工具格式、Sandbox Write、ACP Client 最終訊息、多平台重複訊息修復 |
+| **總計** | **13** | **20** | **28** | **61 項更新** |
+
+**發佈日期**: 2026-03-12
+**版本**: 2026.3.12
+**狀態**: Production Ready
+**GitHub Release**: [v2026.3.12](https://github.com/openclaw/openclaw/releases/tag/v2026.3.12)


### PR DESCRIPTION
## Summary

Add release notes for OpenClaw v2026.3.12 in Traditional Chinese (zh-TW).

### Content
- **61 items** total: 10 features, 23 security improvements, 28 bug fixes
- **13 ⭐⭐⭐ items** with ASCII flowcharts
- **20 ⭐⭐ items** and **28 ⭐ items**
- Summary table and footer included

### Highlights
- Control UI/Dashboard v2 全面翻新
- GPT-5.4 & Claude Fast Mode
- Provider-Plugin 架構重構 (Ollama/vLLM/SGLang)
- 6 critical security fixes (device pairing, plugin auto-load, exec detection/allowlist/approvals, session sandbox)
- Kimi Coding tool format fix, Sandbox write fix, ACP client final message fix

### References
- Upstream: https://github.com/openclaw/openclaw/releases/tag/v2026.3.12
- Guidelines: `release-notes/GUIDELINES.md`

Closes #327