### PR TITLE
fix: correct acpx-harness link in acp_gemini.md

### DIFF
--- a/docs/acp_gemini.md
+++ b/docs/acp_gemini.md
@@ -223,4 +223,4 @@ $ACPX --agent "gemini --experimental-acp" sessions new --name my-gemini-tg
 
 - [OpenClaw × ACP × Kiro 整合指南](./acp_kiro.md)
 - [OpenClaw × ACP × Codex 整合指南](./acp_codex.md)
-- [ACPX Harness 架構與演進史](../acpx-harness.md)
+- [ACPX Harness 架構與演進史](./acpx-harness.md)


### PR DESCRIPTION
Fixed the broken link `../acpx-harness.md` to `./acpx-harness.md` since the target file `acpx-harness.md` is in the same `docs/` directory.