### PR TITLE
docs: add howto guide for subscribing to Amazon Q Developer (2026)

### DIFF
--- a/docs/howto/subscribe-amazon-q-developer.md
+++ b/docs/howto/subscribe-amazon-q-developer.md
@@ -1,0 +1,30 @@
+# How to Subscribe to Amazon Q Developer (2026)
+
+> Created: 2026-03-27
+
+## Create a Kiro Profile
+
+1. Go to the **Amazon Q Developer / Kiro console** and click **"Onboard your team to Kiro"**. Select the **"IAM Identity Center"** option and click **Next**.
+2. In the **"Sign up with email"** menu, select **"Set up application as admin"** and click **Enable**.
+3. A message confirming **"Successfully created Kiro profile"** will appear. Navigate to the **Settings** page (left-hand navigation pane) to confirm.
+
+## Enable Amazon Q Developer
+
+1. Go to the **Amazon Q Developer / Kiro console** → **Settings** (left-hand navigation pane).
+2. Scroll to **"Other applications"** and click **Enable**. Then click **"Enable Q Developer Pro for $19 per user"**.
+3. Verify that **"Amazon Q Developer"** now appears in the left-hand navigation pane.
+
+## Subscribe a New User or Group
+
+1. Go to the **Amazon Q Developer / Kiro console** → **Subscriptions** (under the Amazon Q Developer section). In the Users/Groups tabs, select **"New Subscription"** from the **"More actions"** menu.
+2. Search for the user by display name, username, or email. Select the user and click **Assign**. For groups, search by group name, select it, and click **Done**.
+3. Verify the subscription status from the **Users/Groups** tab.
+
+## Verify an Existing Subscription
+
+1. Go to the **Amazon Q Developer / Kiro console**.
+2. Navigate to **Subscriptions** (under the Amazon Q Developer section) and review the status in the **Users/Groups** tab.
+
+## Reference
+
+- [Amazon Q Developer Subscription Management](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/subscribe-management.html)


### PR DESCRIPTION
Adds a step-by-step guide for subscribing to Amazon Q Developer in 2026, covering:
- Creating a Kiro profile via IAM Identity Center
- Enabling Amazon Q Developer Pro
- Subscribing users and groups
- Verifying existing subscriptions

Reference: https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/subscribe-management.html