### PR TITLE
docs: add validation frontmatter to 2 guides

### DIFF
--- a/docs/github_token_scope.md
+++ b/docs/github_token_scope.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # GitHub Token Scope Troubleshooting（跨倉庫互動）
 
 當你能讀取公開倉庫，但在建立 Issue / Fork 時遇到：

--- a/usecases/lcm-context-retrieval.md
+++ b/usecases/lcm-context-retrieval.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-07
+validated_by: Chloe
+---
+
 # LCM Context Retrieval — 從壓縮記憶中精準撈回細節
 
 > 當對話被 compaction 壓縮後，用 `lcm_grep` → `lcm_expand` → `lcm_expand_query` 精準找回被摘要掉的細節，而不是重新問一遍。


### PR DESCRIPTION
## Summary

Add missing `last_validated` and `validated_by` frontmatter to two remaining documentation guides that were still uncovered by the current open frontmatter PRs.

## Changes

- add validation frontmatter to `docs/github_token_scope.md`
- add validation frontmatter to `usecases/lcm-context-retrieval.md`

## Testing

- metadata-only change; verified both files use the same YAML frontmatter shape as the existing docs set

Fixes #381
Fixes #422