### PR TITLE
chore: replace THEPAGENT_PAT with GitHub App token in workflows

### DIFF
--- a/.github/workflows/auto-merge-approved.yml
+++ b/.github/workflows/auto-merge-approved.yml
@@ -23,11 +23,17 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Auto-merge if approved and not blocked
         id: check
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.THEPAGENT_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Determine PR number depending on trigger
             let prNumber;
@@ -175,5 +181,5 @@ jobs:
       - name: Merge as thepagent
         if: steps.check.outputs.pr_number != ''
         env:
-          GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge ${{ steps.check.outputs.pr_number }} --squash --repo ${{ github.repository }}

--- a/.github/workflows/auto-merge-fork.yml
+++ b/.github/workflows/auto-merge-fork.yml
@@ -19,6 +19,12 @@ jobs:
       github.event.workflow_run.conclusion == 'action_required'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Auto-merge fork PR if approved and checks pass
         uses: actions/github-script@v7
         with:
@@ -74,5 +80,5 @@ jobs:
       - name: Merge as thepagent
         if: env.PR_NUMBER != ''
         env:
-          GH_TOKEN: ${{ secrets.THEPAGENT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge ${{ env.PR_NUMBER }} --squash --repo ${{ github.repository }}

--- a/.github/workflows/housekeeping-approval-labels.yml
+++ b/.github/workflows/housekeeping-approval-labels.yml
@@ -13,10 +13,16 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Sync approval labels on all open PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.THEPAGENT_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/trusted-approval-labels.yml
+++ b/.github/workflows/trusted-approval-labels.yml
@@ -14,10 +14,16 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Apply approval labels
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.THEPAGENT_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
Closes #369

## Changes

- Add `Generate App token` step using `actions/create-github-app-token@v1` (App ID: `${{ secrets.APP_ID }}`, Private Key: `${{ secrets.APP_PRIVATE_KEY }}`)
- Replace `secrets.THEPAGENT_PAT` with the generated App token in:
  - `auto-merge-approved.yml`
  - `auto-merge-fork.yml`
  - `trusted-approval-labels.yml`
  - `housekeeping-approval-labels.yml`

## Why

Same rationale as [openclaw-helm PR #17](https://github.com/thepagent/openclaw-helm/pull/17): App token is scoped, account-independent, and auto-expires after 1 hour.
