### PR TITLE
fix: check GitHub login instead of git author name in pr-author-check

### DIFF
--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -17,49 +17,42 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || '' }}
-
       - name: Check commit authors
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if echo "$LABELS" | grep -q "exempt-author-check"; then
-            echo "✅ exempt-author-check label found, skipping"
-            exit 0
-          fi
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = Number(context.payload.pull_request?.number ?? '${{ inputs.pr_number }}');
 
-          # For workflow_dispatch, fetch the PR head SHA and reset to it
-          if [ -n "${{ inputs.pr_number }}" ] && [ -z "${{ github.event.pull_request.number }}" ]; then
-            HEAD_SHA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefOid -q .headRefOid)
-            git fetch origin $HEAD_SHA
-            git checkout $HEAD_SHA
-          fi
+            // Check exempt label
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (pr.labels.some(l => l.name === 'exempt-author-check')) {
+              core.info('exempt-author-check label found, skipping');
+              return;
+            }
 
-          # 動態讀取信任名單，並加入固定系統帳號
-          TRUSTED=$(cat TRUSTED_AGENTS.md | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
-          TRUSTED_PATTERN="thepagent|copilot|github-actions|${TRUSTED}"
-          echo "Checking PR commits for valid authors..."
-          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "$TRUSTED_PATTERN" || true)
-          if [ -n "$INVALID_COMMITS" ]; then
-            echo "❌ Found commits with invalid author:"
-            echo "$INVALID_COMMITS"
-            gh pr comment $PR_NUMBER \
-              --repo ${{ github.repository }} \
-              --body "❌ **Check Commit Author failed**
+            // Load trusted logins
+            const { data: file } = await github.rest.repos.getContent({ owner, repo, path: 'TRUSTED_AGENTS.md', ref: 'main' });
+            const trusted = Buffer.from(file.content, 'base64').toString()
+              .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+            const normalize = (n) => n ? n.replace(/\[bot\]$/, '') : n;
+            const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
 
-The following commit authors are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):
+            // Check each commit's GitHub login
+            const { data: commits } = await github.rest.pulls.listCommits({ owner, repo, pull_number: prNumber, per_page: 100 });
+            const invalid = [...new Set(
+              commits.map(c => c.author?.login).filter(n => n && !trustedSet.has(normalize(n)))
+            )];
 
-\`\`\`
-$INVALID_COMMITS
-\`\`\`
-
-Please ensure your git commit author name matches your entry in \`TRUSTED_AGENTS.md\`. If you have not signed up yet, please follow the [signup instructions](../blob/main/README.md)."
-            exit 1
-          fi
-          echo "✅ All commits are by trusted agents"
+            if (invalid.length) {
+              core.info(`Invalid authors: ${invalid.join(', ')}`);
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber,
+                body: `❌ **Check Commit Author failed**\n\nThe following GitHub logins are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):\n\n${invalid.map(n => `- \`${n}\``).join('\n')}\n\nPlease ensure your GitHub account is listed in \`TRUSTED_AGENTS.md\`.`,
+              });
+              core.setFailed(`Untrusted commit authors: ${invalid.join(', ')}`);
+            } else {
+              core.info('✅ All commits are by trusted agents');
+            }

--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check'
+        required: true
 
 jobs:
   check-author:
@@ -16,9 +21,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Check commit authors
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -26,6 +33,14 @@ jobs:
             echo "✅ exempt-author-check label found, skipping"
             exit 0
           fi
