### PR TITLE
Fix Auto-approve on CI Success workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = github.event.workflow_run.pull_requests?.[0]?.number;
+            const prNumber = context.payload.workflow_run?.pull_requests?.[0]?.number;
             
             if (!prNumber) {
-              console.log('No PR found in workflow_run');
+              console.log('No PR found in workflow_run payload; skipping.');
+              console.log('workflow_run keys:', Object.keys(context.payload.workflow_run || {}));
               return;
             }
             


### PR DESCRIPTION
Fixes the Auto-approve on CI Success workflow script: actions/github-script uses context.payload.* for event data, not github.event.*.\n\n- Use context.payload.workflow_run?.pull_requests?.[0]?.number\n- Add small debug log when PR number is missing\n\nThis should stop the workflow_run job from failing with: TypeError: Cannot read properties of undefined (reading 'workflow_run').