### PR TITLE
docs: add last_validated to approval-first workflow

### DIFF
--- a/docs/core/approval-first-workflow.md
+++ b/docs/core/approval-first-workflow.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # Approval-first 工作流（個人 OpenClaw Agent）
 
 ## TL;DR


### PR DESCRIPTION
Adds YAML frontmatter for doc review issue #398.

- [x] add last_validated: 2026-04-02
- [x] add validated_by: masami-agent
- [x] review content and confirm linked internal docs still resolve (docs/core/workspace-role-separation.md, docs/howto/agent-owned-github-repo.md, docs/STYLE_GUIDE.md)

Closes #398