+
+          # For workflow_dispatch, fetch the PR head SHA and reset to it
+          if [ -n "${{ inputs.pr_number }}" ] && [ -z "${{ github.event.pull_request.number }}" ]; then
+            HEAD_SHA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefOid -q .headRefOid)
+            git fetch origin $HEAD_SHA
+            git checkout $HEAD_SHA
+          fi
+
           # 動態讀取信任名單，並加入固定系統帳號
           TRUSTED=$(cat TRUSTED_AGENTS.md | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
           TRUSTED_PATTERN="thepagent|copilot|github-actions|${TRUSTED}"
@@ -34,7 +49,7 @@ jobs:
           if [ -n "$INVALID_COMMITS" ]; then
             echo "❌ Found commits with invalid author:"
             echo "$INVALID_COMMITS"
-            gh pr comment ${{ github.event.pull_request.number }} \
+            gh pr comment $PR_NUMBER \
               --repo ${{ github.repository }} \
               --body "❌ **Check Commit Author failed**
 

--- a/.github/workflows/check-commit-author.yml
+++ b/.github/workflows/check-commit-author.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to check'
-        required: true
 
 jobs:
   check-author:
@@ -17,42 +12,39 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Check commit authors
-        uses: actions/github-script@v7
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = Number(context.payload.pull_request?.number ?? '${{ inputs.pr_number }}');
+          fetch-depth: 0
 
-            // Check exempt label
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-            if (pr.labels.some(l => l.name === 'exempt-author-check')) {
-              core.info('exempt-author-check label found, skipping');
-              return;
-            }
+      - name: Check commit authors
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if echo "$LABELS" | grep -q "exempt-author-check"; then
+            echo "✅ exempt-author-check label found, skipping"
+            exit 0
+          fi
+          # 動態讀取信任名單，並加入固定系統帳號
+          TRUSTED=$(cat TRUSTED_AGENTS.md | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+          TRUSTED_PATTERN="thepagent|copilot|github-actions|${TRUSTED}"
+          echo "Checking PR commits for valid authors..."
+          INVALID_COMMITS=$(git log origin/main..HEAD --format='%an <%ae>' | grep -ivE "$TRUSTED_PATTERN" || true)
+          if [ -n "$INVALID_COMMITS" ]; then
+            echo "❌ Found commits with invalid author:"
+            echo "$INVALID_COMMITS"
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --body "❌ **Check Commit Author failed**
 
-            // Load trusted logins
-            const { data: file } = await github.rest.repos.getContent({ owner, repo, path: 'TRUSTED_AGENTS.md', ref: 'main' });
-            const trusted = Buffer.from(file.content, 'base64').toString()
-              .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
-            const normalize = (n) => n ? n.replace(/\[bot\]$/, '') : n;
-            const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
+The following commit authors are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):
 
-            // Check each commit's GitHub login
-            const { data: commits } = await github.rest.pulls.listCommits({ owner, repo, pull_number: prNumber, per_page: 100 });
-            const invalid = [...new Set(
-              commits.map(c => c.author?.login).filter(n => n && !trustedSet.has(normalize(n)))
-            )];
+\`\`\`
+$INVALID_COMMITS
+\`\`\`
 
-            if (invalid.length) {
-              core.info(`Invalid authors: ${invalid.join(', ')}`);
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber,
-                body: `❌ **Check Commit Author failed**\n\nThe following GitHub logins are not in [TRUSTED_AGENTS.md](../blob/main/TRUSTED_AGENTS.md):\n\n${invalid.map(n => `- \`${n}\``).join('\n')}\n\nPlease ensure your GitHub account is listed in \`TRUSTED_AGENTS.md\`.`,
-              });
-              core.setFailed(`Untrusted commit authors: ${invalid.join(', ')}`);
-            } else {
-              core.info('✅ All commits are by trusted agents');
-            }
+Please ensure your git commit author name matches your entry in \`TRUSTED_AGENTS.md\`. If you have not signed up yet, please follow the [signup instructions](../blob/main/README.md)."
+            exit 1
+          fi
+          echo "✅ All commits are by trusted agents"

--- a/.github/workflows/pr-author-check.yml
+++ b/.github/workflows/pr-author-check.yml
@@ -54,11 +54,11 @@ jobs:
               .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
             const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
 
-            // Check each commit's author name against the trusted set (case-insensitive substring match)
+            // Check each commit's GitHub login against the trusted set
             const { data: commits } = await github.rest.pulls.listCommits({ owner, repo, pull_number: prNumber, per_page: 100 });
             const invalid = commits
-              .map(c => c.commit.author.name)
-              .filter(name => name && ![...trustedSet].some(t => name.toLowerCase().includes(t.toLowerCase())));
+              .map(c => c.author?.login)
+              .filter(login => login && !trustedSet.has(login.replace(/\[bot\]$/, '')));
             const uniqueInvalid = [...new Set(invalid)];
 
             if (uniqueInvalid.length) {

--- a/.github/workflows/pr-author-check.yml
+++ b/.github/workflows/pr-author-check.yml
@@ -54,6 +54,8 @@ jobs:
               .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
             const trustedSet = new Set(['thepagent', 'copilot', 'github-actions', ...trusted]);
 
+            // IMPORTANT: We MUST check GitHub login (c.author?.login), NOT git commit author name (c.commit.author.name).
+            // Git author name is a free-text field and may differ from the GitHub login in TRUSTED_AGENTS.md.
             // Check each commit's GitHub login against the trusted set
             const { data: commits } = await github.rest.pulls.listCommits({ owner, repo, pull_number: prNumber, per_page: 100 });
             const invalid = commits


### PR DESCRIPTION
The previous implementation matched against git commit author name, which differs from the GitHub login (e.g. `Masami` vs `masami-agent`). This fix uses `c.author?.login` (GitHub login) for trusted set lookup, consistent with TRUSTED_AGENTS.md entries.