### PR TITLE
docs: release notes for OpenClaw v2026.3.23

### DIFF
--- a/release-notes/2026-03-23.md
+++ b/release-notes/2026-03-23.md
@@ -1,0 +1,290 @@
+# OpenClaw v2026.3.23 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.23)
+
+---
+
+## 概覽
+
+本版本為純錯誤修復版本，無 Breaking Changes，共修復 30+ 項問題，涵蓋瀏覽器自動化、ClawHub 認證、插件穩定性、安全性強化、Gateway 監控等多個面向。
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ Browser/Chrome MCP：修復 macOS Chrome attach 流程中的 session 逾時與重複授權問題
+- ⭐⭐⭐ Browser/CDP：修復較慢 headless Linux 環境下第二次啟動瀏覽器的回歸問題
+- ⭐⭐⭐ Security/exec approvals：強化 shell-wrapper positional-argv 白名單比對邏輯
+- ⭐⭐⭐ Gateway/auth：修復 canvas 路由與 agent session reset 的未授權存取漏洞
+- ⭐⭐ ClawHub/macOS auth：修復 macOS 與 XDG 路徑的認證狀態遺失問題
+- ⭐⭐ Plugins/message tool：修復 Discord/Slack/Feishu 訊息工具的 schema 驗證失敗
+- ⭐⭐ Gateway/model pricing：修復 OpenRouter auto 路由定價無限遞迴問題
+- ⭐⭐ Agents/subagents：修復快速完成的 worker 被誤報為逾時的問題
+- ⭐⭐ Gateway/supervision：修復 launchd/systemd 下鎖衝突導致 crash-loop 的問題
+- ⭐ Mistral/models：修正 Mistral max-token 預設值並提供 `doctor --fix` 自動修復
+- ⭐ Agents/web_search：修復 agent 使用過期 web_search provider 的問題
+- ⭐ Plugins/memory-lancedb：修復全域 npm 安裝後 LanceDB 無法啟動的問題
+- ⭐ Config/plugins：將未知 `plugins.allow` id 改為警告而非致命錯誤
+- ⭐ Doctor/WhatsApp：修復 `doctor --fix` 寫入無效 plugin allowlist 的問題
+- ⭐ Telegram/auto-reply：修復同一 chat 的 debounce 排序與 overflow 問題
+- ⭐ Telegram/message tool：新增 `asDocument` 作為 `forceDocument` 的別名
+- ⭐ Discord/commands：修復特權指令被拒時回傳誤導性回應的問題
+- ⭐ Agents/Anthropic：修復 thinking block 排序導致 Anthropic 驗證失敗的問題
+- ⭐ Plugins/Matrix：修復 Jiti 下重複 export 導致 Matrix 啟動崩潰的問題
+- ⭐ Gateway/probe：修復 gateway 握手後因 RPC 載入慢被誤判為不可達的問題
+- ⭐ Models/OpenAI Codex OAuth & MiniMax OAuth：修復 proxy 環境下 OAuth 流程失敗
+- ⭐ Agents/skills：修復 embedded skill 啟動時 SecretRef 解析失敗的問題
+- ⭐ Channels/catalog：允許外部 channel catalog 覆蓋內建 fallback metadata
+- ⭐ Voice-call/Plivo：穩定 Plivo v2 replay key，避免 webhook retry 碰撞
+- ⭐ Plugins/DeepSeek：重構 DeepSeek provider 至共用 plugin entry
+- ⭐ ClawHub/skills：修復 skill browsing 使用未認證狀態導致 429 的問題
+- ⭐ Release/install：確保發佈的 npm 包含 bundled plugins 與 Control UI assets
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ Security/exec approvals：拒絕單引號 `$0`/`$n` token、禁止換行分隔的 `exec`，防止 shell-wrapper 白名單繞過
+- ⭐⭐⭐ Gateway/auth：canvas 路由強制認證、agent session reset 要求 admin scope，防止匿名存取
+
+---
+
+## 詳細說明
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Browser/Chrome MCP：修復 macOS Chrome attach session 逾時
+
+- **用途**: 等待既有 session 的瀏覽器分頁真正可用後再視為就緒，而非以 MCP 握手完成即判定 ready
+- **解決問題**: macOS Chrome attach 流程中，user-profile 逾時與重複授權同意的問題（Fixes #52930）
+- **影響**: macOS 使用者 attach 既有 Chrome 時不再反覆出現授權提示
+
+```text
+┌─────────────────────┐     ┌──────────────────────────┐
+│  Chrome MCP 握手完成 │────►│  等待分頁實際可用（新邏輯）  │
+└─────────────────────┘     └──────────────────────────┘
+                                          │
+                          ┌───────────────┴───────────────┐
+                          ▼                               ▼
+                  ┌──────────────┐               ┌──────────────┐
+                  │  分頁就緒 ✓  │               │  逾時重試    │
+                  └──────────────┘               └──────────────┘
+```
+
+### ⭐⭐⭐ Browser/CDP：修復 headless Linux 第二次啟動回歸
+
+- **用途**: 短暫連線失敗後重用已執行的 loopback 瀏覽器，而非立即觸發重啟偵測
+- **解決問題**: 較慢的 headless Linux 環境下，第二次 `browser start/open` 失敗的回歸（Fixes #53004）
+- **影響**: headless Linux CI/自動化環境的瀏覽器啟動穩定性提升
+
+```text
+┌──────────────────┐     ┌─────────────────────────┐
+│  初次連線短暫失敗  │────►│  檢查 loopback 是否存活   │
+└──────────────────┘     └─────────────────────────┘
+                                      │
+                      ┌───────────────┴───────────────┐
+                      ▼                               ▼
+              ┌──────────────┐               ┌──────────────┐
+              │  重用現有實例  │               │  重新啟動     │
+              └──────────────┘               └──────────────┘
+```
+
+### ⭐⭐⭐ Security/exec approvals：強化 shell-wrapper 白名單比對
+
+- **用途**: 拒絕單引號 `$0`/`$n` token、禁止換行分隔的 `exec`，仍接受 `exec --` 形式
+- **解決問題**: 惡意構造的 shell-wrapper 可能繞過 positional-argv 白名單的安全漏洞
+- **影響**: exec 核准流程更難被繞過，提升整體執行安全性
+
+```text
+┌─────────────────────┐
+│  exec 指令送入白名單  │
+└─────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────┐
+│  檢查：單引號 $0/$n？換行 exec？      │
+└──────────────────────────────────────┘
+           │
+   ┌───────┴────────┐
+   ▼                ▼
+┌──────┐       ┌──────────┐
+│ 拒絕  │       │  通過審核  │
+└──────┘       └──────────┘
+```
+
+### ⭐⭐⭐ Gateway/auth：修復 canvas 路由與 session reset 未授權存取
+
+- **用途**: canvas 路由強制要求認證；agent session reset 要求 admin scope
+- **解決問題**: 匿名使用者可存取 canvas、非 admin 可重置 agent session 的安全漏洞
+- **影響**: 未授權請求一律 fail closed，提升 gateway 安全邊界
+
+```text
+┌──────────────────┐     ┌─────────────────────┐
+│  canvas / reset  │────►│  auth gate 檢查       │
+│  請求進入         │     │  (新邏輯)             │
+└──────────────────┘     └─────────────────────┘
+                                    │
+                    ┌───────────────┴───────────────┐
+                    ▼                               ▼
+            ┌──────────────┐               ┌──────────────┐
+            │  已認證/admin │               │  401 拒絕    │
+            └──────────────┘               └──────────────┘
+```
+
+### ⭐⭐ ClawHub/macOS auth：修復認證狀態遺失
+
+- **用途**: 同時支援 macOS Application Support 路徑與 XDG config 路徑讀取 ClawHub 登入憑證
+- **解決問題**: `openclaw skills ...` 與 gateway skill browsing 靜默降級為未認證模式（Fixes #53034, #52949）
+- **影響**: macOS 使用者 skill browsing 與 gateway 操作維持登入狀態
+
+### ⭐⭐ Plugins/message tool：修復 Discord/Slack/Feishu schema 驗證
+
+- **用途**: 讓 Discord `components` 與 Slack `blocks` 再次為可選欄位；Feishu `message(..., media=...)` 走正確的 outbound media 路徑
+- **解決問題**: pin/unpin/react 流程 schema 驗證失敗；Feishu 檔案/圖片附件無法送出（Fixes #52970, #52962）
+- **影響**: Discord/Slack/Feishu 訊息工具恢復正常運作
+
+### ⭐⭐ Gateway/model pricing：修復 OpenRouter auto 無限遞迴
+
+- **用途**: 阻止 `openrouter/auto` 定價刷新在 bootstrap 時無限遞迴
+- **解決問題**: OpenRouter auto 路由無法填入快取定價，`usage.cost` 失效（Fixes #53035）
+- **影響**: OpenRouter auto 路由定價與用量成本計算恢復正常
+
+### ⭐⭐ Agents/subagents：修復 worker 誤報逾時
+
+- **用途**: 逾時等待重新檢查最新 runtime snapshot 再送出完成事件
+- **解決問題**: 快速完成的 worker 在實際成功時被誤報為逾時（Fixes #53106）
+- **影響**: subagent 完成狀態回報更準確
+
+### ⭐⭐ Gateway/supervision：修復 launchd/systemd crash-loop
+
+- **用途**: 鎖衝突時讓重複程序進入 retry wait 而非以 failure 退出
+- **解決問題**: 另一個健康 gateway 持有鎖時，重複程序 crash-loop（Fixes #52922）
+- **影響**: launchd/systemd 環境下 gateway 重啟更穩定
+
+### ⭐ Mistral/models：修正 max-token 預設值
+
+- **用途**: 降低 Mistral max-token 預設至安全輸出上限；`doctor --fix` 自動修復舊設定
+- **解決問題**: Mistral 422 錯誤（Fixes #52599）
+- **影響**: 新舊安裝的 Mistral 請求不再被 API 拒絕
+
+### ⭐ Agents/web_search：修復使用過期 provider
+
+- **用途**: 使用 active runtime 的 `web_search` provider 而非過期/預設選擇
+- **解決問題**: agent turn 持續打到錯誤的 provider（Fixes #53020）
+- **影響**: agent web search 使用正確設定的 provider
+
+### ⭐ Plugins/memory-lancedb：修復全域 npm 安裝後無法啟動
+
+- **用途**: 首次使用時若 bundled npm install 未含 LanceDB，自動 bootstrap 至 plugin runtime state
+- **解決問題**: 全域 npm 安裝後 `plugins.slots.memory="memory-lancedb"` 失效（Fixes #26100）
+- **影響**: memory-lancedb plugin 在全域安裝環境下可正常使用
+
+### ⭐ Config/plugins：未知 plugin id 改為警告
+
+- **用途**: 將過期未知的 `plugins.allow` id 視為警告而非致命錯誤
+- **解決問題**: plugin 本地遺失時，`plugins install`、`doctor --fix`、`status` 無法執行（Fixes #52992）
+- **影響**: plugin 遺失時仍可執行修復指令
+
+### ⭐ Doctor/WhatsApp：修復 doctor --fix 寫入無效 allowlist
+
+- **用途**: 阻止 auto-enable 將內建 channel id（如 `whatsapp`）加入 `plugins.allow`
+- **解決問題**: `doctor --fix` 寫入 schema 無效的 plugin allowlist（Fixes #52931）
+- **影響**: `doctor --fix` 修復內建 channel 時不再污染 plugin allowlist
+
+### ⭐ Telegram/auto-reply：修復 debounce 排序
+
+- **用途**: 保留同一 chat 的 inbound debounce 順序，避免 stale busy-session followup 卡住
+- **解決問題**: debounce key 飽和時 overflow turn 排序錯亂（#52998）
+- **影響**: Telegram 高頻訊息場景下回覆順序更穩定
+
+### ⭐ Telegram/message tool：新增 asDocument 別名
+
+- **用途**: 新增 `asDocument` 作為 `forceDocument` 的使用者端別名，保留 `forceDocument` 優先權
+- **解決問題**: 使用者不熟悉 `forceDocument` 參數名稱（#52461）
+- **影響**: Telegram 圖片/GIF 強制以檔案形式傳送的 API 更友善
+
+### ⭐ Discord/commands：修復特權指令拒絕回應
+
+- **用途**: auth gate 拒絕時回傳明確的 unauthorized 回覆
+- **解決問題**: 特權 slash command 被拒時顯示 Discord 誤導性的通用完成訊息（Fixes #53041）
+- **影響**: 使用者收到明確的權限不足提示
+
+### ⭐ Agents/Anthropic：修復 thinking block 排序
+
+- **用途**: transcript 圖片清理時保留 assistant thinking/redacted-thinking block 的最新排序
+- **解決問題**: follow-up turn 觸發 Anthropic unmodified-thinking 驗證失敗（#52961）
+- **影響**: 使用 Anthropic extended thinking 的 agent 多輪對話更穩定
+
+### ⭐ Plugins/Matrix：修復 Jiti 重複 export 崩潰
+
+- **用途**: 避免 `resolveMatrixAccountStringValues` 在 Jiti 下重複 export
+- **解決問題**: bundled Matrix 安裝啟動時崩潰（Fixes #52909, #52891）
+- **影響**: Matrix plugin 在 Jiti 環境下可正常啟動
+
+### ⭐ Gateway/probe：修復握手後誤判不可達
+
+- **用途**: post-connect detail RPC 仍在載入時，不將成功握手判定為不可達
+- **解決問題**: 慢速裝置回報 false negative dead gateway（Fixes #52927）
+- **影響**: 慢速裝置的 gateway 可達性偵測更準確
+
+### ⭐ Models/OpenAI Codex OAuth & MiniMax OAuth：修復 proxy 環境 OAuth
+
+- **用途**: OAuth preflight 與 token exchange 前先初始化 env-configured HTTP/HTTPS proxy dispatcher
+- **解決問題**: proxy 必要環境下 MiniMax 與 OpenAI Codex 登入流程失敗（#52228, Fixes #51619, #51569）
+- **影響**: proxy 環境下 OAuth 登入與 token 刷新恢復正常
+
+### ⭐ Agents/skills：修復 embedded skill SecretRef 解析
+
+- **用途**: embedded skill 啟動時使用 active resolved runtime snapshot 進行 env 注入
+- **解決問題**: `skills.entries.<skill>.apiKey` SecretRef 在 embedded 啟動時解析失敗（Fixes #53098）
+- **影響**: embedded skill 的 API key 設定可正確解析
+
+### ⭐ Channels/catalog：允許外部 catalog 覆蓋內建 metadata
+
+- **用途**: 外部 channel catalog 可覆蓋 shipped fallback metadata 與 npm spec
+- **解決問題**: channel id 與內建相符時，自訂 catalog 仍使用 bundled 套件（#52988）
+- **影響**: 自訂 channel catalog 可完整覆蓋內建設定
+
+### ⭐ Voice-call/Plivo：穩定 replay key
+
+- **用途**: 穩定 Plivo v2 replay key，避免 webhook retry 與 replay protection 碰撞
+- **解決問題**: 合法的 follow-up webhook delivery 被 replay protection 誤擋
+- **影響**: Plivo voice call webhook 重試機制更可靠
+
+### ⭐ Plugins/DeepSeek：重構至共用 plugin entry
+
+- **用途**: 將 bundled DeepSeek provider 重構至共用 single-provider plugin entry，移至 extension test lane
+- **解決問題**: DeepSeek provider 架構與其他 plugin 不一致（#48762）
+- **影響**: DeepSeek plugin 維護性提升，測試覆蓋更完整
+
+### ⭐ ClawHub/skills：修復 skill browsing 429 問題
+
+- **用途**: 解析 local ClawHub auth token 用於 gateway skill browsing，browse-all 改用 search 請求
+- **解決問題**: ClawControl 落入未認證 429 與空的已認證 skill 列表（Fixes #52949）
+- **影響**: skill browsing 使用正確的認證 token，不再遭遇 rate limit
+
+### ⭐ Release/install：確保 npm 包含 bundled artifacts
+
+- **用途**: 保留已發佈的 bundled plugins 與 Control UI assets；release check 在缺少時失敗
+- **解決問題**: 發佈的 openclaw npm 套件遺失 bundled artifacts
+- **影響**: 安裝後即包含完整的 plugins 與 UI assets
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Security/exec approvals：強化 shell-wrapper 白名單
+
+（詳見上方錯誤修復章節）
+
+### ⭐⭐⭐ Gateway/auth：canvas 與 session reset 存取控制
+
+（詳見上方錯誤修復章節）
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 錯誤修復 | 2 | 5 | 20 | 瀏覽器、ClawHub、插件、Gateway 全面修復 |
+| 安全性提升 | 2 | 0 | 0 | exec 白名單強化、canvas/reset 存取控制 |
+
+**發佈日期**: 2026-03-23
+**版本**: 2026.3.23
+**狀態**: Production Ready
+**GitHub Release**: [v2026.3.23](https://github.com/openclaw/openclaw/releases/tag/v2026.3.23)


### PR DESCRIPTION
Closes #363

## Release Notes: OpenClaw v2026.3.23

新增 `release-notes/2026-03-23.md`，依 GUIDELINES.md 格式撰寫。

### 本版本重點
- 純錯誤修復版本，無 Breaking Changes，故無 `⚠️ 升級前必讀` 章節
- 共涵蓋 30+ 項修復，含 2 項 ⭐⭐⭐ 安全性強化
- 分類：錯誤修復 / 安全性提升，各含 star rating 與 ASCII flowchart（⭐⭐⭐ 項目）

### Upstream Release
https://github.com/openclaw/openclaw/releases/tag/v2026.3.23
