### PR TITLE
release-notes: OpenClaw v2026.4.5

### DIFF
--- a/release-notes/2026-04-05.md
+++ b/release-notes/2026-04-05.md
@@ -1,0 +1,573 @@
+# OpenClaw v2026.4.5 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.5)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| 移除舊版 config 別名（`talk.voiceId`、`talk.apiKey`、`agents.*.sandbox.perSession`、`browser.ssrfPolicy.allowPrivateNetwork`、`hooks.internal.handlers`、channel `allow` 等） | 使用舊路徑的設定將無法載入 | 執行 `openclaw doctor --fix` 自動遷移至新路徑 |
+
+### 新功能亮點
+
+- **影片生成工具** — 內建 `video_generate` 工具，支援 xAI、Alibaba Wan、Runway 等多家供應商
+- **音樂生成工具** — 內建 `music_generate` 工具，支援 Google Lyria、MiniMax、ComfyUI
+- **ComfyUI 整合** — 新增 `comfy` workflow 媒體外掛，支援本地與 Comfy Cloud
+- **Memory Dreaming 強化** — 三階段記憶促進（light/deep/REM），可設定衰減參數
+- **多語言 Control UI** — 支援繁中、簡中、日文、韓文等 12 種語言
+
+---
+
+## 概述
+
+### 功能更新
+
+- ⭐⭐⭐ 移除舊版 config 別名，提供 `openclaw doctor --fix` 遷移支援（[#60726](https://github.com/openclaw/openclaw/pull/60726)）
+- ⭐⭐⭐ 新增 `video_generate` 內建工具，整合多家影片生成供應商
+- ⭐⭐⭐ 新增 `music_generate` 內建工具，支援 Google Lyria、MiniMax、ComfyUI
+- ⭐⭐⭐ ComfyUI bundled workflow 媒體外掛（image/video/music）
+- ⭐⭐⭐ Memory Dreaming 三階段架構重構，加入 Dream Diary、衰減控制
+- ⭐⭐⭐ ACPX runtime 內嵌至 bundled plugin，移除外部 ACP CLI 跳轉（[#61319](https://github.com/openclaw/openclaw/pull/61319)）
+- ⭐⭐ Amazon Bedrock Mantle 支援與 inference-profile 自動探索（[#61296](https://github.com/openclaw/openclaw/pull/61296)）
+- ⭐⭐ Control UI 多語言支援（12 種語言）
+- ⭐⭐ iOS exec approvals APNs 通知整合（[#60239](https://github.com/openclaw/openclaw/pull/60239)）
+- ⭐⭐ Matrix exec approvals 原生支援（[#58635](https://github.com/openclaw/openclaw/pull/58635)）
+- ⭐⭐ Prompt caching 穩定性大幅提升（[#58036](https://github.com/openclaw/openclaw/pull/58036) 等）
+- ⭐⭐ ClawHub 搜尋與安裝整合至 Skills 面板（[#60134](https://github.com/openclaw/openclaw/pull/60134)）
+- ⭐ 新增 Qwen、Fireworks AI、StepFun、MiniMax TTS 等供應商（[#60032](https://github.com/openclaw/openclaw/pull/60032) 等）
+- ⭐ Channels `contextVisibility` 可設定補充 context 過濾規則
+- ⭐ Agents/Claude CLI MCP loopback bridge 整合（[#35676](https://github.com/openclaw/openclaw/pull/35676)）
+
+### 安全性提升
+
+- ⭐⭐⭐ 修復 plugin-only tool allowlist 繞過、`/allowlist` 權限管控、`before_tool_call` hook 崩潰時 fail-closed（[#58476](https://github.com/openclaw/openclaw/pull/58476) 等）
+- ⭐⭐⭐ Claude CLI 安全強化：清除繼承的 config-root、provider-routing、managed-auth env overrides
+- ⭐⭐⭐ Gateway plugin routes 限制 write-only fallback scopes（[#59815](https://github.com/openclaw/openclaw/pull/59815)）
+- ⭐⭐⭐ Device pairing 跨裝置 token 竊取防護（[#50627](https://github.com/openclaw/openclaw/pull/50627)）
+- ⭐⭐ Mobile pairing bootstrap token 範圍限縮（[#60128](https://github.com/openclaw/openclaw/pull/60128) 等）
+- ⭐⭐ Sandbox/SSH 硬連結跨裝置 rename 防護
+- ⭐⭐ Gateway loopback auth throttling 正規化
+- ⭐ Synology Chat webhook token 改用 constant-time 比較
+- ⭐ Marketplace symlink escape 防護（[#60556](https://github.com/openclaw/openclaw/pull/60556)）
+
+### 錯誤修復
+
+- ⭐⭐⭐ Discord image generation 修復（生成路徑遺失、重複發送）
+- ⭐⭐⭐ Telegram DM voice-note 轉錄修復（[#61008](https://github.com/openclaw/openclaw/pull/61008)）
+- ⭐⭐⭐ Gateway/macOS LaunchAgent 重啟修復（[#43766](https://github.com/openclaw/openclaw/pull/43766) 等）
+- ⭐⭐⭐ Gateway shutdown 掛起修復（[#61565](https://github.com/openclaw/openclaw/pull/61565)）
+- ⭐⭐ Slack DM 回覆路由修復（[#59030](https://github.com/openclaw/openclaw/pull/59030)）
+- ⭐⭐ WhatsApp blockStreaming 與 watchdog 修復（[#60007](https://github.com/openclaw/openclaw/pull/60007)）
+- ⭐⭐ Matrix secret storage 修復（[#59846](https://github.com/openclaw/openclaw/pull/59846) 等）
+- ⭐⭐ Cron 中斷後首次重啟即重播（[#60583](https://github.com/openclaw/openclaw/pull/60583)）
+- ⭐⭐ Android Talk Mode 多項修復（[#60306](https://github.com/openclaw/openclaw/pull/60306) 等）
+- ⭐ Control UI 多項修復（Stop 按鈕、avatar、cron 刷新等）
+- ⭐ Windows 重啟與排程任務修復（[#59335](https://github.com/openclaw/openclaw/pull/59335) 等）
+
+---
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Config 舊版別名移除與自動遷移 ([#60726](https://github.com/openclaw/openclaw/pull/60726))
+- **用途**: 移除 `talk.voiceId`、`talk.apiKey`、`agents.*.sandbox.perSession`、`browser.ssrfPolicy.allowPrivateNetwork`、`hooks.internal.handlers` 及 channel/group `allow` 等舊版 config 路徑別名
+- **解決問題**: 舊別名長期並存造成 schema 複雜度上升，且容易誤用過時路徑
+- **影響**: Breaking change；需執行 `openclaw doctor --fix` 遷移，load-time 相容性保留
+
+```text
+┌─────────────────────┐
+│  舊版 config 路徑    │
+│  (talk.voiceId 等)  │
+└─────────────────────┘
+          │
+          ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│ openclaw doctor     │────►│ 自動寫入新路徑        │
+│ --fix               │     │ (canonical paths)    │
+└─────────────────────┘     └──────────────────────┘
+          │
+          ▼
+┌─────────────────────┐
+│ Gateway 正常啟動     │
+│ (舊別名不再載入)     │
+└─────────────────────┘
+```
+
+### ⭐⭐⭐ 內建 `video_generate` 工具
+- **用途**: Agent 可直接呼叫 `video_generate` 工具生成影片，結果直接回傳於對話中
+- **解決問題**: 過去影片生成需透過外部 plugin，無法原生整合於 agent 工作流
+- **影響**: 支援 xAI (`grok-imagine-video`)、Alibaba Wan、Runway 三家供應商，可設定 `agents.defaults.videoGenerationModel`
+
+```text
+┌──────────────┐     ┌─────────────────────┐
+│  Agent 呼叫  │────►│  video_generate 工具 │
+└──────────────┘     └─────────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              ▼                ▼                ▼
+      ┌──────────┐    ┌──────────────┐   ┌──────────┐
+      │   xAI    │    │ Alibaba Wan  │   │  Runway  │
+      └──────────┘    └──────────────┘   └──────────┘
+              │                │                │
+              └────────────────┴────────────────┘
+                               │
+                               ▼
+                    ┌─────────────────────┐
+                    │  影片媒體直接回傳    │
+                    └─────────────────────┘
+```
+
+### ⭐⭐⭐ 內建 `music_generate` 工具
+- **用途**: Agent 可呼叫 `music_generate` 生成音樂，支援非同步任務追蹤與完成後交付
+- **解決問題**: 音樂生成無原生工具，需手動整合外部 API
+- **影響**: 支援 Google Lyria、MiniMax、ComfyUI workflow；不支援的 hint（如 `durationSeconds`）改為警告而非失敗
+
+```text
+┌──────────────┐     ┌─────────────────────┐
+│  Agent 呼叫  │────►│  music_generate 工具 │
+└──────────────┘     └─────────────────────┘
+                               │
+              ┌────────────────┼──────────────┐
+              ▼                ▼              ▼
+      ┌──────────────┐  ┌──────────┐  ┌──────────┐
+      │ Google Lyria │  │ MiniMax  │  │ ComfyUI  │
+      └──────────────┘  └──────────┘  └──────────┘
+              │
+              ▼
+      ┌──────────────┐
+      │ 非同步追蹤   │
+      │ → 完成後交付 │
+      └──────────────┘
+```
+
+### ⭐⭐⭐ ComfyUI Bundled Workflow 媒體外掛
+- **用途**: 新增 `comfy` workflow 媒體外掛，支援本地 ComfyUI 與 Comfy Cloud，涵蓋 `image_generate`、`video_generate`、`music_generate`
+- **解決問題**: ComfyUI 整合需手動設定，缺乏統一的 workflow 管理介面
+- **影響**: 支援 prompt injection、reference-image 上傳、live tests、output 下載
+
+```text
+┌──────────────────┐
+│  comfy plugin    │
+└──────────────────┘
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌────────┐  ┌──────────────┐
+│ 本地   │  │ Comfy Cloud  │
+│ComfyUI │  └──────────────┘
+└────────┘
+    │
+    ▼
+┌──────────────────────────────┐
+│ image / video / music output │
+└──────────────────────────────┘
+```
+
+### ⭐⭐⭐ Memory Dreaming 三階段架構重構
+- **用途**: 將 dreaming 重構為 light/deep/REM 三個協作階段，各有獨立排程與恢復行為；新增 Dream Diary、衰減控制、REM preview 工具
+- **解決問題**: 舊版 dreaming 模式互相競爭，記憶促進不穩定，難以調校
+- **影響**: 可設定 `recencyHalfLifeDays`、`maxAgeDays`；`dreams.md` 作為 dreaming trail 主要輸出；`/dreaming` 指令更新
+
+```text
+┌──────────────┐
+│ Daily Notes  │
+└──────────────┘
+       │
+       ▼
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│ Light Phase  │────►│  Deep Phase  │────►│  REM Phase   │
+│ (短期召回)   │     │ (促進評估)   │     │ (持久記憶)   │
+└──────────────┘     └──────────────┘     └──────────────┘
+                                                  │
+                                                  ▼
+                                         ┌──────────────┐
+                                         │  MEMORY.md   │
+                                         │  dreams.md   │
+                                         └──────────────┘
+```
+
+### ⭐⭐⭐ ACPX Runtime 內嵌至 Bundled Plugin ([#61319](https://github.com/openclaw/openclaw/pull/61319))
+- **用途**: 將 ACP runtime 直接嵌入 `acpx` plugin，移除外部 ACP CLI 跳轉；新增 `reply_dispatch` hook 讓 plugin 自主攔截回覆
+- **解決問題**: 外部 ACP CLI 跳轉增加延遲，且 live session binding 不穩定
+- **影響**: ACP session 綁定與重用更穩健；auto-reply routing 不再有 hardcoded ACP 路徑
+
+```text
+┌─────────────────────────────────────┐
+│           acpx plugin               │
+│  ┌──────────────────────────────┐   │
+│  │      ACP Runtime (內嵌)      │   │
+│  │  ┌──────────┐  ┌──────────┐  │   │
+│  │  │ Session  │  │ reply_   │  │   │
+│  │  │ binding  │  │ dispatch │  │   │
+│  │  └──────────┘  └──────────┘  │   │
+│  └──────────────────────────────┘   │
+└─────────────────────────────────────┘
+         │ (不再需要外部 ACP CLI)
+         ▼
+┌─────────────────────┐
+│  Gateway auto-reply │
+└─────────────────────┘
+```
+
+### ⭐⭐ Amazon Bedrock Mantle 支援與 Inference-Profile 自動探索 ([#61296](https://github.com/openclaw/openclaw/pull/61296), [#61299](https://github.com/openclaw/openclaw/pull/61299))
+- **用途**: 新增 Mantle 支援，自動探索 inference profile 並注入 request region；Mantle bearer token 從 AWS credential chain 自動生成
+- **解決問題**: Bedrock 上的 Claude、GPT-OSS、Qwen 等模型需手動設定 region 與 auth
+- **影響**: 減少手動設定；`provider: "auto"` 可自動偵測 AWS credential chain
+
+### ⭐⭐ Control UI 多語言支援
+- **用途**: Control UI 支援繁中、簡中、日文、韓文、德文、西班牙文、法文、土耳其文、印尼文、波蘭文、烏克蘭文、葡萄牙文（巴西）共 12 種語言
+- **解決問題**: 介面僅有英文，非英語使用者體驗不佳
+- **影響**: 全面本地化，包含 channel、instances、nodes、gateway-confirmation 等字串
+
+### ⭐⭐ iOS Exec Approvals APNs 通知整合 ([#60239](https://github.com/openclaw/openclaw/pull/60239))
+- **用途**: 新增 APNs 通知，開啟 in-app exec approval modal；operator 重新連線後才取得指令詳情；approval 解決後清除通知狀態
+- **解決問題**: iOS 端無法即時收到 exec approval 請求
+- **影響**: 提升行動端安全審核體驗
+
+### ⭐⭐ Matrix Exec Approvals 原生支援 ([#58635](https://github.com/openclaw/openclaw/pull/58635))
+- **用途**: Matrix 原生 exec approval 提示，支援 account-scoped approvers、channel/DM 交付、room-thread 感知解析
+- **解決問題**: Matrix 缺乏原生 exec approval 機制
+- **影響**: Matrix 使用者可在頻道或 DM 中審核指令執行
+
+### ⭐⭐ Prompt Caching 穩定性提升 ([#58036](https://github.com/openclaw/openclaw/pull/58036) 等)
+- **用途**: 多項 prompt prefix 穩定化改進：deterministic MCP tool 排序、compaction、embedded image history、system-prompt fingerprint 正規化、移除重複 tool inventory
+- **解決問題**: 後續 turn 無法命中 cache，造成 token 浪費
+- **影響**: follow-up turn cache 命中率顯著提升；`openclaw status --verbose` 新增 cache 診斷
+
+### ⭐⭐ ClawHub 搜尋與安裝整合 ([#60134](https://github.com/openclaw/openclaw/pull/60134))
+- **用途**: Skills 面板直接支援 ClawHub 搜尋、詳情查看、安裝流程
+- **解決問題**: 安裝 skill 需離開 Control UI 至外部頁面
+- **影響**: 一站式 skill 管理體驗
+
+### ⭐ 新增多家供應商 ([#60032](https://github.com/openclaw/openclaw/pull/60032), [#55921](https://github.com/openclaw/openclaw/pull/55921), [#59318](https://github.com/openclaw/openclaw/pull/59318), [#54648](https://github.com/openclaw/openclaw/pull/54648))
+- **用途**: 新增 Qwen、Fireworks AI、StepFun bundled providers；MiniMax TTS、Ollama Web Search、MiniMax Search
+- **解決問題**: 需手動設定這些供應商
+- **影響**: 開箱即用，減少設定負擔
+
+### ⭐ Channels `contextVisibility` 設定
+- **用途**: 每個 channel 可設定 `contextVisibility`（`all`/`allowlist`/`allowlist_quote`），過濾補充 context 的來源
+- **解決問題**: 補充 context 無法依發送者過濾，可能洩漏不相關資訊
+- **影響**: 更精細的 context 控制
+
+### ⭐ Agents/Claude CLI MCP Loopback Bridge ([#35676](https://github.com/openclaw/openclaw/pull/35676))
+- **用途**: 透過 loopback MCP bridge 將 OpenClaw tools 暴露給背景 Claude CLI；改用 stdin + `stream-json` 串流
+- **解決問題**: Claude CLI 背景執行無法使用 OpenClaw tools；長回覆無進度顯示
+- **影響**: prompt 不再透過 argv 傳遞；長回覆有即時進度；session/usage metadata 正確記錄
+
+### ⭐ Agents/進度結構化事件
+- **用途**: 新增實驗性結構化 plan updates 與 execution item events，讓相容 UI 顯示逐步進度
+- **解決問題**: 長時間執行的 agent run 缺乏進度回饋
+- **影響**: 實驗性功能，需相容 UI 支援
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Plugin Tool Allowlist 與 Hook 安全修復 ([#58476](https://github.com/openclaw/openclaw/pull/58476), [#59836](https://github.com/openclaw/openclaw/pull/59836), [#59822](https://github.com/openclaw/openclaw/pull/59822), [#58771](https://github.com/openclaw/openclaw/pull/58771), [#59120](https://github.com/openclaw/openclaw/pull/59120))
+- **用途**: 保留 plugin-only tool allowlist 限制；`/allowlist add/remove` 需 owner 權限；`before_tool_call` hook 崩潰時 fail-closed；阻擋 browser SSRF redirect bypass；非互動式 auth-choice 限縮至 bundled/已信任 plugin
+- **解決問題**: 多個安全邊界可被繞過，允許未授權工具執行或 SSRF 攻擊
+- **影響**: 顯著提升 plugin 執行環境的安全邊界
+
+```text
+┌──────────────────────┐
+│  Tool 呼叫請求        │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│ before_tool_call hook│────►│ hook 崩潰？→ fail-   │
+│ 執行                 │     │ closed（拒絕執行）    │
+└──────────────────────┘     └──────────────────────┘
+          │ (hook 正常)
+          ▼
+┌──────────────────────┐
+│ plugin-only allowlist│
+│ 檢查                 │
+└──────────────────────┘
+          │ (通過)
+          ▼
+┌──────────────────────┐
+│  工具執行            │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Claude CLI 安全強化（多項）
+- **用途**: 清除繼承的 `CLAUDE_CONFIG_DIR`、`CLAUDE_CODE_PLUGIN_*`、provider-routing、managed-auth env overrides；強制 `--setting-sources user`；防止 repo-local `.claude` 設定在非互動 session 中執行
+- **解決問題**: OpenClaw 啟動的 Claude CLI 可被重導向至惡意 config/plugin tree 或 proxy/Bedrock/Vertex 後端
+- **影響**: Claude CLI backdoor session 無法被靜默重導向；安全邊界更明確
+
+```text
+┌──────────────────────────┐
+│ OpenClaw 啟動 Claude CLI  │
+└──────────────────────────┘
+          │
+          ▼
+┌──────────────────────────┐
+│ 清除危險 env overrides    │
+│ CLAUDE_CONFIG_DIR 等      │
+└──────────────────────────┘
+          │
+          ▼
+┌──────────────────────────┐
+│ 強制 --setting-sources   │
+│ user（忽略 repo-local）  │
+└──────────────────────────┘
+          │
+          ▼
+┌──────────────────────────┐
+│ 安全的 Claude CLI 執行   │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway Plugin Routes Scope 限縮 ([#59815](https://github.com/openclaw/openclaw/pull/59815))
+- **用途**: Gateway-auth plugin runtime routes 限制在 write-only fallback scopes，除非 trusted-proxy 明確宣告更窄的 `x-openclaw-scopes`
+- **解決問題**: Plugin HTTP handler 可能在缺少或不受信任的 HTTP scope header 時取得 admin-level runtime scopes
+- **影響**: Plugin HTTP handler 不再自動獲得 admin 權限
+
+```text
+┌──────────────────────┐
+│  Plugin HTTP 請求    │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│ trusted-proxy 宣告   │ No  │ 使用 write-only       │
+│ x-openclaw-scopes？  │────►│ fallback scopes       │
+└──────────────────────┘     └──────────────────────┘
+          │ Yes
+          ▼
+┌──────────────────────┐
+│ 使用宣告的窄 scopes  │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Device Pairing 跨裝置 Token 竊取防護 ([#50627](https://github.com/openclaw/openclaw/pull/50627))
+- **用途**: 非 admin paired-device session 只能管理自己的裝置（token rotate/revoke、paired-device removal）
+- **解決問題**: pairing-scoped session 可竊取其他裝置的 token
+- **影響**: 跨裝置 token 操作被阻擋
+
+```text
+┌──────────────────────┐
+│ Paired Device 請求   │
+│ token rotate/revoke  │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│ 是否為自己的裝置？   │ No  │ 拒絕（403）           │
+└──────────────────────┘────►└──────────────────────┘
+          │ Yes
+          ▼
+┌──────────────────────┐
+│ 允許操作             │
+└──────────────────────┘
+```
+
+### ⭐⭐ Mobile Pairing Bootstrap Token 範圍限縮 ([#60128](https://github.com/openclaw/openclaw/pull/60128), [#60208](https://github.com/openclaw/openclaw/pull/60208), [#60221](https://github.com/openclaw/openclaw/pull/60221))
+- **用途**: QR bootstrap handoff token 限縮至 mobile-safe contract；node handoff 不帶 scope；operator handoff 移除 `node.*`、`operator.admin`、`operator.pairing` 混合 scope
+- **解決問題**: Bootstrap token 範圍過寬，可能被濫用
+- **影響**: Tailscale 與 public remote setup 拒絕 cleartext endpoint；private LAN pairing 仍正常運作
+
+### ⭐⭐ Sandbox/SSH 硬連結防護
+- **用途**: 跨裝置 rename fallback 時拒絕硬連結檔案，保持與直接讀取相同的 pinned file-boundary 檢查
+- **解決問題**: EXDEV file copy 可能繞過 sandbox 邊界
+- **影響**: Sandbox 檔案邊界更嚴格
+
+### ⭐⭐ Gateway Loopback Auth Throttling 正規化
+- **用途**: Loopback browser-origin auth throttling 依正規化 origin 分別計算，避免一個 localhost tab 鎖定其他 localhost origin
+- **解決問題**: 同一機器上不同 localhost origin 共享 throttle 計數器
+- **影響**: Control UI 多 tab 使用更穩定
+
+### ⭐ Synology Chat Webhook Token Constant-Time 比較
+- **用途**: Webhook token 比較改用 shared constant-time secret helper
+- **解決問題**: 時序攻擊（timing attack）風險
+- **影響**: 與其他 bundled plugin 一致的安全實作
+
+### ⭐ Marketplace Symlink Escape 防護 ([#60556](https://github.com/openclaw/openclaw/pull/60556))
+- **用途**: 阻擋 remote marketplace symlink escape，不影響一般本地 marketplace install 路徑
+- **解決問題**: 惡意 marketplace 套件可透過 symlink 逃逸至 sandbox 外
+- **影響**: Marketplace 安裝更安全
+
+### ⭐ Telegram Local Bot API 安全強化 ([#59544](https://github.com/openclaw/openclaw/pull/59544), [#60705](https://github.com/openclaw/openclaw/pull/60705))
+- **用途**: `channels.telegram.apiRoot` 用於 buffered media 下載；新增 `dangerouslyAllowPrivateNetwork`；讀取絕對 `file_path` 前需設定 `trustedLocalFileRoots`
+- **解決問題**: Local Bot API 設定可能允許讀取任意本地檔案
+- **影響**: 需明確設定信任路徑才能讀取本地檔案
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Discord Image Generation 修復
+- **用途**: 修復生成路徑遺失、重複發送問題；text+video 分拆為 text reply + media-only send
+- **解決問題**: Discord image reply 指向不存在的本地檔案；重複發送相同媒體
+- **影響**: Discord 圖片與影片回覆正常運作
+
+```text
+┌──────────────────────┐
+│  image_generate 工具  │
+│  回傳 MEDIA: 路徑    │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ 持久化至 durable     │
+│ outbound media       │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ Discord 正確回傳圖片  │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Telegram DM Voice-Note 轉錄修復 ([#61008](https://github.com/openclaw/openclaw/pull/61008))
+- **用途**: 恢復 DM voice-note preflight 轉錄，避免直接訊息音訊以 `<media:audio>` placeholder 送達
+- **解決問題**: DM 語音訊息無法轉錄，顯示為原始 placeholder
+- **影響**: Telegram DM 語音訊息正常轉錄
+
+```text
+┌──────────────────────┐
+│ Telegram DM 語音訊息  │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ preflight 轉錄       │
+│ (已修復)             │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ 文字轉錄送至 Agent   │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway/macOS LaunchAgent 重啟修復 ([#43766](https://github.com/openclaw/openclaw/pull/43766))
+- **用途**: 修復 `launchctl kickstart -k` 卸載 LaunchAgent 後無法重啟；`openclaw gateway start/restart` 恢復已安裝但未載入的 LaunchAgent；短暫 supervised-exit delay 避免 crash-loop
+- **解決問題**: macOS 上 gateway restart 後 LaunchAgent 變成 unmanaged 狀態
+- **影響**: macOS gateway 重啟更可靠
+
+```text
+┌──────────────────────┐
+│ openclaw gateway     │
+│ restart              │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐
+│ LaunchAgent 已卸載？  │ Yes │ re-bootstrap         │
+└──────────────────────┘────►│ LaunchAgent          │
+          │ No               └──────────────────────┘
+          ▼                            │
+┌──────────────────────┐              │
+│ 正常重啟             │◄─────────────┘
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Gateway Shutdown 掛起修復 ([#61565](https://github.com/openclaw/openclaw/pull/61565))
+- **用途**: 即使無 tracked clients，也限制 websocket-server shutdown 時間，避免 gateway restart 掛起直到 watchdog 強制終止
+- **解決問題**: Gateway restart 偶爾掛起，需等 watchdog 介入
+- **影響**: Gateway 重啟更快速可靠
+
+```text
+┌──────────────────────┐
+│ Gateway shutdown     │
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ websocket-server     │
+│ shutdown（有 timeout）│
+└──────────────────────┘
+          │
+          ▼
+┌──────────────────────┐
+│ 正常退出（不再掛起）  │
+└──────────────────────┘
+```
+
+### ⭐⭐ Slack DM 回覆路由修復 ([#59030](https://github.com/openclaw/openclaw/pull/59030))
+- **用途**: Live DM 回覆路由回具體的 inbound DM channel，保持 persisted routing metadata 為 user-scoped
+- **解決問題**: pairing 時 assistant 回覆消失；system message 仍正常送達
+- **影響**: Slack DM 對話正常運作
+
+### ⭐⭐ WhatsApp blockStreaming 與 Watchdog 修復 ([#60007](https://github.com/openclaw/openclaw/pull/60007), [#60069](https://github.com/openclaw/openclaw/pull/60069))
+- **用途**: 恢復 `channels.whatsapp.blockStreaming`；reconnect 後重置 watchdog timeout
+- **解決問題**: 安靜的 WhatsApp 聊天室不斷進入 reconnect loop
+- **影響**: WhatsApp 連線穩定性提升
+
+### ⭐⭐ Matrix Secret Storage 修復 ([#59846](https://github.com/openclaw/openclaw/pull/59846), [#59851](https://github.com/openclaw/openclaw/pull/59851), [#60599](https://github.com/openclaw/openclaw/pull/60599), [#60289](https://github.com/openclaw/openclaw/pull/60289))
+- **用途**: secret storage 或 recovery key 遺失時重建；持久化時持有 crypto snapshot lock；顯示明確的 too-large attachment marker
+- **解決問題**: Matrix crypto 狀態損壞時無法恢復
+- **影響**: Matrix 加密聊天室更穩定
+
+### ⭐⭐ Cron 中斷後首次重啟即重播 ([#60583](https://github.com/openclaw/openclaw/pull/60583))
+- **用途**: 中斷的 recurring job 在第一次 gateway restart 時重播，不再等待第二次
+- **解決問題**: Cron job 中斷後需等兩次重啟才恢復
+- **影響**: Cron 可靠性提升
+
+### ⭐⭐ Android Talk Mode 多項修復 ([#60306](https://github.com/openclaw/openclaw/pull/60306), [#61164](https://github.com/openclaw/openclaw/pull/61164), [#61214](https://github.com/openclaw/openclaw/pull/61214))
+- **用途**: 明確停止時取消 in-flight `talk.speak` 播放；node-scoped session 語音回覆修復；gateway-backed talk mode session 語音回覆修復
+- **解決問題**: barge-in 後舊回覆仍繼續播放；多種 session 類型語音回覆失效
+- **影響**: Android Talk Mode 語音互動正常
+
+### ⭐⭐ OpenAI GPT-5 與 Codex 多項修復
+- **用途**: GPT-5 更快行動、更低 verbosity；Codex `contextWindow` 與 `contextTokens` 分離；`reasoning.effort: "none"` 保留；commentary 緩衝至 `final_answer`
+- **解決問題**: GPT-5 回覆過長、planning text 洩漏至 web chat/Telegram；Codex context 計算錯誤
+- **影響**: OpenAI 模型回覆品質與穩定性提升
+
+### ⭐⭐ Providers/compat 修復
+- **用途**: 停止對 proxy 與 custom OpenAI-compatible routes 強制 OpenAI-only defaults；保留各供應商原生 reasoning/tool/streaming 行為；GitHub Copilot Claude 改走 Anthropic Messages
+- **解決問題**: Anthropic-compatible、Moonshot、Mistral 等端點行為被 OpenAI defaults 覆蓋
+- **影響**: 多供應商相容性大幅改善
+
+### ⭐ Control UI 多項修復
+- **用途**: Stop 按鈕在 tool-only 執行時保持可見；ClawHub 搜尋結果即時清除；avatar 路徑修復；cron 刷新按鈕 loading 狀態；Overview token/password 按鈕重疊修復
+- **解決問題**: 多個 Control UI 視覺與互動問題
+- **影響**: Control UI 使用體驗改善
+
+### ⭐ Windows 重啟與排程任務修復 ([#59335](https://github.com/openclaw/openclaw/pull/59335), [#58943](https://github.com/openclaw/openclaw/pull/58943), [#60480](https://github.com/openclaw/openclaw/pull/60480))
+- **用途**: 保留 Task Scheduler 設定於重裝時；`/Run` 未啟動時明確失敗；清理 stale gateway listeners 避免 `EADDRINUSE`；scheduled task 未註冊時 fallback 至 Startup-entry launcher
+- **解決問題**: Windows gateway restart 多種失敗情境
+- **影響**: Windows 平台 gateway 重啟可靠性提升
+
+### ⭐ Telegram 多項修復 ([#60384](https://github.com/openclaw/openclaw/pull/60384) 等)
+- **用途**: model picker 當前模型檢查修復；HTML-format `/model` 確認；topic reply 修復；reaction ownership 持久化；caption-media placeholder 修復；升級安裝後 inbound image 讀取修復
+- **解決問題**: 多個 Telegram 頻道功能異常
+- **影響**: Telegram 使用體驗改善
+
+### ⭐ Discord 多項修復 ([#57465](https://github.com/openclaw/openclaw/pull/57465), [#60361](https://github.com/openclaw/openclaw/pull/60361), [#60345](https://github.com/openclaw/openclaw/pull/60345))
+- **用途**: REST/webhook/monitor 流量保持在設定的 proxy；component-only media send 修復；`@everyone`/`@here` mention gate；ACK reaction 綁定正確帳號；voice connect/playback timeout 分離；reply tag 洩漏修復
+- **解決問題**: 多個 Discord 頻道功能異常
+- **影響**: Discord 使用體驗改善
+
+### ⭐ Memory/QMD 修復
+- **用途**: 改用 `qmd collection add --glob`；接受新版單行 JSON hit metadata；更新 doctor install guidance
+- **解決問題**: 舊版 QMD 指令與 metadata 格式不相容
+- **影響**: QMD 記憶搜尋更穩定
+
+### ⭐ Outbound Sanitizer：移除洩漏的 tool_call 標籤 ([#60619](https://github.com/openclaw/openclaw/pull/60619))
+- **用途**: 從 user-visible assistant text 中移除洩漏的 `<tool_call>`、`<function_calls>` 及 model special tokens
+- **解決問題**: 內部 scaffolding 標籤洩漏至各平台的回覆中
+- **影響**: 使用者不再看到內部標籤
+
+### ⭐ Cron 失敗通知修復 ([#60622](https://github.com/openclaw/openclaw/pull/60622))
+- **用途**: 未設定 `failureDestination` 時，透過 job 的主要 delivery channel 發送失敗通知
+- **解決問題**: Cron job 失敗時通知無法送達
+- **影響**: Cron 失敗通知更可靠
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 6 | 6 | 3 | 影片/音樂生成、ComfyUI、Memory Dreaming、ACPX 內嵌、多語言 UI |
+| 安全性 | 4 | 4 | 2 | Plugin allowlist、Claude CLI 強化、Device pairing、Gateway scopes |
+| 錯誤修復 | 4 | 8 | 8 | Discord/Telegram/Slack/WhatsApp/Matrix/Android/Windows 多平台修復 |
+| **總計** | **14** | **18** | **13** | **45 項** |
+
+**發佈日期**: 2026-04-05
+**版本**: 2026.4.5
+**狀態**: Production Ready
+**GitHub Release**: [https://github.com/openclaw/openclaw/releases/tag/v2026.4.5](https://github.com/openclaw/openclaw/releases/tag/v2026.4.5)


### PR DESCRIPTION
Closes #447

## Summary

Release notes for OpenClaw v2026.4.5 in zh-TW.

- 升級前必讀（Breaking Changes + 新功能亮點）
- 功能更新 14 項（⭐⭐⭐×6, ⭐⭐×6, ⭐×3）
- 安全性提升 10 項（⭐⭐⭐×4, ⭐⭐×4, ⭐×2）
- 錯誤修復 20 項（⭐⭐⭐×4, ⭐⭐×8, ⭐×8）
- 所有 ⭐⭐⭐ 項目含 ASCII flowchart
