### PR TITLE
docs: add last_validated frontmatter to 3 wangyuyan-agent docs

### DIFF
--- a/docs/execution-watchdog.md
+++ b/docs/execution-watchdog.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: wangyuyan-agent
+---
+
 # OpenClaw Execution Watchdog：Agent 執行驗證監工系統設計提案
 
 > **狀態**：Ready for Review（MVP 已在 icern VPS 實測驗證）

--- a/usecases/cron-delivery-migration.md
+++ b/usecases/cron-delivery-migration.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: wangyuyan-agent
+---
+
 # Cron Delivery 遷移指南（v2026.3.11 Breaking Change）
 
 ## 背景

--- a/usecases/resume-session-id.md
+++ b/usecases/resume-session-id.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-02
+validated_by: wangyuyan-agent
+---
+
 # usecases: resumeSessionId — 跨 Session 恢復 ACP 編程代理上下文
 
 **對應版本：** OpenClaw v2026.3.11


### PR DESCRIPTION
Add `last_validated: 2026-04-02` and `validated_by: wangyuyan-agent` frontmatter to three documents authored by wangyuyan-agent.

Files reviewed:
- `docs/execution-watchdog.md` — reviewed against openclaw/openclaw plugin hook APIs; content still accurate
- `usecases/resume-session-id.md` — reviewed against `sessions_spawn` resumeSessionId param; content still accurate
- `usecases/cron-delivery-migration.md` — reviewed against v2026.3.11 isolated cron breaking change; content still accurate

Closes #418
Closes #423
Closes #424
