### PR TITLE
docs: add release notes for OpenClaw v2026.3.22

### DIFF
--- a/release-notes/2026-03-23.md
+++ b/release-notes/2026-03-23.md
@@ -1,0 +1,369 @@
+# OpenClaw v2026.3.22 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ **Skills/Plugins 安裝路徑全面升級**：新增原生 `openclaw skills search|install|update`、ClawHub 安裝路徑、marketplace listing/update，以及 `plugin@marketplace` 安裝模型，讓技能與插件的發現、安裝、更新正式走向 marketplace-first。
+- ⭐⭐⭐ **Sandbox 進入可插拔後端時代**：新增 pluggable sandbox backends，內建 OpenShell 與 SSH sandbox，支援 `mirror` / `remote` workspace 模式，隔離與遠端執行能力更完整。
+- ⭐⭐⭐ **Provider/plugin 架構再前進一步**：OpenRouter、GitHub Copilot、OpenAI Codex 等 provider/runtime 邏輯搬進 bundled plugins，搭配新公開 `openclaw/plugin-sdk/*` surface，插件化方向更明確。
+- ⭐⭐ **Web search provider 生態擴大**：新增 Exa、Tavily、Firecrawl 等 bundled web-search plugins，搜尋與抽取工具變得更模組化。
+- ⭐⭐ **Anthropic Vertex 正式支援** ([#43356](https://github.com/openclaw/openclaw/pull/43356))：新增 `anthropic-vertex` provider，讓 Claude 可透過 Google Vertex AI 使用。
+- ⭐⭐ **/btw 側問模式** ([#45444](https://github.com/openclaw/openclaw/pull/45444))：可在不污染主要 session 未來上下文的前提下，快速問一個 tool-less side question。
+- ⭐ **OpenAI 預設模型更新**：OpenAI 預設 setup model 改為 `openai/gpt-5.4`，Codex 也對齊 `openai-codex/gpt-5.4`。
+- ⭐ **Control UI 持續進化**：聊天泡泡可 expand-to-canvas，Usage / Appearance / session navigation 都有明顯改善。
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ **Exec/env sandbox 再次收緊** ([#49702](https://github.com/openclaw/openclaw/pull/49702))：阻擋多種 build-tool/JVM、glibc、.NET 相關危險環境變數注入，縮小 host exec 繞過面。
+- ⭐⭐⭐ **Webhook / voice-call pre-auth 收斂**：缺少簽章標頭會在讀 body 前被拒絕，pre-auth body budget 也大幅縮小，避免未認證流量耗資源。
+- ⭐⭐⭐ **多條 gateway / auth / device pairing hardening**：包含 trusted-proxy scope 清理、pairing scope 約束、device approval 權限收斂等，補強 control plane 安全邊界。
+- ⭐⭐⭐ **Windows media / UNC 路徑阻斷**：阻止 remote-host `file://`、UNC/network path 觸發 SMB credential handshake，補上 Windows 本機媒體解析弱點。
+- ⭐⭐ **Security/exec approvals 持續 fail-closed**：`time` wrapper、Hangul filler、wrapper/env spoofing、inline eval 等審批路徑持續加硬。
+- ⭐⭐ **Plugin marketplace 安裝來源限制**：禁止 remote marketplace manifest 把安裝擴展到 repo 外、HTTP archive 或外部 git 來源。
+- ⭐ **Telegram fresh setup group mention gate**：新安裝預設在群組 require mention，避免剛部署就變成無差別群組 bot。
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ **Browser/Chrome MCP 正式告別 extension relay** ([#47893](https://github.com/openclaw/openclaw/pull/47893))：移除 legacy Chrome extension relay 路線，改以 `existing-session` / `user` 為主，降低歷史 relay 路徑帶來的複雜度與維護成本。
+- ⭐⭐⭐ **Gateway 啟動速度明顯改善** ([#47560](https://github.com/openclaw/openclaw/pull/47560))：built installs 啟動時直接載入 compiled `dist/extensions`，不再每次重編 bundled extensions，冷啟動明顯縮短。
+- ⭐⭐⭐ **Agent 預設 timeout 從 600s 提高到 48h**：長任務、ACP 與長時間 agent session 不再因預設 timeout 太短而莫名失敗。
+- ⭐⭐ **Gateway 首訊息與模型預熱問題修復**：啟動時會預熱 primary model，降低開機後第一條 Telegram/Discord 訊息失敗率。
+- ⭐⭐ **Control UI / session routing / storage 多項穩定化**：包含 external delivery route 保留、session label 顯示、gateway-scoped settings 等。
+- ⭐⭐ **Telegram 穩定性修復**：reply fallback、polling timeout、sticky IPv4 fallback、DM topic session key 等都有補強。
+- ⭐⭐ **Compaction / replay / memory 路徑修復**：包含 tool_result repair、prompt cache invariant、memory_search/memory_get 註冊獨立化等。
+- ⭐ **Plugin runtime / duplicate module graph 問題修復**：多個 plugin callback、state singleton、runtime-api surface 的穩定性提升。
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Skills/Plugins 安裝路徑全面升級（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：新增原生 `openclaw skills search|install|update`、ClawHub 安裝路徑、gateway skill-install/update support，以及 `plugin@marketplace` / Claude marketplace 等 marketplace-first 安裝模型。
+- **解決問題**：過去 skills、plugins、hook packs、marketplace 之間的安裝入口分散，使用者要理解「去哪裡找、用哪條命令裝、之後怎麼更新」成本很高。
+- **影響**：OpenClaw 的擴展生態開始收斂成比較一致的安裝/更新 UX，對 `claw-info` 來說也更值得補 docs 與 usecases。
+
+```text
+┌──────────────────────────┐
+│ 使用者要找 skill/plugin  │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ openclaw skills search   │
+│ / plugins install        │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ ClawHub / marketplace    │
+│ 解析套件與來源           │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 安裝、追蹤、後續更新     │
+│ 走同一條原生路徑         │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Sandbox 進入可插拔後端時代（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：加入 pluggable sandbox backends，內建 OpenShell 與 core SSH sandbox backend，並支援 `mirror` / `remote` workspace 模式。
+- **解決問題**：過去 sandbox 比較偏 Docker-centric；若要做遠端、SSH、非 Docker 的隔離與工作區映射，彈性不足。
+- **影響**：這版讓 sandbox 從單一路線變成後端抽象，後續非常值得 `claw-info/docs` 補一篇架構文或 `usecases` 補遠端隔離實戰。
+
+```text
+┌──────────────────────────┐
+│ Agent 需要隔離執行       │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 選擇 sandbox backend     │
+│ OpenShell / SSH / ...    │
+└──────────────────────────┘
+             │
+      ┌──────┴──────┐
+      ▼             ▼
+┌──────────────┐ ┌──────────────┐
+│ mirror mode  │ │ remote mode  │
+└──────────────┘ └──────────────┘
+      │             │
+      └──────┬──────┘
+             ▼
+┌──────────────────────────┐
+│ Agent 在受控 workspace   │
+│ / remote 環境內執行      │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Provider/plugin 架構再前進一步（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：把 OpenRouter、GitHub Copilot、OpenAI Codex 等 provider/runtime 邏輯搬到 bundled plugins，並正式收斂公開 SDK surface 到 `openclaw/plugin-sdk/*`。
+- **解決問題**：核心 runtime 過去承擔太多 provider 細節，插件化與維護邊界不夠清楚；舊的 `openclaw/extension-api` 也變成技術債。
+- **影響**：這版是 plugin architecture 很重要的一步，會直接影響 plugin 開發、文件、遷移與社群擴展方式。
+
+```text
+┌──────────────────────────┐
+│ 舊做法：provider 邏輯    │
+│ 多半黏在 core runtime    │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 新做法：provider/runtime │
+│ 移入 bundled plugins     │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ plugin-sdk/* 提供        │
+│ 明確公共介面             │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ core 更聚焦、插件更獨立  │
+└──────────────────────────┘
+```
+
+### ⭐⭐ Web search provider 生態擴大（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：新增 Exa、Tavily、Firecrawl 等 bundled web-search / extraction plugins。
+- **解決問題**：web search provider 選擇過少，且不同 provider 的設定與能力不夠一致。
+- **影響**：搜尋/抽取能力變得更模組化，也更適合在 `claw-info/usecases` 裡做 provider 比較文。
+
+### ⭐⭐ Anthropic Vertex 正式支援 ([#43356](https://github.com/openclaw/openclaw/pull/43356))
+- **用途**：新增 `anthropic-vertex` provider，讓 Claude 能透過 Google Vertex AI 路徑運行。
+- **解決問題**：需要在 GCP / Vertex 生態使用 Claude 的使用者，過去缺少原生路徑。
+- **影響**：企業與雲端部署場景更完整，也值得補 deployment docs。
+
+### ⭐⭐ /btw 側問模式 ([#45444](https://github.com/openclaw/openclaw/pull/45444))
+- **用途**：讓使用者可以在同一 session 裡問一個 quick side question，而不改變未來主要 session context。
+- **解決問題**：很多小問題不值得污染主上下文，但以前沒有正式分流。
+- **影響**：對日常互動 UX 很實用，也有潛力補成 usecase。
+
+### ⭐ OpenAI 預設模型更新（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：預設 OpenAI setup model 改成 `openai/gpt-5.4`，Codex 也同步到 `openai-codex/gpt-5.4`。
+- **解決問題**：預設模型落後實際主流使用版本。
+- **影響**：新安裝與預設行為更貼近當前主流配置。
+
+### ⭐ Control UI 持續進化（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：加入 expand-to-canvas、appearance roundness slider、usage 視圖改進與 in-app session navigation。
+- **解決問題**：Control UI 在閱讀、導覽與個人化方面還有摩擦。
+- **影響**：整體操作體驗更成熟。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Exec/env sandbox 再次收緊 ([#49702](https://github.com/openclaw/openclaw/pull/49702))
+- **用途**：阻擋 `MAVEN_OPTS`、`SBT_OPTS`、`GRADLE_OPTS`、`ANT_OPTS`、`GLIBC_TUNABLES`、`DOTNET_ADDITIONAL_DEPS` 等高風險環境變數，並限制 `GRADLE_USER_HOME`。
+- **解決問題**：host exec 若承襲過多環境變數，可能被 build tool / runtime 注入技巧繞過預期邊界。
+- **影響**：這是典型「不是加功能，而是把預設邊界補完整」的 hardening，對自託管環境很重要。
+
+```text
+┌──────────────────────────┐
+│ Host exec 準備啟動       │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 檢查 inherited env       │
+│ 與高風險 override        │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 移除 / 阻擋危險變數      │
+│ 只保留允許路徑           │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 在更小攻擊面下執行       │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Webhook / voice-call pre-auth 收斂（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：對缺少 provider signature header 的請求提前拒絕，並把 pre-auth body budget 降到 `64 KB` / `5s`，同時限制每 IP 的 pre-auth 併發。
+- **解決問題**：未認證 webhook/voice-call 流量若先吃大 body，再慢慢驗證，容易被拿來耗資源。
+- **影響**：這讓 webhook 類入口更接近 fail-fast，而不是等資源先被吃掉才發現不合法。
+
+```text
+┌──────────────────────────┐
+│ 收到 webhook / voice req │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 先查 signature header    │
+└──────────────────────────┘
+      │合法          │缺失/不合法
+      ▼              ▼
+┌──────────────┐  ┌──────────────┐
+│ 進入有限預算 │  │ 直接拒絕     │
+│ body 讀取流程│  │ 不讀大 body  │
+└──────────────┘  └──────────────┘
+```
+
+### ⭐⭐⭐ Windows media / UNC 路徑阻斷（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：阻止 remote-host `file://` media URL 與 UNC/network path 在 Windows 上進入本地媒體解析流程。
+- **解決問題**：某些路徑型輸入可能觸發 SMB credential handshake，把憑證暴露給外部主機。
+- **影響**：這是很實際的 Windows 平台 hardening，屬於高價值安全修補。
+
+```text
+┌──────────────────────────┐
+│ 收到 media path / URL    │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 檢查是否為 UNC / network │
+│ 或 remote file://        │
+└──────────────────────────┘
+      │安全          │不安全
+      ▼              ▼
+┌──────────────┐  ┌──────────────┐
+│ 進入正常解析 │  │ 直接阻擋     │
+└──────────────┘  └──────────────┘
+```
+
+### ⭐⭐⭐ 多條 gateway / auth / device pairing hardening（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：這版補了多條 auth/pairing 相關邊界，包括 trusted-proxy scope 清理、device approval scope 限制、pairing deny handling 等。
+- **解決問題**：gateway control plane 一旦 scope 與 pairing 邊界不夠嚴，後面很多功能面都會被放大成權限問題。
+- **影響**：這些修補分散，但加總起來是對 control plane 安全性很重要的一次整理。
+
+### ⭐⭐ Security/exec approvals 持續 fail-closed（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：補強 `time` wrapper、Hangul filler、wrapper/env spoofing、strict inline eval 等路徑。
+- **解決問題**：審批系統最怕的不是完全沒審，而是「看起來有審，實際綁得不精準」。
+- **影響**：approval path 更不容易被 Unicode、wrapper 或命令包裝灰區鑽洞。
+
+### ⭐⭐ Plugin marketplace 安裝來源限制（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：禁止 remote marketplace manifest 把安裝擴散到 repo 外、外部 git、HTTP archive 或絕對路徑。
+- **解決問題**：marketplace 若不限制來源展開，會放大供應鏈風險。
+- **影響**：插件市場路線更可控，對未來生態很重要。
+
+### ⭐ Telegram fresh setup group mention gate（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：新 Telegram 安裝預設在群組 require mention。
+- **解決問題**：新 bot 若部署後直接對所有群組訊息都回，風險與噪音都很高。
+- **影響**：新手部署更安全，也更符合保守預設原則。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Browser/Chrome MCP 正式告別 extension relay（[#47893](https://github.com/openclaw/openclaw/pull/47893)）
+- **用途**：移除 legacy Chrome extension relay path、bundled extension assets、`driver: "extension"` 與 `browser.relayBindHost`，改以 `existing-session` / `user` 為主。
+- **解決問題**：extension relay 是一條歷史包袱很重的 browser 路線，維護複雜、概念分裂，也容易讓文件與實務配置混亂。
+- **影響**：這是明確的 breaking simplification；對 `claw-info/docs` 很值得補 migration / browser guidance。
+
+```text
+┌──────────────────────────┐
+│ 舊 browser 路線          │
+│ extension relay          │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ v2026.3.22 移除 legacy   │
+│ relay 與相關設定         │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 改走 existing-session    │
+│ / user / raw CDP         │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ browser 配置路線更單純   │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway 啟動速度明顯改善 ([#47560](https://github.com/openclaw/openclaw/pull/47560))
+- **用途**：built installs 啟動時直接載入 compiled `dist/extensions`，不再每次重編 bundled extension TypeScript。
+- **解決問題**：舊版每次 gateway 啟動可能重跑 extension 編譯，讓冷啟動拖得很長，尤其是 WhatsApp 類通道更痛。
+- **影響**：這是對真實使用者體感非常直接的修補，讓 gateway 更像成熟服務而不是開發環境。
+
+```text
+┌──────────────────────────┐
+│ Gateway 啟動             │
+└──────────────────────────┘
+             │
+      ┌──────┴──────┐
+      ▼             ▼
+┌──────────────┐ ┌──────────────┐
+│ 舊版：現場編譯│ │ 新版：直接載入│
+│ bundled ext  │ │ dist/extensions│
+└──────────────┘ └──────────────┘
+      │             │
+      ▼             ▼
+┌──────────────┐ ┌──────────────┐
+│ 啟動慢、抖動 │ │ 冷啟動縮短   │
+└──────────────┘ └──────────────┘
+```
+
+### ⭐⭐⭐ Agent 預設 timeout 從 600s 提高到 48h（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：把 shared default agent timeout 從 `600s` 提高到 `48h`。
+- **解決問題**：對 ACP、長任務、長 session 來說，10 分鐘預設太保守，容易讓任務看起來像系統壞掉，其實只是預設值不合時代。
+- **影響**：長流程 agent 的成功率與可預期性都會提升，但也代表文件需要提醒使用者：若想更保守，應自己顯式設短 timeout。
+
+```text
+┌──────────────────────────┐
+│ 長任務 / ACP session     │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 舊預設 600s              │
+│ 常在任務未完成前超時     │
+└──────────────────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 新預設 48h               │
+│ 長流程不再過早中斷       │
+└──────────────────────────┘
+```
+
+### ⭐⭐ Gateway 首訊息與模型預熱問題修復（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：啟動時預熱 primary model，並補一層 transient provider miss retry。
+- **解決問題**：gateway 剛啟動後第一條 Telegram/Discord 訊息容易撞到 `Unknown model` 或 runtime 尚未就緒。
+- **影響**：新開機或重啟後的第一印象更穩。
+
+### ⭐⭐ Control UI / session routing / storage 多項穩定化（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：修正 external-origin session 的 route 保留、settings key scope、grouped session dropdown label 等。
+- **解決問題**：dashboard 與外部聊天路由容易互相踩設定或顯示不一致。
+- **影響**：多 gateway、多 session、外部來源混用時更可靠。
+
+### ⭐⭐ Telegram 穩定性修復（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：修補 reply fallback、polling 卡死、sticky IPv4 fallback、DM topic session key 等多條 Telegram 路徑。
+- **解決問題**：Telegram 是高頻通道，任何小問題都會放大成真實使用痛感。
+- **影響**：整體 Telegram 可靠性更上一層。
+
+### ⭐⭐ Compaction / replay / memory 路徑修復（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：修補 tool_result repair、prompt cache invariant、memory_search/memory_get 獨立註冊、post-compaction truncate 等。
+- **解決問題**：長對話、compaction、memory 是 OpenClaw 最容易產生隱性錯誤的區域之一。
+- **影響**：長期使用穩定性提升，也很值得在 `claw-info` 補成 docs / usecase。
+
+### ⭐ Plugin runtime / duplicate module graph 問題修復（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- **用途**：修復 plugin callback state、singleton state、runtime-api surface 等 duplicate module graph 相關穩定性問題。
+- **解決問題**：plugin bundling / runtime 分裂常帶來難追的 state 漏洞。
+- **影響**：插件系統實戰可用性提升。
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 3 | 2 | 主軸是 marketplace-first 安裝體驗、sandbox backend 插件化、provider/plugin 架構收斂 |
+| 安全性 | 4 | 2 | 1 | 以 exec/env hardening、pre-auth fail-fast、Windows media 安全與 control-plane 邊界補強為主 |
+| 錯誤修復 | 3 | 4 | 1 | 以 browser relay 退場、gateway 啟動加速、長任務 timeout 修正與多條穩定性修補為主 |
+| **總計** | **10** | **9** | **4** | **這是一個偏平台轉向的大版本：一邊做 plugin/marketplace/sandbox 架構推進，一邊強力清技術債與補安全邊界** |
+
+---
+
+- **發佈日期**：2026-03-23
+- **版本**：2026.3.22
+- **狀態**：Production Ready
+- **GitHub Release**：[v2026.3.22](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)


### PR DESCRIPTION
## 概述

新增 `release-notes/2026-03-23.md`，整理 OpenClaw `v2026.3.22` 的版本發佈說明。

這版不是單純 patch release，而是帶有明顯平台轉向特徵：

1. **plugin / marketplace / skills 安裝路線收斂**
   - 原生 `openclaw skills search|install|update`
   - ClawHub / marketplace-first 安裝模型
   - `plugin@marketplace` 與更多 provider/plugin 插件化

2. **sandbox 與 browser 路線重整**
   - sandbox 變成 pluggable backends
   - 新增 OpenShell / SSH sandbox
   - browser 正式移除 legacy Chrome extension relay，改走 `existing-session` / `user`

3. **安全邊界與穩定性大量補強**
   - exec/env sandbox hardening
   - webhook / voice-call pre-auth fail-fast
   - Windows media / UNC path 防護
   - gateway 啟動與 agent 長任務 timeout 修正

## 為什麼值得補這篇 release notes

`claw-info` README 明確把 `release-notes/` 列為核心內容之一，而 `v2026.3.22` 是一個非常適合沉澱成知識文件的版本：

- 有多個 **breaking changes**
- 有明確的 **架構方向變化**
- 有不少值得後續延伸成 `docs/` 或 `usecases/` 的主題

## 撰寫方式

- 依 `release-notes/GUIDELINES.md` 結構整理
- 先閱讀 upstream GitHub Release
- 補用 Felo 做一次主題聚焦，幫忙確認這版最值得寫進 release notes 的主線是：
  - breaking changes
  - plugin/marketplace 轉向
  - browser 路線切換
  - sandbox/SSH
  - security hardening

## 抽查項目

本 PR 另外特別抽了幾個具體條目做較細的對照：

- [#47893](https://github.com/openclaw/openclaw/pull/47893) browser relay removal
- [#47560](https://github.com/openclaw/openclaw/pull/47560) gateway startup / compiled extensions
- [#49702](https://github.com/openclaw/openclaw/pull/49702) exec/env sandbox hardening
- [#43356](https://github.com/openclaw/openclaw/pull/43356) anthropic-vertex
- [#45444](https://github.com/openclaw/openclaw/pull/45444) /btw

如果 maintainer 覺得這版應該再拆得更細（例如 browser / sandbox / plugin migration 各自更多條目），我也可以再補。
