### PR TITLE
release-notes: OpenClaw 2026.3.13

### DIFF
--- a/release-notes/2026-03-13.md
+++ b/release-notes/2026-03-13.md
@@ -1,0 +1,513 @@
+# OpenClaw v2026.3.13 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Browser/Chrome DevTools MCP 附加模式**：新增官方 Chrome DevTools MCP attach 模式，支援已登入的 Chrome 即時工作階段。
+- ⭐⭐⭐ **安全性/裝置配對一次性設定碼**：Bootstrap 設定碼改為單次使用，防止配對請求被重播並提升至管理員權限。
+- ⭐⭐⭐ **安全性/外部內容標記繞過防護**：清除零寬度與軟連字符字元，防止偽造 `EXTERNAL_UNTRUSTED_CONTENT` 標記繞過邊界正規化。
+- ⭐⭐ **Android/聊天設定重新設計** ([#44894](https://github.com/openclaw/openclaw/pull/44894))：重新設計聊天設定頁面，分組裝置與媒體區塊，更新 Connect 與 Voice 分頁。
+- ⭐⭐ **iOS/首次使用引導** ([#45054](https://github.com/openclaw/openclaw/pull/45054))：新增首次啟動歡迎頁面，停止自動開啟 QR 掃描器，顯示 `/pair qr` 說明。
+- ⭐⭐ **Browser/批次動作自動化**：新增批次動作、選擇器定位與延遲點擊，支援正規化批次派送。
+- ⭐ **Browser/內建瀏覽器設定檔**：新增 `profile="user"` 與 `profile="chrome-relay"` 讓代理可優先使用真實已登入瀏覽器。
+- ⭐ **Docker/時區覆寫** ([#34119](https://github.com/openclaw/openclaw/pull/34119))：新增 `OPENCLAW_TZ` 環境變數，可將容器固定至指定 IANA 時區。
+- ⭐ **Dependencies/pi 套件升級**：升級 `@mariozechner/pi-*` 系列套件至 `0.58.0`。
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **裝置配對一次性設定碼**：防止配對請求重播攻擊，提升管理員配對安全性。
+- ⭐⭐⭐ **外部內容標記繞過防護**：清除零寬度字元，防止標記注入繞過邊界檢查。
+- ⭐⭐⭐ **iMessage/遠端附件路徑注入防護**：在執行 SCP 前拒絕不安全路徑，防止 shell 元字元注入。
+- ⭐⭐⭐ **Telegram/Webhook 驗證提前**：在讀取請求主體前先驗證 webhook 密鑰，防止未驗證請求消耗資源。
+- ⭐⭐ **exec 核准多項強化**：PowerShell `-File`、`env` 包裝器、反斜線換行、技能信任綁定、Perl `-M`/`-I`、`pnpm` 執行形式等多項封閉失敗強化。
+- ⭐ **Telegram/媒體錯誤 URL 遮蔽**：遮蔽 Telegram 檔案 URL，防止 bot token 洩漏至日誌。
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Dashboard/聊天 UI 工具結果重載** ([#45541](https://github.com/openclaw/openclaw/pull/45541))：停止每次工具結果時重載完整聊天記錄，防止 UI 凍結。
+- ⭐⭐⭐ **Gateway/RPC 請求逾時洩漏**：在有限逾時後拒絕未回應的 RPC 呼叫，防止 promise 無限期懸掛。
+- ⭐⭐⭐ **macOS/exec 核准設定遵循** ([#13707](https://github.com/openclaw/openclaw/pull/13707))：在閘道提示器中遵循每代理的 exec 核准設定。
+- ⭐⭐ **多平台修復**：Windows 閘道安裝/停止/狀態/驗證、macOS onboarding/語音喚醒、Discord/Slack/Telegram 各項穩定性修復。
+- ⭐ **設定驗證修復**：修復 `agents.list[].params`、web fetch、Signal groups、discovery 等多項設定驗證誤報。
+
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Browser/Chrome DevTools MCP 附加模式（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：新增官方 Chrome DevTools MCP attach 模式，讓代理可直接附加至已登入的本機 Chrome 工作階段，無需重新登入。
+- **解決問題**：過去代理瀏覽器無法存取使用者已登入的 Chrome 工作階段，需另行設定認證。
+- **影響**：代理可直接操作使用者已登入的瀏覽器，大幅簡化需要認證的自動化流程。
+
+```text
+┌─────────────────────┐
+│  chrome://inspect   │
+│  #remote-debugging  │
+└─────────────────────┘
+          │ 啟用 DevTools 遠端除錯
+          ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│  Chrome DevTools    │────►│  OpenClaw MCP        │
+│  Protocol (CDP)     │     │  attach mode         │
+└─────────────────────┘     └──────────────────────┘
+          │                           │
+          │ 已登入工作階段             │ profile="user"
+          ▼                           ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│  Real signed-in     │     │  Agent browser       │
+│  Chrome session     │◄────│  calls               │
+└─────────────────────┘     └──────────────────────┘
+```
+
+### ⭐⭐ Android/聊天設定重新設計 ([#44894](https://github.com/openclaw/openclaw/pull/44894))
+- **用途**：重新設計 Android 聊天設定頁面，分組裝置與媒體區塊，更新 Connect 與 Voice 分頁，精簡聊天輸入框與工作階段標頭。
+- **解決問題**：舊版設定頁面佈局鬆散，行動裝置上資訊密度不足。
+- **影響**：更清晰的設定分組，提升行動端使用體驗。
+
+### ⭐⭐ iOS/首次使用引導 ([#45054](https://github.com/openclaw/openclaw/pull/45054))
+- **用途**：新增首次啟動歡迎頁面，停止自動開啟 QR 掃描器，在連線步驟顯示 `/pair qr` 說明。
+- **解決問題**：新使用者首次啟動時直接跳至 QR 掃描器，缺乏引導說明。
+- **影響**：降低新使用者上手門檻，提升首次設定成功率。
+
+### ⭐⭐ Browser/批次動作自動化（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：新增批次動作、選擇器定位與延遲點擊功能，支援正規化批次派送。
+- **解決問題**：過去瀏覽器自動化每次只能執行單一動作，效率低下。
+- **影響**：代理可一次派送多個瀏覽器動作，提升自動化效率。
+
+### ⭐ Browser/內建瀏覽器設定檔（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：新增 `profile="user"`（已登入主機瀏覽器）與 `profile="chrome-relay"`（擴充功能中繼）兩個內建設定檔。
+- **解決問題**：代理瀏覽器呼叫需手動指定 `browserSession` 選擇器才能使用已登入瀏覽器。
+- **影響**：簡化代理瀏覽器設定，直接使用真實已登入瀏覽器。
+
+### ⭐ Docker/時區覆寫 ([#34119](https://github.com/openclaw/openclaw/pull/34119))
+- **用途**：新增 `OPENCLAW_TZ` 環境變數，讓 `docker-setup.sh` 可將閘道與 CLI 容器固定至指定 IANA 時區。
+- **解決問題**：容器預設繼承守護程序時區，導致跨時區部署時時間顯示不一致。
+- **影響**：Docker 部署可精確控制時區，避免時間相關問題。
+
+### ⭐ Dependencies/pi 套件升級（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：升級 `@mariozechner/pi-agent-core`、`@mariozechner/pi-ai`、`@mariozechner/pi-coding-agent`、`@mariozechner/pi-tui` 至 `0.58.0`。
+- **解決問題**：使用舊版 pi 套件可能存在相容性問題。
+- **影響**：獲得最新 pi 套件的功能改進與錯誤修復。
+
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ 安全性/裝置配對一次性設定碼（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：將 bootstrap 設定碼改為單次使用，防止待審裝置配對請求被重播並提升至管理員權限。
+- **解決問題**：舊版設定碼可重複使用，攻擊者可重播配對請求取得管理員存取權。
+- **影響**：消除配對請求重播攻擊向量，提升裝置配對安全性。
+
+```text
+┌──────────────────────┐
+│  生成 bootstrap 碼   │
+│  (單次有效)          │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│  裝置提交配對請求    │────►│  驗證設定碼          │
+└──────────────────────┘     └──────────────────────┘
+                                        │
+                          ┌─────────────┴─────────────┐
+                          ▼                           ▼
+               ┌──────────────────┐       ┌──────────────────┐
+               │  首次使用：      │       │  重複使用：      │
+               │  標記為已使用    │       │  拒絕請求        │
+               │  完成配對        │       │  (防重播攻擊)    │
+               └──────────────────┘       └──────────────────┘
+```
+
+### ⭐⭐⭐ 安全性/外部內容標記繞過防護（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在邊界清理時清除零寬度與軟連字符標記分割字元，防止偽造 `EXTERNAL_UNTRUSTED_CONTENT` 標記繞過邊界正規化。
+- **解決問題**：攻擊者可在標記中插入不可見字元，使標記看似合法但繞過正規化檢查。
+- **影響**：強化外部內容隔離邊界，防止標記注入攻擊。
+
+```text
+┌──────────────────────────────────┐
+│  外部輸入含偽造標記              │
+│  EXTERNAL_UNTRU​STED_CONTENT     │
+│  (含零寬度字元 U+200B)           │
+└──────────────────────────────────┘
+          │
+          ▼
+┌──────────────────────────────────┐
+│  邊界清理：清除零寬度/軟連字符   │
+└──────────────────────────────────┘
+          │
+          ▼
+┌──────────────────────────────────┐
+│  正規化後標記不匹配              │
+│  → 回退至現有強化路徑            │
+└──────────────────────────────────┘
+```
+
+### ⭐⭐⭐ iMessage/遠端附件路徑注入防護（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在執行 SCP 前拒絕不安全的遠端附件路徑，防止發送者控制的檔案名稱注入 shell 元字元。
+- **解決問題**：惡意發送者可透過特製檔案名稱在遠端媒體暫存時執行任意 shell 命令。
+- **影響**：消除 iMessage 附件處理中的命令注入漏洞。
+
+```text
+┌──────────────────────┐
+│  收到 iMessage 附件  │
+│  (含惡意檔案名稱)    │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│  路徑安全性驗證      │
+│  檢查 shell 元字元   │
+└──────────────────────┘
+          │
+          ├─── 安全 ──►  ┌──────────────────┐
+          │               │  執行 SCP 傳輸   │
+          │               └──────────────────┘
+          │
+          └─── 不安全 ►  ┌──────────────────┐
+                          │  拒絕附件        │
+                          │  記錄安全事件    │
+                          └──────────────────┘
+```
+
+### ⭐⭐⭐ Telegram/Webhook 驗證提前（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在讀取或解析請求主體前先驗證 Telegram webhook 密鑰，讓未驗證請求立即被拒絕。
+- **解決問題**：舊版先讀取最多 1 MB 請求主體再驗證，攻擊者可發送大量請求消耗資源。
+- **影響**：防止未驗證請求消耗伺服器資源，提升 webhook 端點安全性。
+
+```text
+┌──────────────────────┐
+│  收到 Webhook 請求   │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐   失敗   ┌──────────────────┐
+│  驗證 webhook 密鑰   │─────────►│  立即拒絕 (401)  │
+│  (讀取主體之前)      │          │  不消耗資源      │
+└──────────────────────┘          └──────────────────┘
+          │ 成功
+          ▼
+┌──────────────────────┐
+│  讀取並解析請求主體  │
+│  處理 Telegram 事件  │
+└──────────────────────┘
+```
+
+### ⭐⭐ exec 核准/PowerShell `-File` 識別（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：識別 PowerShell `-File` 與 `-f` 包裝形式，讓核准與命令分析路徑正確處理檔案型 PowerShell 啟動。
+- **解決問題**：檔案型 PowerShell 啟動未被識別，可能繞過核准檢查。
+- **影響**：確保所有 PowerShell 執行形式均受核准策略管控。
+
+### ⭐⭐ exec 核准/`env` 包裝器解析（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在 macOS shell 區段允許清單解析中解包 `env` 派送包裝器，確保對有效執行檔進行解析。
+- **解決問題**：`env FOO=bar /path/to/bin` 形式的命令對包裝器 token 而非實際執行檔進行解析，可能繞過允許清單。
+- **影響**：確保 `env` 包裝的命令正確受允許清單管控。
+
+### ⭐⭐ exec 核准/反斜線換行連續符（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：將反斜線換行視為 shell 行連續符，防止行連續 `$(` 替換繞過命令替換檢查。
+- **解決問題**：多行命令中的行連續符可能使命令替換檢查失效。
+- **影響**：強化多行 shell 命令的安全分析。
+
+### ⭐⭐ exec 核准/技能自動允許信任綁定（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：將 macOS 技能自動允許信任同時綁定至執行檔名稱與解析路徑。
+- **解決問題**：同名但不同路徑的二進位檔可繼承不相關技能的信任。
+- **影響**：防止信任繼承攻擊，確保技能信任精確綁定。
+
+### ⭐⭐ exec 核准/Perl `-M`/`-I` 封閉失敗（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：對 Perl `-M` 與 `-I` 核准流程採用封閉失敗策略，防止預載與載入路徑模組解析繞過核准執行。
+- **解決問題**：Perl 模組預載參數可能被用於繞過核准的執行路徑。
+- **影響**：確保 Perl 執行的模組載入路徑受核准策略管控。
+
+### ⭐⭐ exec 核准/`pnpm` 執行形式解包（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：解包更多 `pnpm` 執行形式，包含 `pnpm --reporter ... exec` 與直接 `pnpm node` 檔案執行，含對應回歸測試與文件更新。
+- **解決問題**：部分 `pnpm` 執行形式未被識別，可能繞過核准檢查。
+- **影響**：確保所有 `pnpm` 執行形式均受核准策略管控。
+
+### ⭐ Telegram/媒體錯誤 URL 遮蔽（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在建立媒體擷取錯誤前遮蔽 Telegram 檔案 URL，防止 bot token 洩漏至日誌。
+- **解決問題**：媒體下載失敗時，包含 bot token 的完整 URL 可能被記錄至日誌。
+- **影響**：防止 bot token 透過錯誤日誌洩漏。
+
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Dashboard/聊天 UI 工具結果重載問題 ([#45541](https://github.com/openclaw/openclaw/pull/45541))
+- **用途**：停止在每次即時工具結果時重載完整聊天記錄，最終事件仍會刷新持久化記錄。
+- **解決問題**：工具密集型執行會在每次工具結果時觸發完整 UI 重載，導致 UI 凍結與重新渲染風暴。
+- **影響**：工具密集型代理執行時 Dashboard 保持流暢，不再出現 UI 凍結。
+
+```text
+┌──────────────────────┐
+│  代理執行工具        │
+│  (多次工具呼叫)      │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│  即時工具結果事件    │
+└──────────────────────┘
+          │
+          ├─── 舊版 ──►  ┌──────────────────────┐
+          │               │  每次重載完整聊天記錄 │
+          │               │  → UI 凍結/重渲染風暴 │
+          │               └──────────────────────┘
+          │
+          └─── 新版 ──►  ┌──────────────────────┐
+                          │  僅更新增量結果       │
+                          │  最終事件才刷新記錄   │
+                          └──────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/RPC 請求逾時洩漏（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在有限逾時後拒絕未回應的閘道 RPC 呼叫並清除待處理狀態，防止 promise 無限期懸掛。
+- **解決問題**：連線中斷時，`GatewayClient.request()` promise 會無限期懸掛，造成記憶體洩漏。
+- **影響**：閘道連線中斷後資源可正確釋放，提升系統穩定性。
+
+```text
+┌──────────────────────┐
+│  GatewayClient       │
+│  .request() 呼叫     │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│  等待 RPC 回應       │
+│  (有限逾時計時器)    │
+└──────────────────────┘
+          │
+          ├─── 正常回應 ►  ┌──────────────────┐
+          │                 │  清除待處理狀態  │
+          │                 │  回傳結果        │
+          │                 └──────────────────┘
+          │
+          └─── 逾時 ──────► ┌──────────────────┐
+                             │  拒絕 promise    │
+                             │  清除待處理狀態  │
+                             └──────────────────┘
+```
+
+### ⭐⭐⭐ macOS/exec 核准設定遵循 ([#13707](https://github.com/openclaw/openclaw/pull/13707))
+- **用途**：在閘道提示器中遵循每個代理的 exec 核准設定，包含原生提示無法顯示時的允許清單回退。
+- **解決問題**：閘道觸發的 `system.run` 請求忽略已設定的核准策略，總是提示或拒絕。
+- **影響**：每代理的 exec 核准設定現在正確生效，自動化工作流程可依設定執行。
+
+```text
+┌──────────────────────┐
+│  閘道觸發            │
+│  system.run 請求     │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│  讀取代理 exec       │
+│  核准設定            │
+└──────────────────────┘
+          │
+          ├─── 允許清單命中 ►  ┌──────────────────┐
+          │                     │  自動允許執行    │
+          │                     └──────────────────┘
+          │
+          ├─── 需要提示 ──────► ┌──────────────────┐
+          │                     │  顯示原生提示    │
+          │                     └──────────────────┘
+          │
+          └─── 無法顯示提示 ►  ┌──────────────────┐
+                                │  允許清單回退    │
+                                └──────────────────┘
+```
+
+### ⭐⭐ Build/plugin-sdk 重複打包 ([#45426](https://github.com/openclaw/openclaw/pull/45426))
+- **用途**：在單一共享建置流程中打包 plugin-sdk 子路徑條目，防止已發佈套件重複共享區塊。
+- **解決問題**：plugin-sdk 子路徑條目各自打包，導致共享區塊重複，造成記憶體暴增。
+- **影響**：plugin-sdk 記憶體使用量顯著降低，建置產物更精簡。
+
+### ⭐⭐ Ollama/推理可見性 ([#45330](https://github.com/openclaw/openclaw/pull/45330))
+- **用途**：停止將原生 `thinking` 與 `reasoning` 欄位提升至最終助理文字。
+- **解決問題**：本地推理模型在一般回覆中洩漏內部思考過程。
+- **影響**：本地推理模型的內部思考不再出現在使用者可見的回覆中。
+
+### ⭐⭐ Android/QR 掃描器升級 ([#45021](https://github.com/openclaw/openclaw/pull/45021))
+- **用途**：改用 Google Code Scanner 進行設定 QR 掃描，取代舊版嵌入式 ZXing 流程。
+- **解決問題**：舊版 ZXing 掃描器在部分裝置上可靠性不足。
+- **影響**：Android 設定 QR 掃描更可靠，提升新使用者設定成功率。
+
+### ⭐⭐ Browser/工作階段生命週期強化 ([#45682](https://github.com/openclaw/openclaw/pull/45682))
+- **用途**：強化驅動程式驗證與工作階段生命週期，傳輸錯誤觸發重連，工具層級錯誤保留工作階段；提取共享 ARIA 角色集以去重 Playwright 與 Chrome MCP 快照路徑。
+- **解決問題**：傳輸錯誤與工具錯誤未被區分，導致工作階段不必要地終止。
+- **影響**：瀏覽器工作階段更穩定，暫時性錯誤不再中斷整個工作階段。
+
+### ⭐⭐ Control UI/不安全驗證保留 ([#45088](https://github.com/openclaw/openclaw/pull/45088))
+- **用途**：在純 HTTP Control UI 連線時保留明確的共享 token 與密碼驗證。
+- **解決問題**：LAN 與反向代理工作階段在首次 WebSocket 握手前丟失共享驗證。
+- **影響**：LAN 與反向代理部署的 Control UI 驗證不再中斷。
+
+### ⭐⭐ Gateway/工作階段重置路由保留 ([#44773](https://github.com/openclaw/openclaw/pull/44773))
+- **用途**：在閘道工作階段重置後保留 `lastAccountId` 與 `lastThreadId`。
+- **解決問題**：`/reset` 後回覆路由至錯誤的帳號或執行緒。
+- **影響**：`/reset` 後回覆仍正確路由至原始帳號與執行緒。
+
+### ⭐⭐ macOS/onboarding 啟動守護程序（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：避免自我重啟剛啟動的 launchd 閘道，並給予新守護程序安裝更長的健康檢查時間。
+- **解決問題**：`openclaw onboard --install-daemon` 在較慢 Mac 與新 VM 快照上誤報失敗。
+- **影響**：macOS 守護程序安裝在各種硬體上更可靠。
+
+### ⭐⭐ Gateway/狀態探測（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：新增 `openclaw gateway status --require-rpc` 與更清晰的 Linux 非互動式守護程序安裝失敗報告。
+- **解決問題**：自動化腳本無法區分 RPC 探測失敗與正常狀態。
+- **影響**：自動化可在探測失敗時硬性失敗，提升 CI/CD 可靠性。
+
+### ⭐⭐ macOS/exec 核准設定遵循（已列於 ⭐⭐⭐ 區段）
+
+### ⭐⭐ Telegram/媒體下載代理策略 ([#44639](https://github.com/openclaw/openclaw/pull/44639))
+- **用途**：將相同的直接或代理傳輸策略注入 SSRF 防護的檔案擷取。
+- **解決問題**：Telegram 在直接與代理網路間回退時，入站附件下載失敗。
+- **影響**：各種網路環境下 Telegram 附件下載更可靠。
+
+### ⭐⭐ Telegram/入站媒體 IPv4 回退（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在 SSRF 防護的 Telegram 檔案下載失敗時以相同 IPv4 回退策略重試。
+- **解決問題**：IPv6 故障主機上新安裝無法下載入站圖片。
+- **影響**：IPv6 環境不完整的主機上 Telegram 媒體下載正常運作。
+
+### ⭐⭐ Windows/閘道安裝 schtasks 逾時（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：限制 `schtasks` 呼叫時間並在任務建立掛起時回退至 Startup 資料夾登入項目。
+- **解決問題**：`openclaw gateway install` 在損壞的排程任務設定上永久卡住。
+- **影響**：Windows 閘道安裝在各種系統狀態下均可完成。
+
+### ⭐⭐ Windows/閘道停止 Startup 回退（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：從已安裝的 `gateway.cmd` 連接埠解析 Startup 資料夾回退監聽器。
+- **解決問題**：`openclaw gateway stop` 未能終止回退啟動的閘道程序。
+- **影響**：`openclaw gateway stop` 在重啟前正確終止所有閘道程序。
+
+### ⭐⭐ Windows/閘道狀態回退（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在讀取執行時狀態時重用已安裝服務命令環境。
+- **解決問題**：startup 回退閘道在 `gateway status --json` 中回報 `gateway port unknown`。
+- **影響**：Windows 閘道狀態報告在所有啟動模式下均正確。
+
+### ⭐⭐ Windows/閘道驗證裝置身份雜訊（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：停止在本地回環共享 token 與密碼閘道呼叫上附加裝置身份。
+- **解決問題**：Windows 代理回覆日誌中出現 `device signature expired` 回退雜訊。
+- **影響**：Windows 本地閘道呼叫日誌更清晰，無誤導性錯誤訊息。
+
+### ⭐⭐ Discord/閘道啟動崩潰 ([#44397](https://github.com/openclaw/openclaw/pull/44397))
+- **用途**：將純文字與暫時性 `/gateway/bot` 元資料擷取失敗視為暫時性啟動錯誤。
+- **解決問題**：Discord 閘道啟動因未處理的拒絕而崩潰。
+- **影響**：Discord 閘道啟動更穩定，暫時性網路問題不再導致崩潰。
+
+### ⭐⭐ Slack/探測穩定性 ([#44775](https://github.com/openclaw/openclaw/pull/44775))
+- **用途**：保持 `auth.test()` bot 與團隊元資料映射穩定，同時簡化探測結果路徑。
+- **解決問題**：Slack 探測結果路徑不穩定，可能導致元資料映射錯誤。
+- **影響**：Slack 整合更穩定可靠。
+
+### ⭐⭐ Gateway/Control UI 裝置驗證繞過 ([#45512](https://github.com/openclaw/openclaw/pull/45512))
+- **用途**：恢復僅限操作員的裝置驗證繞過，並分類瀏覽器連線失敗。
+- **解決問題**：來源與裝置身份問題在 Control UI 中顯示為驗證錯誤，造成混淆。
+- **影響**：Control UI 錯誤訊息更準確，操作員裝置驗證繞過正確運作。
+
+### ⭐ Browser/`list_pages` 與 `new_page` 純文字回應（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：接受 Chrome DevTools MCP 的純文字 `list_pages` 與 `new_page` 回應。
+- **解決問題**：伺服器省略結構化頁面元資料時，分頁探索與新分頁開啟失敗。
+- **影響**：即時工作階段分頁管理在各種 Chrome DevTools MCP 伺服器實作下均可運作。
+
+### ⭐ Dashboard/聊天 UI 長文字渲染（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：將過大的純文字回覆渲染為一般段落而非截斷的灰色程式碼區塊。
+- **解決問題**：長桌面聊天回應被截斷顯示為程式碼區塊，需切換分頁才能閱讀完整內容。
+- **影響**：長回覆在 Dashboard 中直接可讀，無需額外操作。
+
+### ⭐ Dashboard/聊天 UI 新訊息按鈕 ([#44856](https://github.com/openclaw/openclaw/pull/44856))
+- **用途**：恢復「新訊息」捲動按鈕的 `chat-new-messages` CSS 類別。
+- **解決問題**：按鈕渲染為全螢幕 SVG 覆蓋層而非緊湊樣式。
+- **影響**：新訊息按鈕正確顯示為緊湊樣式。
+
+### ⭐ macOS/語音喚醒崩潰（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：停止在語音片段範圍來自不同轉錄實例時崩潰於喚醒詞命令提取。
+- **解決問題**：特定語音輸入情境下 macOS 語音喚醒功能崩潰。
+- **影響**：macOS 語音喚醒功能更穩定。
+
+### ⭐ Discord/允許清單 guild_id（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在水合 guild 物件缺失時遵循原始 `guild_id`。
+- **解決問題**：允許清單頻道與執行緒在頻道允許清單檢查前被誤丟棄。
+- **影響**：Discord 允許清單設定正確生效，`#maintainers` 等頻道不再被誤過濾。
+
+### ⭐ macOS/執行時定位器 Node 版本要求（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：在 macOS 執行時探索期間要求 Node >=22.16.0。
+- **解決問題**：應用程式接受後續主執行時守衛會拒絕的 Node 版本，導致後期失敗。
+- **影響**：Node 版本不相容問題在早期探索階段即被發現。
+
+### ⭐ Agents/自訂提供者空白 API 金鑰 ([#45631](https://github.com/openclaw/openclaw/pull/45631))
+- **用途**：在執行時清除回環 OpenAI 相容自訂提供者的合成 Authorization 標頭，同時保留明確的 apiKey 與 oauth/token 設定。
+- **解決問題**：空白 API 金鑰被轉換為假的 bearer 驗證，導致回環端點驗證失敗。
+- **影響**：回環 OpenAI 相容端點可正確使用空白 API 金鑰。
+
+### ⭐ Models/google-vertex Gemini flash-lite 正規化 ([#42435](https://github.com/openclaw/openclaw/pull/42435))
+- **用途**：對 `google-vertex` 模型參考與提供者設定套用現有裸 ID 預覽正規化。
+- **解決問題**：`google-vertex/gemini-3.1-flash-lite` 無法正確解析為 `gemini-3.1-flash-lite-preview`。
+- **影響**：Google Vertex Gemini flash-lite 模型可正確使用。
+
+### ⭐ Cron/隔離工作階段死鎖（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：將巢狀 cron 觸發的嵌入式執行器工作路由至巢狀通道。
+- **解決問題**：隔離 cron 工作在壓縮或其他排隊內部工作執行時死鎖。
+- **影響**：隔離 cron 工作不再因內部工作排隊而死鎖。
+
+### ⭐ Agents/OpenAI 相容覆寫 ([#44432](https://github.com/openclaw/openclaw/pull/44432))
+- **用途**：遵循非原生 `openai-completions` 端點的明確使用者 `models[].compat` 選擇。
+- **解決問題**：串流中使用能力覆寫被強制關閉，即使端點實際支援。
+- **影響**：自訂 OpenAI 相容端點的能力覆寫設定正確生效。
+
+### ⭐ Agents/Azure OpenAI 啟動提示 ([#43403](https://github.com/openclaw/openclaw/pull/43403))
+- **用途**：重新措辭內建 `/new`、`/reset` 與壓縮後啟動指令。
+- **解決問題**：Azure OpenAI 部署因內容過濾器觸發 HTTP 400 誤報。
+- **影響**：Azure OpenAI 部署不再因啟動提示觸發內容過濾器。
+
+### ⭐ Agents/記憶體啟動 ([#26054](https://github.com/openclaw/openclaw/pull/26054))
+- **用途**：僅載入一個根記憶體檔案（優先 `MEMORY.md`，回退 `memory.md`）。
+- **解決問題**：大小寫不敏感 Docker 掛載注入重複記憶體上下文。
+- **影響**：Docker 部署中記憶體上下文不再重複。
+
+### ⭐ Agents/壓縮 token 健全性檢查 ([#28347](https://github.com/openclaw/openclaw/pull/28347))
+- **用途**：將壓縮後 token 健全性檢查與完整工作階段壓縮前總量比較，並在 token 估算失敗時跳過檢查。
+- **解決問題**：含大型啟動上下文的工作階段壓縮後 token 計數不正確。
+- **影響**：大型上下文工作階段的壓縮 token 計數更準確。
+
+### ⭐ Agents/壓縮摘要語言連續性 ([#10456](https://github.com/openclaw/openclaw/pull/10456))
+- **用途**：透過預設與可設定的自訂指令保留壓縮摘要語言連續性。
+- **解決問題**：自動壓縮後代理角色與語言風格發生漂移。
+- **影響**：自動壓縮後代理保持一致的語言風格與角色設定。
+
+### ⭐ Agents/工具警告分類（[v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)）
+- **用途**：區分受限核心工具（如 `apply_patch`）與僅限外掛的未知條目。
+- **解決問題**：不可用核心工具建議安裝外掛，而非說明實際限制原因。
+- **影響**：工具警告訊息更準確，使用者可快速了解工具不可用的真實原因。
+
+### ⭐ Config/`agents.list[].params` 驗證 ([#41171](https://github.com/openclaw/openclaw/pull/41171))
+- **用途**：在嚴格設定驗證中接受已記錄的每代理覆寫。
+- **解決問題**：`openclaw config validate` 拒絕有效的 `cacheRetention`、`temperature`、`maxTokens` 設定。
+- **影響**：有效的每代理設定不再被誤報為無效。
+
+### ⭐ Config/web fetch 驗證 ([#42583](https://github.com/openclaw/openclaw/pull/42583))
+- **用途**：恢復 `tools.web.fetch.readability` 與 `tools.web.fetch.firecrawl` 的執行時驗證。
+- **解決問題**：有效的 web fetch 設定因未識別金鑰錯誤而失敗。
+- **影響**：web fetch 相關設定可正確通過驗證。
+
+### ⭐ Signal/設定驗證 ([#27199](https://github.com/openclaw/openclaw/pull/27199))
+- **用途**：新增 `channels.signal.groups` schema 支援。
+- **解決問題**：每群組 `requireMention`、`tools`、`toolsBySender` 覆寫在設定驗證時被拒絕。
+- **影響**：Signal 群組設定可正確通過驗證。
+
+### ⭐ Config/discovery 驗證 ([#35615](https://github.com/openclaw/openclaw/pull/35615))
+- **用途**：在嚴格設定驗證中接受 `discovery.wideArea.domain`。
+- **解決問題**：單播 DNS-SD 閘道設定因未識別金鑰錯誤而失敗。
+- **影響**：DNS-SD 閘道設定可正確通過驗證。
+
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 3 | 3 | 瀏覽器 MCP 附加、Android/iOS 引導改版、批次自動化 |
+| 安全性提升 | 4 | 6 | 1 | 配對防重播、標記注入防護、路徑注入、Webhook 驗證提前 |
+| 錯誤修復 | 3 | 16 | 18 | UI 凍結、RPC 洩漏、exec 核准、多平台穩定性 |
+| **總計** | **10** | **25** | **22** | **57 項改進** |
+
+---
+
+**發佈日期**：2026-03-13
+**版本**：2026.3.13
+**狀態**：Production Ready
+**GitHub Release**：[https://github.com/openclaw/openclaw/releases/tag/v2026.3.13](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13)


### PR DESCRIPTION
Closes #334

## Release Notes: OpenClaw 2026.3.13

新增 `release-notes/2026-03-13.md`，涵蓋：

- **功能更新**：9 項（3⭐×3、2⭐×3、1⭐×3）
- **安全性提升**：11 項（3⭐×4、2⭐×6、1⭐×1）
- **錯誤修復**：37 項（3⭐×3、2⭐×16、1⭐×18）

共 57 項改進，所有 ⭐⭐⭐ 項目均附 ASCII 流程圖。

Rebased on current `main` (a2b3926).

## Checklist
- [x] GitHub release page reviewed
- [x] All items include star ratings
- [x] Items sorted by star rating (descending)
- [x] All items include PR/Issue numbers or release links
- [x] All items have 用途、解決問題、影響
- [x] All ⭐⭐⭐ items include ASCII solid-line flowchart
- [x] Overview items appear in detailed sections
- [x] Summary table completed
- [x] GitHub release link included
