### PR TITLE
release notes: OpenClaw v2026.3.31

### DIFF
--- a/release-notes/2026-03-31.md
+++ b/release-notes/2026-03-31.md
@@ -1,0 +1,510 @@
+# OpenClaw v2026.3.31 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.3.31)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Nodes/exec：移除 `nodes.run` shell wrapper | 原本透過 `nodes.run` 執行的 shell 指令將失效 | 改用 `exec host=node`；node 專屬功能改用 `nodes invoke` |
+| Plugin SDK：棄用舊版 provider compat subpaths 與 channel-runtime shims | 使用舊版 `openclaw/plugin-sdk` 子路徑的 plugin 將收到 migration warning | 遷移至 `openclaw/plugin-sdk/*` 正式 entrypoints 及 `api.ts` / `runtime-api.ts` |
+| Skills/Plugins install：危險程式碼預設 fail closed | 原本可成功安裝的 plugin/skill 若含 `critical` 危險程式碼發現，現在將安裝失敗 | 確認安全後加上 `--dangerously-force-unsafe-install` 旗標 |
+| Gateway/auth：`trusted-proxy` 拒絕混合 shared-token 設定 | 混用 shared-token 的 trusted-proxy 設定將被拒絕；local-direct fallback 需要設定的 token | 更新 gateway auth 設定，移除混合 shared-token 配置 |
+| Gateway/node commands：node commands 需等 pairing 核准才啟用 | 僅完成 device pairing 不再足以啟用 node commands | 確保 node pairing 已通過核准流程 |
+| Gateway/node events：node-originated runs 限縮 trusted surface | 依賴 host/session tool 廣泛存取的 node-triggered flows 可能需要調整 | 審查 node-triggered flows 的工具存取需求並更新設定 |
+
+### 新功能亮點
+
+- **Background Tasks 統一控制平面** — ACP、subagent、cron、background CLI 統一至 SQLite-backed 任務帳本，支援 `openclaw flows list|show|cancel`
+- **QQ Bot 頻道** — 新增 QQ Bot 作為內建頻道 plugin，支援多帳號、slash commands、媒體收發
+- **Matrix 串流回覆** — Matrix 回覆改為 draft streaming，部分回覆就地更新而非逐塊發送新訊息
+- **ACP/sessions_spawn 修復** — 子 run 現在正確追蹤生命週期，避免已啟動的 ACP turn 被誤判為中止
+- **安全強化** — exec 環境變數注入防護、ACP 危險工具語意核准分類、gateway auth 多項強化
+
+---
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ Background Tasks 統一控制平面（ACP/subagent/cron/CLI 統一至 SQLite-backed 任務帳本）
+- ⭐⭐⭐ Background Tasks：新增 linear task flow 控制介面（`openclaw flows list|show|cancel`）
+- ⭐⭐⭐ Channels/QQ Bot：新增 QQ Bot 內建頻道 plugin
+- ⭐⭐ ACP/plugins：新增 ACPX plugin-tools MCP bridge 設定，強化 stdio MCP session 支援 ([#56867](https://github.com/openclaw/openclaw/pull/56867))
+- ⭐⭐ Agents/MCP：bundle MCP tools 使用 provider-safe 命名，支援 `streamable-http` transport ([#49505](https://github.com/openclaw/openclaw/pull/49505))
+- ⭐⭐ Android/notifications：新增通知轉發控制（套件過濾、靜音時段、速率限制）([#40175](https://github.com/openclaw/openclaw/pull/40175))
+- ⭐⭐ Matrix/streaming：新增 draft streaming，部分回覆就地更新 ([#56387](https://github.com/openclaw/openclaw/pull/56387))
+- ⭐⭐ MCP：新增遠端 HTTP/SSE server 支援，含 auth headers ([#50396](https://github.com/openclaw/openclaw/pull/50396))
+- ⭐⭐ Slack/exec approvals：新增 Slack 原生 exec 核准路由
+- ⭐ Agents/LLM：新增可設定的 idle-stream timeout ([#55072](https://github.com/openclaw/openclaw/pull/55072))
+- ⭐ LINE/outbound media：新增 LINE 圖片、影片、音訊外送 ([#45826](https://github.com/openclaw/openclaw/pull/45826))
+- ⭐ Matrix/history：新增 room history context 支援 ([#57022](https://github.com/openclaw/openclaw/pull/57022))
+- ⭐ Matrix/network：新增 `channels.matrix.proxy` 設定 ([#56931](https://github.com/openclaw/openclaw/pull/56931))
+- ⭐ Matrix/threads：新增 per-DM `threadReplies` 覆寫 ([#57995](https://github.com/openclaw/openclaw/pull/57995))
+- ⭐ Memory/QMD：新增 per-agent `memorySearch.qmd.extraCollections`
+- ⭐ Microsoft Teams/member info：新增 Graph-backed 成員資訊查詢 ([#57528](https://github.com/openclaw/openclaw/pull/57528))
+- ⭐ Pi/Codex：新增 Codex web search 支援 ([#46579](https://github.com/openclaw/openclaw/pull/46579))
+- ⭐ WhatsApp/reactions：agent 可對 WhatsApp 訊息回應 emoji
+- ⭐ OpenAI/Responses：轉發 `text.verbosity` 設定 ([#47106](https://github.com/openclaw/openclaw/pull/47106))
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ ACP/security：以語意核准分類取代危險工具名稱覆寫，限縮自動核准範圍
+- ⭐⭐⭐ Exec/env：封鎖 proxy、TLS、Docker endpoint 環境變數注入
+- ⭐⭐⭐ Exec/env：封鎖 Python package index 覆寫變數
+- ⭐⭐⭐ Gateway/auth：強化 trusted-proxy 設定驗證，local-direct fallback 需要 token
+- ⭐⭐⭐ Gateway/node commands：node commands 需等 pairing 核准才啟用 ([#57777](https://github.com/openclaw/openclaw/pull/57777))
+- ⭐⭐⭐ Gateway/node events：node-originated runs 限縮 trusted surface ([#57691](https://github.com/openclaw/openclaw/pull/57691))
+- ⭐⭐⭐ Skills/Plugins install：危險程式碼預設 fail closed
+- ⭐⭐ Gateway/auth：WebSocket handshake 期間維持 shared-auth rate limiting
+- ⭐⭐ Gateway/auth：拒絕不符的 browser Origin header
+- ⭐⭐ Gateway/device tokens：token rotation 後立即斷開現有 session
+- ⭐⭐ Gateway/plugins：plugin-auth HTTP route 限縮為 read-only
+- ⭐⭐ Nostr/inbound DMs：驗證 inbound event 簽章
+- ⭐⭐ Heartbeat/auth：防止 exec-event heartbeat 繼承 owner-only 工具存取
+- ⭐ Exec approvals：強化 `awk`/`sed` 不列入 safeBins 快速路徑
+- ⭐ Exec/exec approvals：macOS `arch`/`xcrun` wrapper 解包後再推導 shell payload
+- ⭐ Feishu/groups：quoted replies 與 topic bootstrap 對齊 allowlist 檢查
+- ⭐ Discord/voice：語音 ingress 套用 guild channel/member allowlist 檢查
+- ⭐ Sandbox/networking：SSH subprocess env vars 透過 sandbox policy 清理
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ ACP/sessions_spawn：子 run 正確追蹤生命週期與清理 ([#40885](https://github.com/openclaw/openclaw/pull/40885))
+- ⭐⭐⭐ Gateway/OpenAI compatibility：接受 flat Responses API function tool 定義
+- ⭐⭐⭐ Gateway/pairing：修復 QR bootstrap onboarding handoff ([#58382](https://github.com/openclaw/openclaw/pull/58382))
+- ⭐⭐ Agents/Anthropic failover：將 `api_error` 非預期錯誤視為 transient ([#57441](https://github.com/openclaw/openclaw/pull/57441))
+- ⭐⭐ Config/Telegram：自動遷移已移除的 `groupMentionsOnly` 設定 ([#55336](https://github.com/openclaw/openclaw/pull/55336))
+- ⭐⭐ Gateway/OpenAI HTTP：修復 bearer-authenticated 請求的預設 operator scopes ([#57596](https://github.com/openclaw/openclaw/pull/57596))
+- ⭐⭐ Cron/isolated sessions：跨 retry restart 保留 provider/model/auth-profile 選擇 ([#57972](https://github.com/openclaw/openclaw/pull/57972))
+- ⭐⭐ Control UI/agents：修復 Files panel 自動載入與 model 顯示 ([#56637](https://github.com/openclaw/openclaw/pull/56637))
+- ⭐⭐ ACP/tasks：cleanly exited ACP runs 在 write/auth blockers 時標記為 blocked
+- ⭐ Agents/BTW：強制 `/btw` 停用 provider reasoning，修復 Anthropic adaptive-thinking 失敗 ([#55376](https://github.com/openclaw/openclaw/pull/55376))
+- ⭐ Android/device info：改用 package manager 讀取版本，修復 Android 15+ 問題 ([#58126](https://github.com/openclaw/openclaw/pull/58126))
+- ⭐ Android/pairing：修復重複 QR pairing 導致 push receiver 重複 ([#58256](https://github.com/openclaw/openclaw/pull/58256))
+- ⭐ Config/SecretRef：強化 SecretRef redaction round-trip 與 preflight 驗證 ([#58044](https://github.com/openclaw/openclaw/pull/58044))
+- ⭐ Cron/announce：修復 multi-line cron 報告只傳最後一塊的問題
+- ⭐ LINE/ACP：新增 current-conversation binding，對齊其他頻道行為
+- ⭐ LINE/markdown：修復 Latin/Cyrillic/CJK 字詞內底線被誤刪 ([#47465](https://github.com/openclaw/openclaw/pull/47465))
+- ⭐ Slack：修復 retry 導致重複回覆的問題
+- ⭐ Control UI/slash commands：修復 `/steer` 與 `/redirect` 在 command palette 的行為 ([#54625](https://github.com/openclaw/openclaw/pull/54625))
+- ⭐ Exec/runtime：預設 implicit exec 為 `host=auto`，sandbox 不存在時 fail closed ([#56800](https://github.com/openclaw/openclaw/pull/56800))
+- ⭐ iOS/Live Activities：修復 Xcode 26.4 / Swift 6 strict concurrency 編譯錯誤 ([#57180](https://github.com/openclaw/openclaw/pull/57180))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Background Tasks 統一控制平面
+
+- **用途**: 將 ACP、subagent、cron、background CLI 執行統一至 SQLite-backed 任務帳本，並新增 `openclaw flows list|show|cancel` 流程控制介面
+- **解決問題**: 各類背景任務各自為政，缺乏統一的生命週期追蹤、稽核與失敗恢復機制
+- **影響**: 所有背景任務現在共享一個控制平面，可統一查看狀態、取消任務、追蹤 orphaned runs
+
+```text
+┌─────────────────────────────────────────────────────┐
+│              Background Task Sources                 │
+│  ┌────────┐  ┌──────────┐  ┌──────┐  ┌──────────┐  │
+│  │  ACP   │  │ subagent │  │ cron │  │ CLI exec │  │
+│  └────┬───┘  └────┬─────┘  └──┬───┘  └────┬─────┘  │
+└───────┼───────────┼───────────┼────────────┼────────┘
+        │           │           │            │
+        └───────────┴─────┬─────┴────────────┘
+                          ▼
+              ┌───────────────────────┐
+              │  SQLite Task Ledger   │
+              │  (統一帳本)            │
+              └───────────┬───────────┘
+                          │
+              ┌───────────┴───────────┐
+              │                       │
+              ▼                       ▼
+  ┌─────────────────────┐  ┌──────────────────────┐
+  │  openclaw flows     │  │  Audit / Recovery    │
+  │  list|show|cancel   │  │  lost-run detection  │
+  └─────────────────────┘  └──────────────────────┘
+```
+
+### ⭐⭐⭐ Channels/QQ Bot：新增 QQ Bot 內建頻道 plugin ([#52986](https://github.com/openclaw/openclaw/pull/52986))
+
+- **用途**: 新增 QQ Bot 作為 OpenClaw 內建頻道 plugin，支援多帳號設定、SecretRef 憑證、slash commands、提醒與媒體收發
+- **解決問題**: QQ 使用者無法透過 OpenClaw 使用 AI agent 服務
+- **影響**: QQ Bot 使用者可直接與 OpenClaw agents 互動，無需額外整合
+
+```text
+┌──────────────┐     ┌─────────────────────┐
+│   QQ Bot     │────►│  OpenClaw Gateway   │
+│  (多帳號)    │     │  QQ Channel Plugin  │
+└──────────────┘     └──────────┬──────────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │                       │
+                    ▼                       ▼
+          ┌──────────────────┐   ┌──────────────────┐
+          │  slash commands  │   │  media send/recv │
+          │  reminders       │   │  SecretRef creds │
+          └──────────────────┘   └──────────────────┘
+```
+
+### ⭐⭐ ACP/plugins：ACPX plugin-tools MCP bridge ([#56867](https://github.com/openclaw/openclaw/pull/56867))
+
+- **用途**: 新增預設關閉的 ACPX plugin-tools MCP bridge 設定，強化 global install 與 stdio MCP session 的可靠性
+- **解決問題**: ACPX plugin 工具在 stdio MCP session 中無法可靠運作
+- **影響**: MCP bridge 使用者可透過明確設定啟用，trust boundary 有文件說明
+
+### ⭐⭐ Agents/MCP：bundle MCP tools provider-safe 命名 ([#49505](https://github.com/openclaw/openclaw/pull/49505))
+
+- **用途**: bundle MCP tools 使用 `serverName__toolName` 格式命名，支援 `streamable-http` transport 與 per-server connection timeout，保留 aborted/error turns 的真實工具結果
+- **解決問題**: MCP tool 命名衝突，以及 aborted turns 的工具結果遺失
+- **影響**: 多 MCP server 環境下工具命名不再衝突，結果保留更完整
+
+### ⭐⭐ Android/notifications：通知轉發控制 ([#40175](https://github.com/openclaw/openclaw/pull/40175))
+
+- **用途**: 新增通知轉發的套件過濾、靜音時段、速率限制與更安全的 picker 行為
+- **解決問題**: Android 通知轉發缺乏細粒度控制，可能轉發不必要的通知
+- **影響**: Android 使用者可精確控制哪些 app 的通知被轉發，以及何時轉發
+
+### ⭐⭐ Matrix/streaming：draft streaming 就地更新 ([#56387](https://github.com/openclaw/openclaw/pull/56387))
+
+- **用途**: Matrix 回覆改為 draft streaming，部分回覆就地更新同一則訊息，而非每個 chunk 發送新訊息
+- **解決問題**: streaming 回覆在 Matrix 中產生大量碎片訊息，影響閱讀體驗
+- **影響**: Matrix 使用者看到的 streaming 回覆更整潔，體驗接近其他頻道
+
+### ⭐⭐ MCP：遠端 HTTP/SSE server 支援 ([#50396](https://github.com/openclaw/openclaw/pull/50396))
+
+- **用途**: `mcp.servers` URL 設定支援遠端 HTTP/SSE server，含 auth headers 與安全的 credential redaction
+- **解決問題**: 無法連接遠端 MCP server，限制了 MCP 生態系整合
+- **影響**: 可整合任何支援 HTTP/SSE 的遠端 MCP server
+
+### ⭐⭐ Slack/exec approvals：原生 Slack 核准路由
+
+- **用途**: exec 核准提示可直接在 Slack 中處理，不再需要退回 Web UI 或 terminal
+- **解決問題**: Slack 使用者需要切換到其他介面才能核准 exec 操作，流程中斷
+- **影響**: Slack 工作流程更流暢，exec 核准可在 Slack 內完成
+
+### ⭐ Agents/LLM：可設定 idle-stream timeout ([#55072](https://github.com/openclaw/openclaw/pull/55072))
+
+- **用途**: 新增 embedded runner 請求的 idle-stream timeout 設定，stalled model streams 會乾淨地中止
+- **解決問題**: stalled model streams 會一直掛起直到整體 run timeout 才觸發
+- **影響**: 減少因 stalled stream 導致的長時間等待
+
+### ⭐ LINE/outbound media ([#45826](https://github.com/openclaw/openclaw/pull/45826))
+
+- **用途**: 新增 LINE 圖片、影片、音訊外送，影片含 preview/tracking 處理
+- **解決問題**: LINE 頻道無法發送媒體內容
+- **影響**: LINE agent 可回傳圖片、影片、音訊給使用者
+
+### ⭐ Matrix/history：room history context ([#57022](https://github.com/openclaw/openclaw/pull/57022))
+
+- **用途**: Matrix group triggers 可選擇性載入 room history context，透過 `channels.matrix.historyLimit` 設定，含 per-agent watermarks 與 retry-safe snapshots
+- **解決問題**: Matrix group trigger 缺乏歷史訊息 context，agent 無法了解對話背景
+- **影響**: Matrix group agent 可獲得更豐富的對話 context
+
+### ⭐ Memory/QMD：per-agent extraCollections
+
+- **用途**: 新增 per-agent `memorySearch.qmd.extraCollections`，讓 agent 可選擇性加入跨 agent session 搜尋
+- **解決問題**: 跨 agent 記憶搜尋會將所有 transcript collection 合併至同一 QMD namespace
+- **影響**: agent 可精確控制記憶搜尋範圍，避免 namespace 污染
+
+### ⭐ WhatsApp/reactions
+
+- **用途**: agent 可對 incoming WhatsApp 訊息回應 emoji reaction
+- **解決問題**: WhatsApp agent 只能以文字回覆，缺乏輕量互動方式
+- **影響**: 更自然的 WhatsApp 對話互動，例如以 ❤️ 確認收到照片
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ ACP/security：語意核准分類取代危險工具名稱覆寫
+
+- **用途**: 以語意核准分類取代 ACP 危險工具名稱覆寫，僅允許窄範圍的 readonly reads/searches 自動核准，indirect exec-capable 與 control-plane 工具一律需要明確核准
+- **解決問題**: 舊機制以工具名稱判斷危險性，容易被繞過或誤判
+- **影響**: ACP 工具核准更精確，降低惡意工具自動執行的風險
+
+```text
+┌─────────────────────────────────────┐
+│         ACP Tool Request            │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │  語意核准分類判斷     │
+        └──────────┬───────────┘
+                   │
+       ┌───────────┴───────────┐
+       │                       │
+       ▼                       ▼
+┌─────────────┐       ┌─────────────────────┐
+│ readonly    │       │ exec-capable /      │
+│ reads/      │       │ control-plane tools │
+│ searches    │       └──────────┬──────────┘
+└──────┬──────┘                  │
+       │                         ▼
+       ▼               ┌──────────────────┐
+  ✅ 自動核准           │  需要明確核准    │
+                        └──────────────────┘
+```
+
+### ⭐⭐⭐ Exec/env：封鎖 proxy/TLS/Docker endpoint 環境變數注入
+
+- **用途**: 封鎖 request-scoped host execution 中的 proxy、TLS、Docker endpoint 環境變數覆寫，防止指令重導向外部流量或信任攻擊者提供的憑證
+- **解決問題**: 攻擊者可透過環境變數注入，將 exec 流量導向惡意 proxy 或使用偽造 TLS 憑證
+- **影響**: host exec 環境更安全，防止 MITM 與流量劫持攻擊
+
+### ⭐⭐⭐ Exec/env：封鎖 Python package index 覆寫
+
+- **用途**: 封鎖 request-scoped host exec 環境中的 Python package index 覆寫變數（如 `PIP_INDEX_URL`）
+- **解決問題**: 攻擊者可透過覆寫 package index，在 exec 期間安裝惡意套件
+- **影響**: Python 相關 exec 操作不再受 caller-supplied index 影響
+
+### ⭐⭐⭐ Gateway/auth：trusted-proxy 設定強化
+
+- **用途**: `trusted-proxy` 拒絕混合 shared-token 設定；local-direct fallback 需要設定的 token 而非隱式信任同主機呼叫者
+- **解決問題**: 混合設定可能導致意外的信任提升；同主機呼叫者被隱式信任存在安全風險
+- **影響**: gateway auth 設定更嚴格，需更新混合 shared-token 設定
+
+```text
+┌─────────────────────────────────────┐
+│         Incoming Request            │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │  trusted-proxy 檢查  │
+        └──────────┬───────────┘
+                   │
+       ┌───────────┴───────────┐
+       │                       │
+       ▼                       ▼
+┌─────────────────┐   ┌─────────────────────┐
+│ 混合 shared-    │   │ local-direct        │
+│ token 設定      │   │ fallback            │
+└────────┬────────┘   └──────────┬──────────┘
+         │                       │
+         ▼                       ▼
+    ❌ 拒絕                需要設定的 token
+                          (非隱式信任)
+```
+
+### ⭐⭐⭐ Gateway/node commands：pairing 核准才啟用 ([#57777](https://github.com/openclaw/openclaw/pull/57777))
+
+- **用途**: node commands 現在需等 node pairing 核准後才啟用，device pairing 本身不再足以啟用 node commands
+- **解決問題**: 僅完成 device pairing 即可執行 node commands，存在未授權存取風險
+- **影響**: node commands 的啟用需要明確的核准步驟，提升安全性
+
+### ⭐⭐⭐ Gateway/node events：node-originated runs 限縮 trusted surface ([#57691](https://github.com/openclaw/openclaw/pull/57691))
+
+- **用途**: node-originated runs 限縮至較小的 trusted surface，依賴廣泛 host/session tool 存取的 node-triggered flows 可能需要調整
+- **解決問題**: node-triggered flows 可存取過多 host/session 工具，擴大攻擊面
+- **影響**: 需審查並更新依賴廣泛工具存取的 node-triggered flows
+
+### ⭐⭐⭐ Skills/Plugins install：危險程式碼預設 fail closed
+
+- **用途**: 內建危險程式碼 `critical` 發現與安裝時掃描失敗現在預設 fail closed，需要明確的 `--dangerously-force-unsafe-install` 旗標才能繼續
+- **解決問題**: 含危險程式碼的 plugin/skill 可在未明確確認的情況下安裝
+- **影響**: 安裝流程更安全，但原本可成功安裝的 plugin 可能需要加上覆寫旗標
+
+### ⭐⭐ Gateway/auth：WebSocket handshake rate limiting
+
+- **用途**: WebSocket handshake 期間維持 shared-auth rate limiting，即使 caller 同時送出 device-token 候選也不例外
+- **解決問題**: 帶有 device-token 欄位的請求可繞過 shared-secret brute-force 追蹤
+- **影響**: 防止透過 device-token 欄位繞過 rate limiting 的暴力破解攻擊
+
+### ⭐⭐ Gateway/auth：拒絕不符的 browser Origin header
+
+- **用途**: 拒絕 trusted-proxy HTTP operator 請求中不符的 browser `Origin` header，同時保持 origin-less headless proxy clients 正常運作
+- **解決問題**: 惡意網頁可偽造 Origin header 發送 trusted-proxy 請求
+- **影響**: 防止 CSRF 類型攻擊透過 trusted-proxy 路徑執行
+
+### ⭐⭐ Gateway/device tokens：token rotation 後立即斷開 session
+
+- **用途**: token rotation 後立即斷開使用舊 token 的 active device sessions
+- **解決問題**: token rotation 後舊 token 的 session 仍可繼續使用，直到自然關閉
+- **影響**: token rotation 立即生效，舊憑證無法繼續使用
+
+### ⭐⭐ Nostr/inbound DMs：驗證 inbound event 簽章
+
+- **用途**: 驗證 inbound Nostr event 簽章，偽造的 DM events 不再觸發 pairing 請求或回覆嘗試
+- **解決問題**: 未驗證簽章的 inbound events 可被偽造，觸發非預期的 pairing 或回覆
+- **影響**: Nostr DM 處理更安全，防止偽造事件攻擊
+
+### ⭐⭐ Heartbeat/auth：防止 exec-event heartbeat 繼承 owner-only 工具存取
+
+- **用途**: 防止 exec-event heartbeat runs 從 session delivery target 繼承 owner-only 工具存取
+- **解決問題**: node exec 輸出可能透過 heartbeat 繼承 owner-only 工具存取，存在權限提升風險
+- **影響**: node exec 輸出維持在 non-owner 工具表面，即使 target session 屬於 owner
+
+### ⭐ Discord/voice：語音 ingress allowlist 檢查
+
+- **用途**: 語音 ingress 在轉錄前套用相同的 guild channel 與 member allowlist 檢查
+- **解決問題**: 加入的語音頻道可接受 allowlist 外使用者的語音輸入
+- **影響**: 語音頻道的存取控制與文字頻道一致
+
+### ⭐ Exec approvals：`awk`/`sed` 不列入 safeBins
+
+- **用途**: 將 `awk` 與 `sed` 系列工具從 low-risk `safeBins` 快速路徑移除
+- **解決問題**: `awk`/`sed` 可執行任意程式碼，不應被視為低風險工具
+- **影響**: 使用 `awk`/`sed` 的 exec 操作需要明確核准
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ ACP/sessions_spawn：子 run 生命週期追蹤 ([#40885](https://github.com/openclaw/openclaw/pull/40885))
+
+- **用途**: 為 ACP child runs 正確註冊 completion tracking 與 lifecycle cleanup；registration-failure cleanup 明確為 best-effort，避免 caller 誤以為已啟動的 ACP turn 被完全中止
+- **解決問題**: ACP child runs 未被追蹤，導致 lifecycle 管理混亂；registration 失敗時 cleanup 行為不明確
+- **影響**: ACP sessions_spawn 的可靠性大幅提升，orphaned runs 可被正確清理
+
+```text
+┌─────────────────────────────────────┐
+│         sessions_spawn 呼叫         │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │  啟動 ACP child run  │
+        └──────────┬───────────┘
+                   │
+       ┌───────────┴───────────┐
+       │                       │
+       ▼                       ▼
+┌─────────────────┐   ┌─────────────────────┐
+│  Registration   │   │  Registration       │
+│  成功           │   │  失敗               │
+└────────┬────────┘   └──────────┬──────────┘
+         │                       │
+         ▼                       ▼
+  追蹤 completion          best-effort cleanup
+  lifecycle cleanup        (不假設 turn 已中止)
+```
+
+### ⭐⭐⭐ Gateway/OpenAI compatibility：接受 flat Responses API function tool 定義
+
+- **用途**: `/v1/responses` 接受 flat Responses API function tool 定義，並在 normalize 至 embedded runner 時保留 `strict`
+- **解決問題**: 符合規格的 client（如 Codex）送出 flat function tool 定義時驗證失敗，或 `strict` 被靜默丟棄
+- **影響**: Codex 等 OpenAI-compatible client 可正常使用 `/v1/responses` endpoint
+
+### ⭐⭐⭐ Gateway/pairing：修復 QR bootstrap onboarding handoff ([#58382](https://github.com/openclaw/openclaw/pull/58382))
+
+- **用途**: 修復 `/pair qr` iPhone 初始設定的 auto-approve initial node pairing、接收 reusable node device token，以及停止以已用完的 bootstrap auth 重試
+- **解決問題**: 新 iPhone 透過 QR code 配對時，onboarding 流程中斷，無法完成初始設定
+- **影響**: 新裝置 QR 配對流程可正常完成
+
+### ⭐⭐ Agents/Anthropic failover：transient error 重試 ([#57441](https://github.com/openclaw/openclaw/pull/57441))
+
+- **用途**: 將 Anthropic `api_error` 中含 `An unexpected error occurred while processing the response` 的錯誤視為 transient，允許 retry/fallback 介入
+- **解決問題**: 此類錯誤被視為 terminal failure，無法觸發重試或 fallback
+- **影響**: Anthropic API 偶發性錯誤可自動重試，提升穩定性
+
+### ⭐⭐ Config/Telegram：自動遷移 `groupMentionsOnly` ([#55336](https://github.com/openclaw/openclaw/pull/55336))
+
+- **用途**: 載入時自動將已移除的 `channels.telegram.groupMentionsOnly` 遷移至 `channels.telegram.groups["*"].requireMention`
+- **解決問題**: 使用舊版設定的 gateway 在啟動時 crash
+- **影響**: 升級後舊版 Telegram 設定可自動遷移，無需手動修改
+
+### ⭐⭐ Gateway/OpenAI HTTP：修復 bearer-authenticated 請求的預設 scopes ([#57596](https://github.com/openclaw/openclaw/pull/57596))
+
+- **用途**: 修復省略 `x-openclaw-scopes` 的 bearer-authenticated 請求的預設 operator scopes
+- **解決問題**: 最近的 method-scope 強化後，headless `/v1/chat/completions` 與 session-history callers 無法正常運作
+- **影響**: 使用 bearer token 但未指定 scopes 的 client 可正常使用
+
+### ⭐⭐ Cron/isolated sessions：跨 retry 保留 model 選擇 ([#57972](https://github.com/openclaw/openclaw/pull/57972))
+
+- **用途**: 跨 retry restart 保留完整的 live-session provider、model 與 auth-profile 選擇
+- **解決問題**: 有 model override 的 cron jobs 在 mid-run model-switch 請求時失敗或進入迴圈
+- **影響**: 使用 model override 的 cron jobs 在 retry 後可正常繼續
+
+### ⭐⭐ Control UI/agents：修復 Files panel 與 model 顯示 ([#56637](https://github.com/openclaw/openclaw/pull/56637))
+
+- **用途**: Files panel 開啟時自動載入 agent workspace files；overview 的 model/workspace/fallbacks 從 effective runtime agent metadata 填入
+- **解決問題**: Files panel 需手動觸發才載入；預設 model 顯示為 `Not set`
+- **影響**: Control UI 的 agent 設定頁面顯示更準確
+
+### ⭐⭐ ACP/tasks：blocked state 正確標記
+
+- **用途**: cleanly exited ACP runs 在 deterministic write 或 authorization blockers 時標記為 blocked，並以 follow-up 喚醒 parent session
+- **解決問題**: 在 write/auth blockers 結束的 ACP runs 被誤報為成功
+- **影響**: ACP task 狀態更準確，parent session 可正確處理 blocked 狀態
+
+### ⭐ Agents/BTW：修復 Anthropic adaptive-thinking 失敗 ([#55376](https://github.com/openclaw/openclaw/pull/55376))
+
+- **用途**: 強制 `/btw` side questions 停用 provider reasoning，修復 Anthropic adaptive-thinking sessions 的 `No BTW response generated` 錯誤
+- **解決問題**: 在 Anthropic adaptive-thinking session 中使用 `/btw` 時持續失敗
+- **影響**: `/btw` 在 Anthropic adaptive-thinking session 中可正常使用
+
+### ⭐ Android/device info：修復 Android 15+ 版本讀取 ([#58126](https://github.com/openclaw/openclaw/pull/58126))
+
+- **用途**: 改用 package manager 讀取 app 版本 metadata，取代 hidden APIs
+- **解決問題**: Android 15+ onboarding 與 device info 無法編譯或回報 placeholder 值
+- **影響**: Android 15+ 裝置的 onboarding 與版本顯示正常
+
+### ⭐ Android/pairing：修復重複 QR pairing push receiver ([#58256](https://github.com/openclaw/openclaw/pull/58256))
+
+- **用途**: 停止在重複 QR pairing 時附加重複的 push receiver 至 `gateway-service.conf`
+- **解決問題**: 多次 QR pairing 後 push delivery 異常
+- **影響**: 重複配對後 push 通知正常運作
+
+### ⭐ Config/SecretRef：強化 redaction round-trip ([#58044](https://github.com/openclaw/openclaw/pull/58044))
+
+- **用途**: 強化 SecretRef redaction round-trip restore，封鎖 unsafe raw fallback，並在 config write 前 preflight 驗證 SecretRefs
+- **解決問題**: SecretRef 在某些情況下可能洩漏或無法正確還原
+- **影響**: SecretRef 處理更安全，config 寫入前有額外驗證
+
+### ⭐ Cron/announce：修復 multi-line 報告截斷
+
+- **用途**: 修復 announce mode 只傳最後一個 chunk 的問題，保留所有可傳遞的文字 payload
+- **解決問題**: multi-line cron 報告在 Telegram forum topics 中只顯示最後一行
+- **影響**: cron 報告完整傳遞至 Telegram
+
+### ⭐ Control UI/slash commands：修復 `/steer` 與 `/redirect` ([#54625](https://github.com/openclaw/openclaw/pull/54625))
+
+- **用途**: 修復 `/steer` 與 `/redirect` 在 chat command palette 的行為，含 active-run `/steer` 的 pending state 顯示與 command menu 去重
+- **解決問題**: `/steer` 與 `/redirect` 在 command palette 中無法正常運作
+- **影響**: Control UI 的 slash commands 行為正確
+
+### ⭐ Exec/runtime：implicit exec 預設 `host=auto` ([#56800](https://github.com/openclaw/openclaw/pull/56800))
+
+- **用途**: 預設 implicit exec 為 `host=auto`，sandbox 不存在時 fail closed；停止 denied async approval followups 重用先前的指令輸出
+- **解決問題**: implicit exec 行為不一致；denied approval 後可能重用舊輸出
+- **影響**: exec 行為更可預測，sandbox 不存在時明確失敗
+
+### ⭐ iOS/Live Activities：修復 Swift 6 編譯錯誤 ([#57180](https://github.com/openclaw/openclaw/pull/57180))
+
+- **用途**: 在 `LiveActivityManager.swift` 中將 `ActivityKit` import 標記為 `@preconcurrency`
+- **解決問題**: Xcode 26.4 / Swift 6 strict concurrency 檢查導致編譯失敗
+- **影響**: iOS app 可在 Xcode 26.4 / Swift 6 環境下正常編譯
+
+### ⭐ LINE/ACP：current-conversation binding
+
+- **用途**: 新增 LINE 的 current-conversation binding 與 inbound binding-routing parity，使 `/acp spawn ... --thread here`、configured ACP bindings 與 active conversation-bound ACP sessions 在 LINE 上正常運作
+- **解決問題**: LINE 頻道缺少 ACP conversation binding，行為與其他頻道不一致
+- **影響**: LINE 上的 ACP 功能與其他頻道對齊
+
+### ⭐ LINE/markdown：修復底線誤刪 ([#47465](https://github.com/openclaw/openclaw/pull/47465))
+
+- **用途**: 修復 Latin、Cyrillic、CJK 字詞內的底線被誤刪，同時仍正確移除獨立的 `_italic_` markdown 標記
+- **解決問題**: 含底線的技術術語（如 `snake_case`）在 LINE 訊息中被破壞
+- **影響**: LINE 與 TTS 的 markdown 處理更準確
+
+### ⭐ Slack：修復 retry 重複回覆
+
+- **用途**: 修復 draft-finalization edits 失敗時 retry 導致的重複回覆；configured allowlisted users/channels 改以可讀名稱記錄
+- **解決問題**: Slack 訊息在特定失敗情況下被重複發送
+- **影響**: Slack 回覆不再因 retry 產生重複訊息
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 5 | 11 | Background Tasks 統一控制平面、QQ Bot 頻道、Matrix streaming 等重大功能 |
+| 安全性提升 | 7 | 6 | 2 | exec 環境變數防護、ACP 語意核准、gateway auth 多項強化 |
+| 錯誤修復 | 3 | 5 | 13 | ACP sessions_spawn、Gateway OpenAI 相容性、QR pairing 等關鍵修復 |
+| **總計** | **13** | **16** | **26** | **55 項變更** |
+
+**發佈日期**: 2026-03-31
+**版本**: 2026.3.31
+**狀態**: Production Ready
+**GitHub Release**: [v2026.3.31](https://github.com/openclaw/openclaw/releases/tag/v2026.3.31)


### PR DESCRIPTION
Closes #426

## Release Notes: OpenClaw v2026.3.31

新增 `release-notes/2026-03-31.md`，涵蓋：

- **6 項 Breaking Changes**（含升級前必讀表格）
- **55 項變更**：13 項 ⭐⭐⭐、16 項 ⭐⭐、26 項 ⭐
- 三大分類：功能更新 / 安全性提升 / 錯誤修復
- 所有 ⭐⭐⭐ 項目含 ASCII flowchart
- 所有 PR/Issue 連結可點

### 亮點
- Background Tasks 統一控制平面（ACP/subagent/cron/CLI 統一至 SQLite-backed 任務帳本）
- QQ Bot 新增為內建頻道 plugin
- ACP/security 語意核准分類強化
- exec 環境變數注入防護（proxy/TLS/Docker/Python package index）
- ACP/sessions_spawn 生命週期追蹤修復
