### PR TITLE
docs: add last_validated to 10 howto/core docs

### DIFF
--- a/docs/core/gateway-lifecycle.md
+++ b/docs/core/gateway-lifecycle.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # Gateway 架構與生命週期（Lifecycle）
 
 > 本文件說明 OpenClaw **Gateway** 的整體架構、生命週期狀態/轉換、重啟與更新行為、可觀測性（observability）與常見故障排除。

--- a/docs/core/gateway-security-milestones.md
+++ b/docs/core/gateway-security-milestones.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # ClawJacked 漏洞：原因、修復與安全性演進歷程
 
 ## 概述

--- a/docs/core/memory-strategy.md
+++ b/docs/core/memory-strategy.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # 記憶系統：以檔案作為記憶（files-as-memory）策略
 
 > 本文說明 OpenClaw 在「沒有永久腦內記憶」的前提下，如何透過**檔案**建立可維護、可稽核、可控風險的長期記憶系統。

--- a/docs/core/skills-system.md
+++ b/docs/core/skills-system.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # Skills 系統（打包、版本控制、測試）
 
 > 本文是 OpenClaw 的核心概念深度解析：Skills 是什麼、如何打包、如何寫 SKILL.md、如何在本機測試與安全地發布/更新。

--- a/docs/howto/agent-browser-agentcore.md
+++ b/docs/howto/agent-browser-agentcore.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # How-to：Build agent-browser（PR #397）並連線 AWS Bedrock AgentCore Browser
 
 ```text

--- a/docs/howto/agent-owned-github-repo.md
+++ b/docs/howto/agent-owned-github-repo.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # Agent 專用 GitHub 帳號與備份策略（預設私有）
 
 ## TL;DR

--- a/docs/howto/aws-iam-minimal-openclawrole.md
+++ b/docs/howto/aws-iam-minimal-openclawrole.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # OpenClaw AWS IAM 最小權限配置（OpenClawRole）
 
 本文說明我們在 OpenClaw 中使用 AWS 的情境，以及對應的最小 IAM 權限配置。

--- a/docs/howto/gws-cli-scoped-auth.md
+++ b/docs/howto/gws-cli-scoped-auth.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # Google Workspace CLI (`gws`) 授權範圍控制指南
 
 本文說明如何為 agent 使用的 Google Workspace CLI (`gws`) 設定最小權限授權，限制存取範圍到特定資料夾，並補充其他服務的特殊考量。

--- a/docs/howto/skills-extradirs-symlink.md
+++ b/docs/howto/skills-extradirs-symlink.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # OpenClaw Skills Symlink 載入問題與 `extraDirs` 解法
 
 本文說明：當你用 symlink 把外部 skills repo 掛進 OpenClaw 的技能目錄時，為什麼在 2026-03-07 之後可能載入失敗，以及正確的替代做法 `skills.load.extraDirs`。

--- a/docs/howto/subscribe-amazon-q-developer.md
+++ b/docs/howto/subscribe-amazon-q-developer.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: masami-agent
+---
+
 # How to Subscribe to Amazon Q Developer (2026)
 
 > Created: 2026-03-27


### PR DESCRIPTION
Adds YAML frontmatter for doc review issues #386, #387, #388, #389, #390, #391, #392, #393, #394, and #395.

- [x] add last_validated: 2026-04-02
- [x] add validated_by: masami-agent
- [x] review affected howto/core docs and confirm they remain internally consistent for this frontmatter-only pass

Closes #386
Closes #387
Closes #388
Closes #389
Closes #390
Closes #391
Closes #392
Closes #393
Closes #394
Closes #395