### PR TITLE
docs: improve OpenClaw v2026.3.22 release notes

### DIFF
--- a/release-notes/2026-03-22.md
+++ b/release-notes/2026-03-22.md
@@ -23,6 +23,16 @@
 - **Android** 新增通話記錄（`callLog.search`）與簡訊搜尋（`sms.search`）
 - **`/btw`** 側邊問答，不污染 session 上下文
 
+### 你是否受影響？
+
+若你符合以下任一情況，這版升級前請先完整閱讀下方對應段落：
+
+- **你有自製 plugin / channel integration** → 重點看 `openclaw/extension-api` 移除、message discovery API 變更、Matrix plugin 重寫
+- **你在本機用 Chrome extension relay 自動化** → 重點看 Chrome relay 移除與 `openclaw doctor --fix` 遷移
+- **你有沿用舊環境變數或舊狀態目錄** → 重點看 `CLAWDBOT_*` / `MOLTBOT_*` 移除與 `.moltbot` fallback 移除
+- **你在 exec / scripts 中依賴 `jq`** → 重點看 `jq` 從預設 safeBins 移除
+- **你主要用 Android node、Talk、或 Telegram topic** → 這版有明顯的新能力與行為變更，值得看功能更新區
+
 ---
 
 ## 概述
@@ -32,37 +42,37 @@
 - ⭐⭐⭐ Plugins/install：`openclaw plugins install <package>` 現在優先查詢 ClawHub，僅在 ClawHub 無此套件時才 fallback 至 npm（[文件](https://docs.openclaw.ai/tools/clawhub)）
 - ⭐⭐⭐ Browser/Chrome MCP：移除舊版 Chrome extension relay 路徑、`driver: "extension"` 及 `browser.relayBindHost`；執行 `openclaw doctor --fix` 可自動遷移（[#47893](https://github.com/openclaw/openclaw/pull/47893)）
 - ⭐⭐⭐ Plugins/SDK：新公開 plugin SDK 介面為 `openclaw/plugin-sdk/*`；移除 `openclaw/extension-api`，無相容 shim（[文件](https://docs.openclaw.ai/plugins/sdk-migration)）
-- ⭐⭐⭐ Config/env：移除舊版 `CLAWDBOT_*` 與 `MOLTBOT_*` 相容環境變數，請改用 `OPENCLAW_*`
-- ⭐⭐⭐ Config/state：移除 `.moltbot` 狀態目錄與 `moltbot.json` 自動偵測/遷移 fallback
+- ⭐⭐⭐ Config/env：移除舊版 `CLAWDBOT_*` 與 `MOLTBOT_*` 相容環境變數，請改用 `OPENCLAW_*`（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- ⭐⭐⭐ Config/state：移除 `.moltbot` 狀態目錄與 `moltbot.json` 自動偵測/遷移 fallback（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐⭐⭐ Exec/env sandbox：封鎖 JVM 注入環境變數（`MAVEN_OPTS`、`SBT_OPTS`、`GRADLE_OPTS`、`ANT_OPTS`）、glibc 可調參數（`GLIBC_TUNABLES`）及 .NET 依賴劫持（`DOTNET_ADDITIONAL_DEPS`）（[#49702](https://github.com/openclaw/openclaw/pull/49702)）
-- ⭐⭐ ClawHub/install：新增 `openclaw skills search|install|update` 流程及 `openclaw plugins install clawhub:<package>`
+- ⭐⭐ ClawHub/install：新增 `openclaw skills search|install|update` 流程及 `openclaw plugins install clawhub:<package>`（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐⭐ Plugins/marketplaces：新增 Claude marketplace registry 解析、`plugin@marketplace` 安裝與更新支援（[#48058](https://github.com/openclaw/openclaw/pull/48058)）
-- ⭐⭐ Sandbox/runtime：新增可插拔 sandbox 後端，內建 OpenShell 後端（`mirror` 與 `remote` 工作區模式）
+- ⭐⭐ Sandbox/runtime：新增可插拔 sandbox 後端，內建 OpenShell 後端（`mirror` 與 `remote` 工作區模式）（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐⭐ Models/OpenAI：預設 OpenAI 模型切換為 `openai/gpt-5.4`
 - ⭐⭐ Android/Talk：Talk 語音合成移至 gateway `talk.speak`，Android 播放改為最終回應音訊（[#50849](https://github.com/openclaw/openclaw/pull/50849)）
 - ⭐⭐ Feishu/ACP：新增當前對話 ACP 與 subagent session 綁定（[#46819](https://github.com/openclaw/openclaw/pull/46819)）
 - ⭐ Commands/btw：新增 `/btw` 側邊問答，不影響 session 上下文（[#45444](https://github.com/openclaw/openclaw/pull/45444)）
 - ⭐ Telegram/topics：DM forum topic 首次訊息自動以 LLM 生成標籤重命名（[#51502](https://github.com/openclaw/openclaw/pull/51502)）
-- ⭐ Control UI/chat：assistant 訊息泡泡新增展開至 canvas 按鈕
+- ⭐ Control UI/chat：assistant 訊息泡泡新增展開至 canvas 按鈕（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐ Android/nodes：新增 `callLog.search` 與 `sms.search`（[#44073](https://github.com/openclaw/openclaw/pull/44073)、[#48299](https://github.com/openclaw/openclaw/pull/48299)）
 - ⭐ Plugins/Matrix：新增官方 `matrix-js-sdk` 支援的 Matrix plugin（[遷移指南](https://docs.openclaw.ai/install/migrating-matrix)）
 - ⭐ Models/Anthropic Vertex：新增 `anthropic-vertex` provider 支援（[#43356](https://github.com/openclaw/openclaw/pull/43356)）
 
 ### 安全性提升（Security）
 
-- ⭐⭐⭐ Voice-call/webhooks：在讀取 body 前先驗證 provider 簽章 header，pre-auth body 上限降至 64 KB / 5s，並限制每來源 IP 的並發 pre-auth 請求數
-- ⭐⭐⭐ Security/exec approvals：`time` 指令視為透明 dispatch wrapper，allowlist 評估綁定內層可執行檔
-- ⭐⭐⭐ Security/exec：加固 macOS allowlist 解析，防 wrapper 與 `env` 欺騙；新增 `tools.exec.strictInlineEval`；Discord guild 訊息 body 視為不可信外部內容
+- ⭐⭐⭐ Voice-call/webhooks：在讀取 body 前先驗證 provider 簽章 header，pre-auth body 上限降至 64 KB / 5s，並限制每來源 IP 的並發 pre-auth 請求數（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- ⭐⭐⭐ Security/exec approvals：`time` 指令視為透明 dispatch wrapper，allowlist 評估綁定內層可執行檔（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- ⭐⭐⭐ Security/exec：加固 macOS allowlist 解析，防 wrapper 與 `env` 欺騙；新增 `tools.exec.strictInlineEval`；Discord guild 訊息 body 視為不可信外部內容（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐⭐⭐ Security/device pairing：加固 `device.token.rotate` deny 處理，公開失敗訊息保持通用（`GHSA-7jrw-x62h-64p8`）
-- ⭐⭐⭐ Security/exec safe bins：從預設 safe-bin allowlist 移除 `jq`，並在明確 opt-in 時封鎖 `jq -n env`
-- ⭐⭐⭐ Security/exec approvals：在 approval prompt 中 escape 空白 Hangul filler 字元，防止視覺上空白的 Unicode 隱藏指令文字
+- ⭐⭐⭐ Security/exec safe bins：從預設 safe-bin allowlist 移除 `jq`，並在明確 opt-in 時封鎖 `jq -n env`（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
+- ⭐⭐⭐ Security/exec approvals：在 approval prompt 中 escape 空白 Hangul filler 字元，防止視覺上空白的 Unicode 隱藏指令文字（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐⭐ Security/pairing：iOS setup code 綁定至目標 node profile，拒絕要求更廣泛 role/scope 的 bootstrap 兌換
 - ⭐⭐ Nostr/security：在解密前強制執行 inbound DM policy，加入 pre-crypto 速率與大小限制
 - ⭐⭐ Synology Chat/security：reply delivery 預設綁定穩定的數字 `user_id`，可變 username 查詢需明確啟用 `dangerouslyAllowNameMatching`
 - ⭐⭐ Security/network：加固 explicit-proxy SSRF pinning，對無法保留 pinned DNS 的明文 HTTP 請求 fail-closed
 - ⭐⭐ Security/Synology Chat：多帳號設定預設要求明確的 per-account webhook 路徑，拒絕重複路徑
 - ⭐⭐ Browser/remote CDP：在遠端 CDP 可達性檢查時強制 SSRF policy，從 status 輸出中遮蔽敏感 `cdpUrl` token
-- ⭐ Media/Windows security：在本地檔案系統解析前封鎖遠端主機 `file://` media URL 與 UNC/network 路徑
+- ⭐ Media/Windows security：在本地檔案系統解析前封鎖遠端主機 `file://` media URL 與 UNC/network 路徑（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.22)）
 - ⭐ Gateway/discovery：在 CLI discovery 中對無法解析的 Bonjour/DNS-SD 端點 fail-closed
 - ⭐ Security/plugins：拒絕遠端 marketplace manifest 中將安裝擴展至 clone repo 外的條目
 


### PR DESCRIPTION
## Summary

Follow-up improvement for the already-merged `release-notes/2026-03-22.md`.

This PR focuses on two practical quality improvements:

1. **Add a quick “你是否受影響？” section** under `升級前必讀`
   - Helps readers quickly decide whether they need to care about plugin migration, Chrome relay removal, old env/state migration, `jq` safeBins changes, or Android/Talk/Telegram topic changes.
   - The goal is to make the release notes more actionable, not just comprehensive.

2. **Fill in several missing verification links in the overview**
   - Some items were descriptive but did not have a clickable upstream reference.
   - This PR adds explicit GitHub Release links for those entries, so readers can cross-check more easily.

## Why this follow-up

In the discussion on #354, maintainer feedback explicitly invited a follow-up PR if `release-notes/2026-03-22.md` could be improved further. I think these two changes are small, low-risk, and directly improve usability:

- quicker self-triage for affected users
- better source traceability

## Scope

- No content category reshuffle
- No star-rating changes
- No new claims added beyond what is already in the release notes / release page

Just readability + verification improvements.
