### PR TITLE
docs: add validation frontmatter to 5 docs

### DIFF
--- a/docs/howto/exec-strategy-patterns.md
+++ b/docs/howto/exec-strategy-patterns.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # OpenClaw Exec 權限策略模式
 
 ## 為什麼需要這篇

--- a/docs/node-delegation-arch.md
+++ b/docs/node-delegation-arch.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # Node Delegation Architecture
 
 OpenClaw Gateway 作為控制平面，將 ACP 任務派發到遠端的 OpenClaw Node，由 Node 在本機執行 coding CLI（Claude Code、Kiro CLI 等）。

--- a/docs/telegram-streaming.md
+++ b/docs/telegram-streaming.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # Telegram 串流輸出機制
 
 > OpenClaw 如何實現 Telegram Bot 的動態回覆體驗

--- a/usecases/README.md
+++ b/usecases/README.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # Use Cases
 
 Real-world OpenClaw deployment scenarios, integration guides, and practical configurations.

--- a/usecases/subagent-orchestration.md
+++ b/usecases/subagent-orchestration.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # Sub-Agent Orchestration：背景任務委派實戰指南
 
 > 讓 agent 派出分身處理耗時任務，自己繼續回應主人——不阻塞、不遺漏、不失控。


### PR DESCRIPTION
## Summary
- add `last_validated` and `validated_by` frontmatter to 5 docs still tracked by open doc-review issues
- keep scope limited to metadata-only documentation maintenance

## Files
- docs/howto/exec-strategy-patterns.md
- docs/node-delegation-arch.md
- docs/telegram-streaming.md
- usecases/README.md
- usecases/subagent-orchestration.md

Closes #448
Closes #449
Closes #403
Closes #457
Closes #425