### PR TITLE
docs: add release notes for OpenClaw v2026.3.13-1

### DIFF
--- a/release-notes/2026-03-14.md
+++ b/release-notes/2026-03-14.md
@@ -1,0 +1,319 @@
+# OpenClaw v2026.3.13-1 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)
+
+> 註：此版本為 recovery release。GitHub tag / release 使用 `v2026.3.13-1` 以修復先前損壞的 `v2026.3.13` 發佈路徑；對應的 npm 版本仍是 `2026.3.13`。
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Browser/已登入 Chrome 附加模式**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：新增官方 Chrome DevTools MCP attach 模式，讓代理可直接附加到使用者已登入的 Chrome 工作階段，不必重新登入。
+- ⭐⭐ **Android/聊天設定重新設計**（[#44894](https://github.com/openclaw/openclaw/pull/44894)）：聊天設定頁面改為裝置與媒體分區，並整理 Connect / Voice 分頁與聊天輸入區配置。
+- ⭐⭐ **iOS/首次使用歡迎流程**（[#45054](https://github.com/openclaw/openclaw/pull/45054)）：加入 welcome pager，並把 QR 掃描改成明確引導步驟。
+- ⭐⭐ **Browser/批次操作與 selector 派送**（[#45457](https://github.com/openclaw/openclaw/pull/45457)）：browser act 支援批次動作、selector targeting 與延遲點擊。
+- ⭐ **Docker/時區覆寫**（[#34119](https://github.com/openclaw/openclaw/pull/34119)）：新增 `OPENCLAW_TZ`，讓 Docker 部署可直接指定 IANA 時區。
+- ⭐ **Slack/互動式回覆指示**（[#44607](https://github.com/openclaw/openclaw/pull/44607)）：新增 opt-in interactive reply directives，改善 Slack 上的回覆互動能力。
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Telegram/Webhook 提前驗證密鑰**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：在讀取 request body 前先驗證 webhook secret，減少未授權請求消耗資源。
+- ⭐⭐⭐ **裝置配對 bootstrap code 改為單次使用**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：阻止待批准配對請求被 replay 後擴權成 admin。
+- ⭐⭐⭐ **外部內容邊界清理強化**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：清除零寬與 soft-hyphen 類分隔字元，避免偽造 `EXTERNAL_UNTRUSTED_CONTENT` 標記繞過保護。
+- ⭐⭐ **exec approvals 持續封閉失敗強化**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：補齊 `pnpm`、PowerShell `-File`、`env` 包裝器、Perl `-M/-I` 等形式的核准綁定與解析。
+- ⭐⭐ **Docker/gateway token 洩漏防護**（[#44956](https://github.com/openclaw/openclaw/pull/44956)）：避免 gateway token 在 Docker build context 暴露。
+- ⭐ **Telegram/媒體錯誤不再外洩 bot token**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：下載失敗時會先 redact Telegram file URL。
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Cron/isolated sessions 避免 nested lane deadlock**（[#45459](https://github.com/openclaw/openclaw/pull/45459)）：修正 isolated cron 在內層工作排程時卡死的問題。
+- ⭐⭐⭐ **Dashboard/chat UI 停止 chat history reload storm**（[#45541](https://github.com/openclaw/openclaw/pull/45541)）：工具密集型執行不再因每次事件都全量重載聊天紀錄而凍結 UI。
+- ⭐⭐⭐ **Gateway/client requests 加上邊界**（[#45689](https://github.com/openclaw/openclaw/pull/45689)）：限制長時間無回應的 client request，避免待答請求無限累積。
+- ⭐⭐ **Session reset 保留 thread/account 路由資訊**（[#44773](https://github.com/openclaw/openclaw/pull/44773)）：`/reset` 後仍可回到原本 account 與 thread。
+- ⭐⭐ **Control UI/shared auth 連線修復**（[#45512](https://github.com/openclaw/openclaw/pull/45512)）：修正 auth bypass 與 connect failure 分類，降低 UI 假性 auth 錯誤。
+- ⭐⭐ **Agents/重播時丟棄 Anthropic thinking blocks**（[#44843](https://github.com/openclaw/openclaw/pull/44843)）：避免 replay 階段把 thinking block 當成正常內容注入。
+- ⭐⭐ **Memory root file 重複注入修復**（[#26054](https://github.com/openclaw/openclaw/pull/26054)）：在大小寫不敏感掛載上只載入單一根記憶檔，避免重複注入。
+- ⭐⭐ **Cross-agent subagent workspace 解析修復**（[#40176](https://github.com/openclaw/openclaw/pull/40176)）：跨 agent spawn subagent 時會解析到正確 workspace。
+- ⭐ **Browser/existing-session lifecycle 強化**（[#45682](https://github.com/openclaw/openclaw/pull/45682)）：既有 session 驗證、重連與錯誤處理更穩定。
+- ⭐ **Config/validation 補齊 documented schema**（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）：補回 `agents.list[].params`、Signal groups、discovery.wideArea.domain、web fetch firecrawl/readability 等文件已寫但 runtime schema 缺漏的欄位。
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Browser/已登入 Chrome 附加模式（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：新增官方 Chrome DevTools MCP attach 模式，讓 OpenClaw 能附加到使用者已登入的本機 Chrome 工作階段，直接重用既有登入狀態。
+- **解決問題**：過去 browser automation 常需在代理用的瀏覽器 session 裡重新登入網站，實務上很麻煩，對需要真實登入態的流程尤其卡。
+- **影響**：大幅降低 browser automation 的啟動成本，尤其適合需要使用真實已登入帳號做查詢、測試與操作的場景。
+
+```text
+┌──────────────────────────┐
+│ 使用者啟用 Chrome 遠端除錯 │
+│ chrome://inspect/...     │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ OpenClaw browser attach  │
+│ mode 建立 MCP/CDP 連線   │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 直接附加既有 Chrome      │
+│ signed-in session        │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ Agent 以真實登入態操作   │
+│ 不必重登或重建 session   │
+└──────────────────────────┘
+```
+
+### ⭐⭐ Android/聊天設定重新設計 ([#44894](https://github.com/openclaw/openclaw/pull/44894))
+- **用途**：重新整理 Android chat settings sheet，把 device 與 media 區塊分組，並讓 Connect / Voice 分頁更緊湊。
+- **解決問題**：原本聊天設定在手機上資訊密度與分區都不夠理想，切換與調整成本偏高。
+- **影響**：Android 使用者在連線、語音與媒體設定上的操作路徑更清楚。
+
+### ⭐⭐ iOS/首次使用歡迎流程 ([#45054](https://github.com/openclaw/openclaw/pull/45054))
+- **用途**：加入 onboarding welcome pager，並在 connect step 明確顯示 `/pair qr` 提示，不再一開始就直接打開掃碼器。
+- **解決問題**：首次啟動流程太跳躍，新手容易在還沒理解流程時就被丟進 QR 掃描器。
+- **影響**：iOS onboarding 更平順，也更容易理解 Gateway 配對流程。
+
+### ⭐⭐ Browser/批次操作與 selector 派送 ([#45457](https://github.com/openclaw/openclaw/pull/45457))
+- **用途**：browser act 支援 batched actions、selector targeting 與 delayed clicks，讓單次 browser request 能涵蓋更完整的操作流程。
+- **解決問題**：原本多步驟瀏覽器操作需要拆成多次呼叫，增加延遲與失敗面積。
+- **影響**：browser automation 的表達能力和效率都更高，也更適合真實工作流。
+
+### ⭐ Docker/時區覆寫 ([#34119](https://github.com/openclaw/openclaw/pull/34119))
+- **用途**：透過 `OPENCLAW_TZ` 固定 gateway 與 CLI 容器時區。
+- **解決問題**：容器時區常跟宿主或 daemon 預設綁在一起，跨時區部署時容易混亂。
+- **影響**：cron、日誌與人機互動時間顯示更一致。
+
+### ⭐ Slack/互動式回覆指示 ([#44607](https://github.com/openclaw/openclaw/pull/44607))
+- **用途**：新增 opt-in interactive reply directives，讓 Slack 回覆可以更精準地對齊互動情境。
+- **解決問題**：Slack 上的回覆位置與互動上下文不夠穩定時，使用體驗會打折。
+- **影響**：Slack 整合更自然，回覆脈絡更清楚。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Telegram/Webhook 提前驗證密鑰（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：把 Telegram webhook secret 驗證提前到讀取與解析 request body 之前。
+- **解決問題**：舊流程會先吃進請求主體，再驗證是否可信；即使最後拒絕，仍可能浪費資源，留下可被濫用的入口。
+- **影響**：未授權請求更早被擋下，降低 webhook surface 被濫用的成本。
+
+```text
+┌──────────────────────┐
+│ 收到 Telegram webhook │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 先驗證 secret header │
+└──────────────────────┘
+      │成功        │失敗
+      ▼            ▼
+┌──────────────┐  ┌──────────────┐
+│ 讀取 body    │  │ 立即拒絕請求 │
+│ 解析事件     │  │ 不再繼續解析 │
+└──────────────┘  └──────────────┘
+```
+
+### ⭐⭐⭐ 裝置配對 bootstrap code 改為單次使用（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：將 device pairing 使用的 bootstrap setup code 改為 single-use。
+- **解決問題**：舊的 setup code 若可重複使用，就有 replay 風險，可能讓待批准配對被重新利用並擴權。
+- **影響**：配對流程更接近一次性憑證語義，降低配對重播攻擊面。
+
+```text
+┌──────────────────────┐
+│ 產生 bootstrap code  │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 首次配對驗證成功     │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ code 立即失效        │
+│ 不可再次重放使用     │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ 外部內容邊界清理強化（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：清除零寬字元與 soft-hyphen 等 marker-splitting 字元，避免偽造的外部內容邊界標記騙過正規化流程。
+- **解決問題**：攻擊者可用不可見字元把 `EXTERNAL_UNTRUSTED_CONTENT` 類標記切碎，讓看似相同的字串在實際解析時逃過保護邏輯。
+- **影響**：外部不可信內容的邊界判定更穩健，降低 prompt boundary spoofing 風險。
+
+```text
+┌──────────────────────────────┐
+│ 輸入含偽造 boundary marker   │
+│ (夾帶零寬 / soft-hyphen)     │
+└──────────────────────────────┘
+              │
+              ▼
+┌──────────────────────────────┐
+│ 先做字元正規化與清理         │
+│ 移除不可見切割字元           │
+└──────────────────────────────┘
+              │
+              ▼
+┌──────────────────────────────┐
+│ 用乾淨 marker 套用既有保護路徑│
+│ 避免被假標記繞過             │
+└──────────────────────────────┘
+```
+
+### ⭐⭐ exec approvals 持續封閉失敗強化（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：持續補強 exec approval 對 `pnpm`、PowerShell `-File`、`env` wrapper、Perl `-M/-I` 與 shell line continuation 的解析。
+- **解決問題**：命令包裝形式一多，approval binding 很容易出現「看起來有審，實際沒綁準」的灰區。
+- **影響**：approval 系統更接近 fail-closed，而不是只守住常見 happy path。
+
+### ⭐⭐ Docker/gateway token 洩漏防護 ([#44956](https://github.com/openclaw/openclaw/pull/44956))
+- **用途**：避免 gateway token 落入 Docker build context。
+- **解決問題**：build context 若包含敏感資料，後續快取、層與建置流程都可能成為外洩面。
+- **影響**：Docker-based 部署更安全。
+
+### ⭐ Telegram/媒體錯誤不再外洩 bot token（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：Telegram 媒體抓取失敗時會先 redact file URL。
+- **解決問題**：錯誤路徑若直接把 URL 寫進日誌，可能連帶暴露 bot token。
+- **影響**：失敗案例的日誌也比較安全。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Cron/isolated sessions 避免 nested lane deadlock ([#45459](https://github.com/openclaw/openclaw/pull/45459))
+- **用途**：讓 nested cron-triggered embedded runner 的工作改走 nested lane，而不是卡在本來的隔離 lane 裡互等。
+- **解決問題**：isolated cron job 在 compaction 或其他內層佇列工作發生時，可能出現互相等待，最後整個工作卡死。
+- **影響**：cron 隔離工作流更穩，不容易出現「看起來有排到，但其實永遠不結束」的死結。
+
+```text
+┌──────────────────────┐
+│ isolated cron job    │
+│ 進入 embedded runner │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 觸發內層工作         │
+│ 例如 compaction      │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 新版改派到 nested    │
+│ lane 處理            │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 避免同 lane 互等     │
+│ 降低 deadlock 風險   │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Dashboard/chat UI 停止 chat history reload storm ([#45541](https://github.com/openclaw/openclaw/pull/45541))
+- **用途**：在工具結果很多的執行裡，停止每次 live tool result 都觸發完整聊天紀錄重載。
+- **解決問題**：舊版在 tool-heavy run 中會不斷整頁重抓 chat history，導致 UI freeze、重繪風暴與體感卡頓。
+- **影響**：Control UI 在真實 agent 執行時可讀性與流暢度明顯提升。
+
+```text
+┌──────────────────────┐
+│ agent 連續產生       │
+│ 多個 tool results    │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 舊版：每次都全量重載 │
+│ chat history         │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ 新版：只保留 live    │
+│ 更新，最後再刷新     │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ UI 不再 freeze/storm │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/client requests 加上邊界 ([#45689](https://github.com/openclaw/openclaw/pull/45689))
+- **用途**：對長時間沒有回應的 client requests 加上界限與回收機制。
+- **解決問題**：如果 client request 一直得不到回答，就可能在 gateway 內累積成懸掛狀態，讓資源與穩定性慢慢惡化。
+- **影響**：gateway 對異常 client 行為的韌性更高，也更容易在故障情境下恢復。
+
+```text
+┌──────────────────────┐
+│ client 發出 request  │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│ gateway 等待回應     │
+└──────────────────────┘
+      │有回應      │逾時無回應
+      ▼            ▼
+┌──────────────┐  ┌──────────────┐
+│ 正常完成請求 │  │ 強制結束等待 │
+│ 清理狀態     │  │ 回收懸掛狀態 │
+└──────────────┘  └──────────────┘
+```
+
+### ⭐⭐ Session reset 保留 thread/account 路由資訊 ([#44773](https://github.com/openclaw/openclaw/pull/44773))
+- **用途**：在 session reset 時保留 `lastAccountId` 與 `lastThreadId`。
+- **解決問題**：`/reset` 之後若 routing metadata 遺失，回覆可能跑錯 account 或 thread。
+- **影響**：重設會話不再打斷原本的回覆落點。
+
+### ⭐⭐ Control UI/shared auth 連線修復 ([#45512](https://github.com/openclaw/openclaw/pull/45512))
+- **用途**：修復 control-ui auth bypass 與 connect failure 分類。
+- **解決問題**：某些情況下 origin、device identity 或 auth 問題會混在一起，讓 UI 看起來像是假性 auth error。
+- **影響**：control-ui 連線問題更容易判斷與排除。
+
+### ⭐⭐ Agents/重播時丟棄 Anthropic thinking blocks ([#44843](https://github.com/openclaw/openclaw/pull/44843))
+- **用途**：在 replay 時丟掉 Anthropic thinking blocks，避免把 reasoning 內容再注入正常上下文。
+- **解決問題**：thinking block 若被當普通內容重播，會污染後續對話與工具路徑。
+- **影響**：重播一致性更好，也減少隱性 context 污染。
+
+### ⭐⭐ Memory root file 重複注入修復 ([#26054](https://github.com/openclaw/openclaw/pull/26054))
+- **用途**：只載入單一根記憶檔，優先 `MEMORY.md`，必要時才 fallback 到 `memory.md`。
+- **解決問題**：在大小寫不敏感掛載或特殊環境下，記憶檔可能被注入兩次。
+- **影響**：減少重複 context，降低 token 浪費與語義偏移。
+
+### ⭐⭐ Cross-agent subagent workspace 解析修復 ([#40176](https://github.com/openclaw/openclaw/pull/40176))
+- **用途**：跨 agent spawn subagent 時，會解析 target agent 的 workspace。
+- **解決問題**：若 workspace 解錯，subagent 可能在錯的資料夾工作，結果自然不可靠。
+- **影響**：多 agent 協作的 workspace 邊界更正確。
+
+### ⭐ Browser/existing-session lifecycle 強化 ([#45682](https://github.com/openclaw/openclaw/pull/45682))
+- **用途**：強化 browser existing-session 的 driver validation、重連與 lifecycle 管理。
+- **解決問題**：signed-in browser session 在 transport error 或 metadata 缺漏時容易進入脆弱狀態。
+- **影響**：browser attach / existing-session 類能力更適合實際長時間使用。
+
+### ⭐ Config/validation 補齊 documented schema（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)）
+- **用途**：補齊 `agents.list[].params`、Signal groups、discovery.wideArea.domain、web fetch firecrawl/readability 等 runtime schema。
+- **解決問題**：有些設定文件已寫可用，但 strict validation 仍報 unrecognized-key，造成「文件說可以、系統說不行」的落差。
+- **影響**：文件與 runtime 行為更一致，也降低設定排錯成本。
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 1 | 3 | 2 | 以已登入 Chrome attach、行動端 onboarding/設定整理、browser automation 能力提升為主 |
+| 安全性 | 3 | 2 | 1 | 聚焦 webhook 提前驗證、pairing single-use、boundary hardening 與 exec approvals 補強 |
+| 錯誤修復 | 3 | 5 | 2 | 重點在 cron deadlock、UI reload storm、gateway request 邊界與 session / workspace / memory 穩定性 |
+| **總計** | **7** | **10** | **5** | **recovery release，主軸是穩定性、邊界安全與真實工作流可用性修補** |
+
+---
+
+- **發佈日期**：2026-03-14
+- **版本**：2026.3.13-1
+- **狀態**：Production Ready
+- **GitHub Release**：[v2026.3.13-1](https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1)


### PR DESCRIPTION
## 概述

新增 `release-notes/2026-03-14.md`，整理 OpenClaw recovery release `v2026.3.13-1` 的版本發佈說明。

這份 release notes 聚焦三條主線：

1. **功能更新**：已登入 Chrome attach mode、行動端 onboarding / chat settings 整理、browser batch act 能力
2. **安全性提升**：Telegram webhook 提前驗證、device pairing single-use bootstrap code、external content boundary hardening、exec approvals 持續封閉失敗補強
3. **錯誤修復**：isolated cron nested lane deadlock、dashboard chat history reload storm、gateway unanswered client requests 邊界化，以及 session / memory / workspace 等穩定性修復

## 為什麼新增 2026-03-14.md

- `claw-info` 已有 `release-notes/2026-03-13.md`
- 這次是 **recovery release**，GitHub tag / release 使用 `v2026.3.13-1`
- GitHub 發佈時間是 `2026-03-14`

為避免把 recovery release 與原始 `2026-03-13` 正式版混在同一檔，這裡採用獨立檔案 `2026-03-14.md`。

## 撰寫依據

- 依 `release-notes/GUIDELINES.md` 結構整理
- 先閱讀 upstream GitHub Release 內容
- 另外抽查幾個 ⭐⭐⭐ 項目對應的 upstream PR / summary：
  - [#45459](https://github.com/openclaw/openclaw/pull/45459)
  - [#45541](https://github.com/openclaw/openclaw/pull/45541)
  - [#45689](https://github.com/openclaw/openclaw/pull/45689)

## 備註

此 PR 是 release notes 文檔新增，不涉及 repo 內其他流程或自動化修改。
