### PR TITLE
docs: add validated_by to 5 core docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # OpenClaw 文件索引（docs/）

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # OpenClaw Docs Style Guide（寫作規約）

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # OpenClaw Cron 調度系統

--- a/docs/start.md
+++ b/docs/start.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # Start / Onboarding（最小可行）

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # Troubleshooting（常見故障排除）


### PR DESCRIPTION
## Summary
- add `validated_by` frontmatter to five core docs that already had `last_validated`
- keep the change metadata-only and topic-grouped

## Files
- `docs/README.md`
- `docs/STYLE_GUIDE.md`
- `docs/cron.md`
- `docs/start.md`
- `docs/troubleshooting.md`

## Testing
- metadata-only change; no runtime tests required