### PR TITLE
docs: add zh-TW release notes for OpenClaw v2026.4.7

### DIFF
--- a/release-notes/2026-04-07.md
+++ b/release-notes/2026-04-07.md
@@ -1,0 +1,1064 @@
+# OpenClaw v2026.4.7 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.7)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Host exec/env 環境變數清理 ([#59119](https://github.com/openclaw/openclaw/pull/59119), [#62002](https://github.com/openclaw/openclaw/pull/62002), [#62291](https://github.com/openclaw/openclaw/pull/62291)) | Java、Rust、Cargo、Git、K8s、雲端憑證等危險環境變數將被阻擋，依賴這些變數的 host-run 工具可能失敗 | 檢查自訂工具是否依賴被阻擋的環境變數，改用安全的傳遞方式 |
+| Gateway config.apply 寫入限制 ([#62001](https://github.com/openclaw/openclaw/pull/62001)) | 模型端無法再透過 `gateway config.apply` / `config.patch` 修改 exec approval 路徑（如 `safeBins`、`strictInlineEval`） | 確認 exec approval 設定僅透過操作者手動配置 |
+| `/allowlist` 指令需 owner 授權 ([#62383](https://github.com/openclaw/openclaw/pull/62383)) | 非 owner 使用者即使有指令權限也無法修改 allowlist | 確認 allowlist 管理由 owner 角色執行 |
+| 跨來源重導向 body 丟棄 ([#62357](https://github.com/openclaw/openclaw/pull/62357)) | 跨來源 `307`/`308` 重導向預設不再攜帶 request body，依賴此行為的整合可能中斷 | 需要跨來源 body 重播的呼叫者須明確 opt-in |
+| Plugin archive SHA-256 驗證 ([#60517](https://github.com/openclaw/openclaw/pull/60517)) | 缺少或格式錯誤的 SHA-256 metadata 將導致 plugin 安裝失敗 | 確保 ClawHub 套件 metadata 包含正確的 SHA-256 雜湊 |
+
+### 新功能亮點
+
+- **`openclaw infer` CLI** — 全新一站式推論指令，涵蓋 model、image、audio、TTS、video、web search、embedding 工作流
+- **Memory Wiki 回歸** — 完整的知識庫編譯器，含 claim/evidence 結構、矛盾叢集、新鮮度搜尋
+- **Webhook Ingress Plugin** — 外部自動化可透過 shared-secret 端點建立並驅動 TaskFlow
+- **可插拔 Compaction Provider** — Plugin 可替換內建摘要管線，透過 `agents.defaults.compaction.provider` 設定
+- **Media Generation 自動降級** — 跨 image/music/video provider 自動降級，保留意圖並重新映射參數
+
+---
+
+## 概述
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ `openclaw infer` 一站式推論 CLI hub
+- ⭐⭐⭐ Media generation 跨 provider 自動降級與參數重映射
+- ⭐⭐⭐ Memory Wiki 完整回歸，含 plugin、CLI、sync/query/apply 工具鏈
+- ⭐⭐⭐ Webhook ingress plugin 支援外部自動化驅動 TaskFlow ([#61892](https://github.com/openclaw/openclaw/pull/61892))
+- ⭐⭐⭐ 可插拔 compaction provider registry ([#56224](https://github.com/openclaw/openclaw/pull/56224))
+- ⭐⭐ Gateway sessions 壓縮檢查點與 Sessions UI 分支/還原 ([#62146](https://github.com/openclaw/openclaw/pull/62146))
+- ⭐⭐ `systemPromptOverride` 與 heartbeat prompt-section 控制
+- ⭐⭐ Gemma 4 模型支援與 Google fallback 修正 ([#61507](https://github.com/openclaw/openclaw/pull/61507))
+- ⭐⭐ Arcee AI provider plugin 與 Trinity catalog ([#62068](https://github.com/openclaw/openclaw/pull/62068))
+- ⭐⭐ Ollama 視覺能力自動偵測 ([#62193](https://github.com/openclaw/openclaw/pull/62193))
+- ⭐⭐ Memory dreaming 攝取已遮蔽 session 逐字稿 ([#62227](https://github.com/openclaw/openclaw/pull/62227))
+- ⭐⭐ Context engine prompt-cache 對齊 ([#62179](https://github.com/openclaw/openclaw/pull/62179))
+- ⭐ Gemma 4 thinking-off 語意保留 ([#62127](https://github.com/openclaw/openclaw/pull/62127))
+- ⭐ Claude CLI 恢復為 Anthropic 本地首選路徑
+- ⭐ inferrs string-content 相容性
+- ⭐ Plugin SDK `availableTools`/`citationsMode` 傳入 `assemble()`
+- ⭐ ACPX pin 升級至 0.5.1 ([#62148](https://github.com/openclaw/openclaw/pull/62148))
+- ⭐ Discord event-create 支援封面圖片 ([#60883](https://github.com/openclaw/openclaw/pull/60883))
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Host exec/env 危險環境變數阻擋 ([#59119](https://github.com/openclaw/openclaw/pull/59119), [#62002](https://github.com/openclaw/openclaw/pull/62002), [#62291](https://github.com/openclaw/openclaw/pull/62291))
+- ⭐⭐⭐ 跨來源重導向 body 丟棄 ([#62357](https://github.com/openclaw/openclaw/pull/62357))
+- ⭐⭐⭐ Browser SSRF 重導向阻擋 ([#62355](https://github.com/openclaw/openclaw/pull/62355))
+- ⭐⭐⭐ Plugin archive SHA-256 驗證 ([#60517](https://github.com/openclaw/openclaw/pull/60517))
+- ⭐⭐⭐ Gateway auth session 失效機制 ([#62350](https://github.com/openclaw/openclaw/pull/62350))
+- ⭐⭐⭐ `/allowlist` 指令 owner 授權 ([#62383](https://github.com/openclaw/openclaw/pull/62383))
+- ⭐⭐⭐ Feishu docx workspace-only 限制 ([#62369](https://github.com/openclaw/openclaw/pull/62369))
+- ⭐⭐⭐ Gateway config.apply exec approval 寫入阻擋 ([#62001](https://github.com/openclaw/openclaw/pull/62001))
+- ⭐⭐⭐ MS Teams 上傳 SSRF 驗證 ([#23596](https://github.com/openclaw/openclaw/pull/23596))
+- ⭐⭐⭐ Base64 decode 大小限制 ([#62007](https://github.com/openclaw/openclaw/pull/62007))
+- ⭐⭐⭐ Runtime event trust 標記 ([#62003](https://github.com/openclaw/openclaw/pull/62003))
+- ⭐⭐ Node pairing 升級審核 ([#62658](https://github.com/openclaw/openclaw/pull/62658))
+- ⭐⭐ Browser profile 變更阻擋 ([#60489](https://github.com/openclaw/openclaw/pull/60489))
+- ⭐⭐ Windows cmd.exe wrapper approval 強化 ([#62439](https://github.com/openclaw/openclaw/pull/62439))
+- ⭐ QQ Bot media 路由防護
+- ⭐ Auto-reply media 路徑限制
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Context overflow 合併復原 ([#61651](https://github.com/openclaw/openclaw/pull/61651))
+- ⭐⭐⭐ Auth/OpenAI Codex OAuth 重新載入與 refresh_token 修復
+- ⭐⭐⭐ Auth/OpenAI Codex OAuth profile 選擇修復 ([#62744](https://github.com/openclaw/openclaw/pull/62744))
+- ⭐⭐⭐ Anthropic thinking blocks 與 OAuth streaming 修復 ([#60356](https://github.com/openclaw/openclaw/pull/60356), [#61793](https://github.com/openclaw/openclaw/pull/61793))
+- ⭐⭐ CLI/infer 多項行為對齊修復
+- ⭐⭐ History/replies buffer 與序列追蹤修復 ([#61729](https://github.com/openclaw/openclaw/pull/61729))
+- ⭐⭐ iOS gateway 結構化連線問題 ([#62650](https://github.com/openclaw/openclaw/pull/62650))
+- ⭐⭐ TUI 多項修復 ([#49130](https://github.com/openclaw/openclaw/pull/49130))
+- ⭐⭐ web_fetch/web_search undici 8.0 HTTP/2 修復 ([#61738](https://github.com/openclaw/openclaw/pull/61738))
+- ⭐⭐ Plugin loader Windows 相容性修復 ([#62286](https://github.com/openclaw/openclaw/pull/62286))
+- ⭐⭐ Docker plugin 路徑修復 ([#62316](https://github.com/openclaw/openclaw/pull/62316))
+- ⭐ Ollama multi-endpoint streaming 修復 ([#61678](https://github.com/openclaw/openclaw/pull/61678))
+- ⭐ Slack thread mention 設定 ([#58276](https://github.com/openclaw/openclaw/pull/58276))
+- ⭐ Matrix onboarding 自動加入 ([#62168](https://github.com/openclaw/openclaw/pull/62168))
+- ⭐ Telegram doctor 多帳號修復 ([#62263](https://github.com/openclaw/openclaw/pull/62263))
+- ⭐ macOS gateway 版本解析修復 ([#61111](https://github.com/openclaw/openclaw/pull/61111))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ `openclaw infer` 一站式推論 CLI Hub
+
+- **用途**: 新增 `openclaw infer` 頂層指令，統一 model run、image generate、audio transcribe、TTS convert、video generate、web search、embedding create 等推論工作流
+- **解決問題**: 過去各推論任務分散在不同工具與 wrapper 中，缺乏統一的 headless 自動化介面
+- **影響**: 開發者可透過單一指令樹搭配 `--json` 輸出進行腳本化推論，無需為每個後端單獨接線
+
+```text
+┌──────────────────┐
+│  使用者 / 腳本    │
+└────────┬─────────┘
+         │ openclaw infer <subcommand>
+         ▼
+┌──────────────────┐
+│  Infer CLI Hub   │
+│  (指令路由)       │
+└────────┬─────────┘
+         │ 依 subcommand 分派
+         ▼
+┌────┬────┬─────┬─────┬─────┬──────┬──────────┐
+│model│image│audio│ tts │video│ web  │embedding │
+└──┬─┘└──┬┘└──┬─┘└──┬─┘└──┬─┘└──┬──┘└────┬─────┘
+   │     │    │     │     │     │        │
+   ▼     ▼    ▼     ▼     ▼     ▼        ▼
+┌──────────────────────────────────────────────┐
+│  Provider Registry (已設定的 providers)        │
+└──────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  --json 結構化輸出 │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Media Generation 跨 Provider 自動降級
+
+- **用途**: image、music、video 生成自動在已授權的 provider 間降級，保留使用者意圖並將 size/aspect/resolution/duration 提示重新映射至最接近的支援選項
+- **解決問題**: 單一 provider 不可用時，media 生成直接失敗；不同 provider 的參數格式不一致
+- **影響**: 提升 media 生成可靠性，使用者無需手動切換 provider 或調整參數
+
+```text
+┌──────────────────┐
+│  Media 生成請求    │
+│  (size/aspect 等) │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐    成功    ┌──────────────┐
+│  Provider A      │──────────►│  回傳結果     │
+│  (首選)          │           └──────────────┘
+└────────┬─────────┘
+         │ 失敗
+         ▼
+┌──────────────────┐
+│  意圖保留引擎     │
+│  重映射參數至      │
+│  Provider B 格式  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐    成功    ┌──────────────┐
+│  Provider B      │──────────►│  回傳結果     │
+│  (降級)          │           └──────────────┘
+└────────┬─────────┘
+         │ 失敗
+         ▼
+┌──────────────────┐
+│  Provider C ...  │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Memory Wiki 完整回歸
+
+- **用途**: 恢復內建 `memory-wiki` 堆疊，包含 plugin、CLI、sync/query/apply 工具、memory-host 整合、結構化 claim/evidence 欄位、編譯摘要檢索、claim-health linting、矛盾叢集、新鮮度儀表板與加權搜尋
+- **解決問題**: 先前版本移除了 memory-wiki，使用者失去持久化知識庫編譯與結構化查詢能力
+- **影響**: 使用者可再次使用 wiki vault 管理持久知識，搭配 Obsidian 工作流與 `memory_search corpus=all` 統一搜尋
+
+```text
+┌──────────────────┐     ┌──────────────────┐
+│  Active Memory   │     │  Memory Wiki     │
+│  (recall/dream)  │     │  Plugin          │
+└────────┬─────────┘     └────────┬─────────┘
+         │                        │
+         │  memory_search         │ wiki_search
+         │  corpus=all            │ wiki_get
+         ▼                        ▼
+┌──────────────────────────────────────────┐
+│  Shared Recall Layer                     │
+└────────────────────┬─────────────────────┘
+                     │
+                     ▼
+┌──────────────────────────────────────────┐
+│  Wiki Vault (Markdown)                   │
+│  ├── claim/evidence 結構                  │
+│  ├── contradiction clustering            │
+│  ├── freshness-weighted search           │
+│  └── Obsidian CLI 整合                    │
+└──────────────────────────────────────────┘
+```
+
+### ⭐⭐⭐ Webhook Ingress Plugin ([#61892](https://github.com/openclaw/openclaw/pull/61892))
+
+- **用途**: 新增內建 webhook ingress plugin，外部自動化系統可透過 per-route shared-secret 端點建立並驅動綁定的 TaskFlow
+- **解決問題**: 外部系統（CI/CD、監控等）無法直接觸發 OpenClaw 工作流，需透過 channel 間接操作
+- **影響**: 實現 event-driven 自動化整合，外部系統可直接驅動 agent 任務
+
+```text
+┌──────────────────┐
+│  外部系統         │
+│  (CI/CD, 監控)   │
+└────────┬─────────┘
+         │ POST /webhook/<route>
+         │ Header: X-Shared-Secret
+         ▼
+┌──────────────────┐
+│  Webhook Ingress │
+│  Plugin          │
+│  (驗證 secret)   │
+└────────┬─────────┘
+         │ 驗證通過
+         ▼
+┌──────────────────┐
+│  建立/驅動       │
+│  Bound TaskFlow  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Agent 執行任務   │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ 可插拔 Compaction Provider Registry ([#56224](https://github.com/openclaw/openclaw/pull/56224))
+
+- **用途**: 新增 compaction provider registry，plugin 可實作 `CompactionProvider` 介面並註冊，取代內建的 `summarizeInStages()` 摘要管線
+- **解決問題**: 內建摘要管線無法客製化，不同使用場景需要不同的壓縮策略
+- **影響**: 透過 `agents.defaults.compaction.provider` 設定即可切換摘要引擎，provider 失敗時自動降級至 LLM 摘要
+
+```text
+┌──────────────────┐
+│  Compaction      │
+│  Safeguard 觸發  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  查詢 Provider Registry      │
+│  (process-global singleton)  │
+└────────┬─────────────────────┘
+         │
+    ┌────┴────┐
+    │ 有註冊?  │
+    └────┬────┘
+    Yes  │  No
+    ┌────┘    └────┐
+    ▼              ▼
+┌────────────┐ ┌────────────────┐
+│ Plugin     │ │ 內建           │
+│ summarize()│ │ summarize-     │
+│            │ │ InStages()     │
+└─────┬──────┘ └───────┬────────┘
+      │   失敗          │
+      │───────►         │
+      ▼                 ▼
+┌──────────────────────────┐
+│  壓縮後的 Session 狀態    │
+└──────────────────────────┘
+```
+
+### ⭐⭐ Gateway Sessions 壓縮檢查點與 UI 分支/還原 ([#62146](https://github.com/openclaw/openclaw/pull/62146))
+
+- **用途**: 新增持久化壓縮檢查點，Sessions UI 支援分支與還原操作
+- **解決問題**: 壓縮後無法回溯至先前的 session 狀態
+- **影響**: 操作者可檢視並恢復壓縮前的 session 狀態，提升除錯與回溯能力
+
+### ⭐⭐ `systemPromptOverride` 與 Heartbeat Prompt 控制
+
+- **用途**: 新增 `agents.defaults.systemPromptOverride` 設定，以及 heartbeat prompt-section 控制
+- **解決問題**: 無法在不修改程式碼的情況下進行 prompt 實驗；heartbeat 指令每回合都注入
+- **影響**: 可進行受控的 prompt 實驗，heartbeat 行為可保持啟用但不注入指令
+
+### ⭐⭐ Gemma 4 模型支援 ([#61507](https://github.com/openclaw/openclaw/pull/61507))
+
+- **用途**: 新增 Google Gemma 4 模型支援，修正 Google fallback 解析路徑
+- **解決問題**: 原生 Google Gemma 路由無法正常運作
+- **影響**: Gemma 4 模型可正常使用，包含推理支援
+
+### ⭐⭐ Arcee AI Provider Plugin ([#62068](https://github.com/openclaw/openclaw/pull/62068))
+
+- **用途**: 新增內建 Arcee AI provider plugin，含 Trinity catalog、OpenRouter 支援與 onboarding 指引
+- **解決問題**: 使用 Arcee AI 模型需手動設定
+- **影響**: 透過內建 plugin 即可使用 Arcee AI 模型
+
+### ⭐⭐ Ollama 視覺能力自動偵測 ([#62193](https://github.com/openclaw/openclaw/pull/62193))
+
+- **用途**: 從 `/api/show` 回應偵測視覺能力，自動為支援的模型啟用圖片輸入
+- **解決問題**: Ollama 視覺模型無法接受圖片附件
+- **影響**: 視覺模型自動支援圖片輸入，無需手動設定
+
+### ⭐⭐ Memory Dreaming 攝取已遮蔽 Session 逐字稿 ([#62227](https://github.com/openclaw/openclaw/pull/62227))
+
+- **用途**: 將已遮蔽的 session 逐字稿攝取至 dreaming corpus，含每日 session-corpus 筆記與 cursor checkpointing
+- **解決問題**: Dreaming 無法從 session 歷史中學習
+- **影響**: 記憶系統可從過往 session 中提取知識
+
+### ⭐⭐ Context Engine Prompt-Cache 對齊 ([#62179](https://github.com/openclaw/openclaw/pull/62179))
+
+- **用途**: 將 prompt-cache runtime context 暴露給 context engine，並對齊當前回合的 prompt-cache 使用
+- **解決問題**: Prompt-cache 使用量與過時的先前回合狀態對齊，而非當前嘗試
+- **影響**: Context engine 可正確消費 prompt-cache 狀態
+
+### ⭐ Gemma 4 Thinking-Off 語意保留 ([#62127](https://github.com/openclaw/openclaw/pull/62127))
+
+- **用途**: 保留 Gemma 4 明確的 thinking-off 語意，同時在相容性 wrapper 中啟用推理支援
+- **解決問題**: Thinking-off 設定在 Gemma 4 上未被正確尊重
+- **影響**: 使用者可精確控制 Gemma 4 的推理行為
+
+### ⭐ Claude CLI 恢復為 Anthropic 本地首選路徑
+
+- **用途**: 在 onboarding、model-auth 指引、doctor 流程中恢復 Claude CLI 為首選本地 Anthropic 路徑
+- **解決問題**: Claude CLI 不再被推薦為本地 Anthropic 路徑
+- **影響**: 改善 Anthropic 使用者的 onboarding 體驗
+
+### ⭐ inferrs String-Content 相容性
+
+- **用途**: 為較嚴格的 OpenAI 相容 chat 後端新增 string-content 相容性，並提供完整設定範例與疑難排解指引
+- **解決問題**: 部分本地後端在直接探測時通過但在完整 agent 提示時失敗
+- **影響**: 改善本地 OpenAI 相容後端的穩定性
+
+### ⭐ Plugin SDK `availableTools`/`citationsMode` 傳入 `assemble()`
+
+- **用途**: 將 `availableTools` 和 `citationsMode` 傳入 context engine 的 `assemble()`，暴露 memory-artifact 與 memory-prompt 接縫
+- **解決問題**: Companion plugin 與非 legacy context engine 無法消費 active memory 狀態
+- **影響**: Plugin 開發者可更靈活地整合記憶系統
+
+### ⭐ ACPX Pin 升級至 0.5.1 ([#62148](https://github.com/openclaw/openclaw/pull/62148))
+
+- **用途**: 將內建 `acpx` pin 升級至 `0.5.1`
+- **解決問題**: Plugin-local 安裝與嚴格版本檢查無法取得最新 runtime
+- **影響**: 確保 ACP 相容性
+
+### ⭐ Discord Event-Create 支援封面圖片 ([#60883](https://github.com/openclaw/openclaw/pull/60883))
+
+- **用途**: `event-create` 可接受封面圖片 URL 或本地檔案路徑，驗證 PNG/JPG/GIF 格式
+- **解決問題**: 無法為 Discord 活動設定封面圖片
+- **影響**: 豐富 Discord 活動的視覺呈現
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Host Exec/Env 危險環境變數阻擋 ([#59119](https://github.com/openclaw/openclaw/pull/59119), [#62002](https://github.com/openclaw/openclaw/pull/62002), [#62291](https://github.com/openclaw/openclaw/pull/62291))
+
+- **用途**: 阻擋 Java、Rust、Cargo、Git、Kubernetes、雲端憑證、config-path、Helm 等危險環境變數覆寫
+- **解決問題**: Host-run 工具可被重導向至攻擊者控制的程式碼、設定、憑證或 repository 狀態
+- **影響**: 大幅降低透過環境變數注入的供應鏈攻擊風險
+
+```text
+┌──────────────────┐
+│  Host-Run Tool   │
+│  執行請求         │
+└────────┬─────────┘
+         │ 附帶 env 變數
+         ▼
+┌──────────────────────────┐
+│  Env Sanitization Layer  │
+│  檢查 blocklist:         │
+│  JAVA_*, CARGO_*, GIT_*, │
+│  KUBECONFIG, HELM_*,     │
+│  AWS_*, GOOGLE_*...      │
+└────────┬─────────────────┘
+         │
+    ┌────┴────┐
+    │ 危險?   │
+    └────┬────┘
+    Yes  │  No
+    ┌────┘    └────┐
+    ▼              ▼
+┌────────────┐ ┌────────────┐
+│  阻擋並     │ │  允許執行   │
+│  記錄警告   │ │            │
+└────────────┘ └────────────┘
+```
+
+### ⭐⭐⭐ 跨來源重導向 Body 丟棄 ([#62357](https://github.com/openclaw/openclaw/pull/62357))
+
+- **用途**: 跨來源 `307`/`308` 重導向預設丟棄 request body 與 body-describing headers
+- **解決問題**: 攻擊者控制的重導向跳板可接收 SSRF-guarded fetch 流程中含機密的 POST payload
+- **影響**: 防止機密資料透過重導向洩漏至非預期的目標
+
+```text
+┌──────────────────┐
+│  SSRF-Guarded    │
+│  Fetch (POST)    │
+│  含 secret body  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Origin A 回應   │
+│  307/308 重導向   │
+│  → Origin B      │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  Cross-Origin 偵測           │
+│  Origin A ≠ Origin B?        │
+└────────┬─────────────────────┘
+    Yes  │
+         ▼
+┌──────────────────────────────┐
+│  丟棄 body + body headers    │
+│  (除非 caller 明確 opt-in)   │
+└────────┬─────────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  以 GET 繼續     │
+│  至 Origin B     │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Browser SSRF 重導向阻擋 ([#62355](https://github.com/openclaw/openclaw/pull/62355))
+
+- **用途**: 將 main-frame `document` 重導向跳板視為導航，即使 Playwright 未標記為 `isNavigationRequest()`
+- **解決問題**: 嚴格的 private-network 阻擋無法攔截透過重導向跳板進入內部目標的請求
+- **影響**: 防止瀏覽器被重導向至內部網路目標
+
+```text
+┌──────────────────┐
+│  Browser 請求     │
+│  外部 URL         │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  伺服器回應 302/307 重導向    │
+│  → 內部 IP (10.x/192.168.x) │
+└────────┬─────────────────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  SSRF Guard 檢查             │
+│  document redirect =         │
+│  navigation (即使 Playwright │
+│  未標記 isNavigationRequest) │
+└────────┬─────────────────────┘
+         │ 目標為 private network
+         ▼
+┌──────────────────┐
+│  阻擋請求         │
+│  記錄 SSRF 嘗試   │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Plugin Archive SHA-256 驗證 ([#60517](https://github.com/openclaw/openclaw/pull/60517))
+
+- **用途**: 下載的 plugin archive 與版本 metadata 中的 SHA-256 進行比對驗證，metadata 缺失或格式錯誤時直接失敗
+- **解決問題**: Plugin 安裝可在不完整或被竄改的 ClawHub 套件 metadata 下繼續進行
+- **影響**: 確保 plugin 完整性，防止供應鏈攻擊
+
+```text
+┌──────────────────┐
+│  Plugin 安裝請求  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  從 ClawHub 下載 archive │
+│  + 取得版本 metadata      │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  檢查 SHA-256 metadata   │
+│  是否存在且格式正確?      │
+└────────┬─────────────────┘
+    No   │  Yes
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────┐ ┌──────────────────┐
+│ 安裝失敗  │ │ 計算 archive     │
+│ (fail    │ │ SHA-256 雜湊     │
+│  closed) │ └────────┬─────────┘
+└──────────┘          │
+                 ┌────┴────┐
+                 │ 比對?   │
+                 └────┬────┘
+            Match │      │ Mismatch
+                  ▼      ▼
+           ┌────────┐ ┌──────────┐
+           │ 安裝   │ │ 安裝失敗  │
+           │ 繼續   │ └──────────┘
+           └────────┘
+```
+
+### ⭐⭐⭐ Gateway Auth Session 失效機制 ([#62350](https://github.com/openclaw/openclaw/pull/62350))
+
+- **用途**: 當設定的 shared-token 或 password 輪換時，使現有的 WebSocket session 失效
+- **解決問題**: 過時的已認證 socket 在 token 或 password 變更後仍可保持連線
+- **影響**: 確保憑證輪換後舊 session 立即斷開
+
+```text
+┌──────────────────┐
+│  操作者輪換       │
+│  token/password  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  Gateway 偵測 secret 變更 │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  列舉所有 active         │
+│  WebSocket sessions      │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  使用舊 secret 認證的     │
+│  session → 強制斷開       │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ `/allowlist` 指令 Owner 授權 ([#62383](https://github.com/openclaw/openclaw/pull/62383))
+
+- **用途**: `/allowlist add` 和 `/allowlist remove` 在 channel 解析前要求 owner 授權
+- **解決問題**: 非 owner 但有指令權限的使用者可持久性地改寫 allowlist 策略
+- **影響**: 防止未授權的 allowlist 策略變更
+
+```text
+┌──────────────────┐
+│  使用者執行       │
+│  /allowlist add  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  檢查 owner 角色     │
+│  (在 channel 解析前) │
+└────────┬─────────────┘
+    No   │  Yes
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────┐ ┌──────────────┐
+│ 拒絕執行  │ │ 繼續 channel │
+│          │ │ 解析與執行    │
+└──────────┘ └──────────────┘
+```
+
+### ⭐⭐⭐ Feishu Docx Workspace-Only 限制 ([#62369](https://github.com/openclaw/openclaw/pull/62369))
+
+- **用途**: 對 Feishu 的 `upload_file` 和 `upload_image` 路徑強制執行 `tools.fs.workspaceOnly` 限制
+- **解決問題**: Docx 上傳可讀取 workspace 外的 host-local 檔案
+- **影響**: 防止透過 Feishu docx 上傳洩漏 workspace 外的檔案
+
+```text
+┌──────────────────┐
+│  Feishu Docx     │
+│  upload_file 請求 │
+│  (本地路徑)       │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  workspaceOnly 啟用?         │
+└────────┬─────────────────────┘
+    Yes  │  No
+         ▼
+┌──────────────────────────────┐
+│  檢查路徑是否在               │
+│  localRoots (workspace) 內   │
+└────────┬─────────────────────┘
+    外部  │  內部
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────┐ ┌──────────┐
+│ 阻擋上傳  │ │ 允許上傳  │
+└──────────┘ └──────────┘
+```
+
+### ⭐⭐⭐ Gateway Config.Apply Exec Approval 寫入阻擋 ([#62001](https://github.com/openclaw/openclaw/pull/62001))
+
+- **用途**: 阻擋模型端透過 `gateway config.apply` 和 `config.patch` 修改 exec approval 路徑
+- **解決問題**: 模型可透過 config 寫入修改 `safeBins`、`safeBinProfiles`、`safeBinTrustedDirs`、`strictInlineEval` 等安全設定
+- **影響**: 確保 exec approval 設定僅能由操作者手動變更
+
+```text
+┌──────────────────┐
+│  模型端發出       │
+│  config.apply    │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  解析寫入路徑                 │
+│  是否涉及 exec approval?     │
+│  (safeBins, strictInline-   │
+│   Eval, safeBinProfiles...) │
+└────────┬─────────────────────┘
+    Yes  │  No
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────┐ ┌──────────────┐
+│ 阻擋寫入  │ │ 允許寫入     │
+│          │ │ (值未變更時   │
+└──────────┘ │  也允許通過)  │
+             └──────────────┘
+```
+
+### ⭐⭐⭐ MS Teams 上傳 SSRF 驗證 ([#23596](https://github.com/openclaw/openclaw/pull/23596))
+
+- **用途**: 在上傳附件前驗證 file-consent upload URL 的 HTTPS、Microsoft/SharePoint host allowlist 與 private-IP DNS 檢查
+- **解決問題**: 惡意的 consent-upload URL 可被用於 SSRF 攻擊
+- **影響**: 防止透過 MS Teams file-consent 機制進行 SSRF
+
+```text
+┌──────────────────┐
+│  File-Consent    │
+│  Upload URL      │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐    失敗    ┌──────────┐
+│  HTTPS 檢查      │──────────►│ 阻擋上傳  │
+└────────┬─────────┘           └──────────┘
+         │ 通過
+         ▼
+┌──────────────────┐    失敗    ┌──────────┐
+│  Host Allowlist  │──────────►│ 阻擋上傳  │
+│  (MS/SharePoint) │           └──────────┘
+└────────┬─────────┘
+         │ 通過
+         ▼
+┌──────────────────┐    失敗    ┌──────────┐
+│  Private-IP DNS  │──────────►│ 阻擋上傳  │
+│  檢查            │           └──────────┘
+└────────┬─────────┘
+         │ 通過
+         ▼
+┌──────────────────┐
+│  允許上傳         │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Base64 Decode 大小限制 ([#62007](https://github.com/openclaw/openclaw/pull/62007))
+
+- **用途**: 在解碼前對 Teams、Signal、QQ Bot、image-tool 的 base64 payload 強制執行 byte 限制
+- **解決問題**: 過大的 inbound media 和 data URL 繞過了解碼前的大小檢查
+- **影響**: 防止記憶體耗盡攻擊
+
+```text
+┌──────────────────┐
+│  Inbound Base64  │
+│  Payload         │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  Pre-Decode 大小檢查     │
+│  估算解碼後 byte 數      │
+│  (base64 長度 × 3/4)    │
+└────────┬─────────────────┘
+         │
+    ┌────┴────┐
+    │ 超限?   │
+    └────┬────┘
+    Yes  │  No
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────┐ ┌──────────┐
+│ 拒絕解碼  │ │ 正常解碼  │
+└──────────┘ └──────────┘
+```
+
+### ⭐⭐⭐ Runtime Event Trust 標記 ([#62003](https://github.com/openclaw/openclaw/pull/62003))
+
+- **用途**: 將背景 `notifyOnExit` 摘要、ACP parent-stream relay、wake-hook payload 標記為不受信任的系統事件
+- **解決問題**: 低信任度的 runtime 輸出在後續回合中被當作受信任的 `System:` 文字重新進入
+- **影響**: 防止不受信任的 runtime 輸出提升為受信任的系統提示
+
+```text
+┌──────────────────────┐
+│  Runtime 事件來源     │
+│  (notifyOnExit /     │
+│   ACP relay /        │
+│   wake-hook)         │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  標記為 untrusted    │
+│  system event        │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  後續回合處理時       │
+│  不提升為 System:    │
+│  trusted text        │
+└──────────────────────┘
+```
+
+### ⭐⭐ Node Pairing 升級審核 ([#62658](https://github.com/openclaw/openclaw/pull/62658))
+
+- **用途**: 當已配對的 node 以額外宣告的 commands 重新連線時，要求新的配對請求
+- **解決問題**: 重新連線的 node 可自動擴展已核准的 command set
+- **影響**: 確保 command set 擴展需經過明確核准
+
+### ⭐⭐ Browser Profile 變更阻擋 ([#60489](https://github.com/openclaw/openclaw/pull/60489))
+
+- **用途**: 阻擋透過 `browser.proxy` 在 gateway-forwarded `node.invoke` 和 node-host proxy 路徑上的持久性 browser profile 變更
+- **解決問題**: 即使未設定 profile allowlist，仍可透過 proxy 進行 profile 變更
+- **影響**: 防止未授權的 browser profile 操作
+
+### ⭐⭐ Windows cmd.exe Wrapper Approval 強化 ([#62439](https://github.com/openclaw/openclaw/pull/62439))
+
+- **用途**: 即使 `env` carrier（含 env-assignment carrier）包裝了 shell 呼叫，Windows `cmd.exe /c` wrapper 仍需 approval
+- **解決問題**: Env carrier 可繞過 Windows cmd.exe 的 approval 機制
+- **影響**: 確保 Windows 環境下的 exec approval 一致性
+
+### ⭐⭐ Host=Node POSIX Shell Wrapper 對齊 ([#62401](https://github.com/openclaw/openclaw/pull/62401))
+
+- **用途**: 對齊 `host=node` POSIX transport shell wrapper (`/bin/sh -lc ...`) 與內部 command allowlist 分析
+- **解決問題**: 已列入 allowlist 的腳本仍不必要地觸發 approval 提示
+- **影響**: 減少不必要的 approval 提示，同時保持 Windows wrapper 的 approval 機制
+
+### ⭐ QQ Bot Media 路由防護
+
+- **用途**: 將 gateway 端的附件與 fallback 下載路由至受防護的 QQ/Tencent HTTPS fetch
+- **解決問題**: QQ media 處理可能跟隨任意遠端主機
+- **影響**: 限制 QQ media 下載僅至受信任的 QQ/Tencent 主機
+
+### ⭐ Auto-Reply Media 路徑限制
+
+- **用途**: 允許受管理的 generated-media `MEDIA:` 路徑，同時阻擋任意 host-local media 和 document 路徑
+- **解決問題**: 先前的修復過度阻擋了 generated media 的傳遞
+- **影響**: Generated media 可正常傳遞，同時防止 host-path 注入
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Context Overflow 合併復原 ([#61651](https://github.com/openclaw/openclaw/pull/61651))
+
+- **用途**: 將 oversized 與 aggregate tool-result 復原合併為單一 pass，並恢復 total-context overflow backstop
+- **解決問題**: 可復原的 session 過早失敗而非重試
+- **影響**: 大幅提升長 session 的穩定性，減少因 context overflow 導致的中斷
+
+```text
+┌──────────────────┐
+│  Agent Turn      │
+│  (context 超限)  │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  合併復原 Pass               │
+│  1. Oversized tool-result   │
+│     truncation              │
+│  2. Aggregate tool-result   │
+│     compression             │
+└────────┬─────────────────────┘
+         │
+         ▼
+┌──────────────────────────────┐
+│  Total-Context Overflow      │
+│  Backstop 檢查               │
+└────────┬─────────────────────┘
+    超限  │  正常
+    ┌────┘    └────┐
+    ▼              ▼
+┌──────────────┐ ┌──────────────┐
+│ 重試 (而非   │ │ 繼續執行     │
+│  直接失敗)   │ │              │
+└──────────────┘ └──────────────┘
+```
+
+### ⭐⭐⭐ Auth/OpenAI Codex OAuth 重新載入與 Refresh Token 修復
+
+- **用途**: 在鎖定的 refresh 路徑中重新載入磁碟上的最新憑證，並在 `refresh_token_reused` 僅輪換 stored refresh token 後重試一次
+- **解決問題**: 重新登入/重啟後的復原流程卡在過時的快取 auth 狀態
+- **影響**: 解決 Codex OAuth 認證卡住的問題
+
+```text
+┌──────────────────┐
+│  Token Refresh   │
+│  請求            │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  取得 refresh lock       │
+│  重新載入磁碟憑證         │
+│  (非使用快取)             │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  嘗試 refresh    │
+└────────┬─────────┘
+         │
+    ┌────┴──────────────┐
+    │ refresh_token_    │
+    │ reused 錯誤?      │
+    └────┬──────────────┘
+    Yes  │  No (成功)
+         ▼
+┌──────────────────────────┐
+│  更新 stored refresh     │
+│  token → 重試一次        │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  認證恢復         │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Auth/OpenAI Codex OAuth Profile 選擇修復 ([#62744](https://github.com/openclaw/openclaw/pull/62744))
+
+- **用途**: 保持原生 `/model ...@profile` 選擇在目標 session 上，並尊重使用者明確鎖定的 auth profile
+- **解決問題**: 當 per-agent auth order 排除了使用者鎖定的 profile 時，profile 選擇被忽略
+- **影響**: 確保使用者的 model/profile 選擇被正確尊重
+
+```text
+┌──────────────────┐
+│  使用者選擇       │
+│  /model X@profile│
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  解析 model + profile    │
+│  分離處理                 │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  使用者明確鎖定 profile?  │
+└────────┬─────────────────┘
+    Yes  │  No
+         ▼
+┌──────────────────────────┐
+│  優先使用鎖定 profile    │
+│  (即使 per-agent auth    │
+│   order 排除)            │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────┐
+│  Session 使用     │
+│  正確的 profile   │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ Anthropic Thinking Blocks 與 OAuth Streaming 修復 ([#60356](https://github.com/openclaw/openclaw/pull/60356), [#61793](https://github.com/openclaw/openclaw/pull/61793))
+
+- **用途**: 保留 Claude Opus 4.5+、Sonnet 4.5+ 和 Claude 4 系列模型的 thinking blocks，並跳過 OAuth stream wrapper 請求的 `service_tier` 注入
+- **解決問題**: Prompt-cache prefix 不再匹配；Claude OAuth streaming 因 HTTP 401 失敗
+- **影響**: 修復 Claude 模型的 prompt-cache 與 OAuth streaming
+
+```text
+┌──────────────────┐
+│  Claude 4.5+     │
+│  模型請求         │
+└────────┬─────────┘
+         │
+    ┌────┴────┐
+    │ OAuth?  │
+    └────┬────┘
+    Yes  │  No
+    ┌────┘    └────┐
+    ▼              ▼
+┌────────────┐ ┌────────────────┐
+│ 跳過       │ │ 正常注入       │
+│ service_   │ │ service_tier   │
+│ tier 注入  │ │                │
+└─────┬──────┘ └───────┬────────┘
+      │                │
+      └────────┬───────┘
+               ▼
+┌──────────────────────────┐
+│  保留 thinking blocks    │
+│  確保 prompt-cache       │
+│  prefix 匹配             │
+└──────────────────────────┘
+```
+
+### ⭐⭐ CLI/Infer 多項行為對齊修復
+
+- **用途**: 修正 TTS override 處理、profile-aware gateway TTS 偏好解析、per-request transcription 覆寫、image 輸出 MIME/extension 不匹配、web-search fallback 行為、agent-vs-CLI web-search 執行差異
+- **解決問題**: Provider-backed infer 行為與實際 runtime 執行不一致
+- **影響**: 確保 `openclaw infer` 的行為與 agent runtime 一致
+
+### ⭐⭐ History/Replies Buffer 與序列追蹤修復 ([#61729](https://github.com/openclaw/openclaw/pull/61729), [#61747](https://github.com/openclaw/openclaw/pull/61747), [#61829](https://github.com/openclaw/openclaw/pull/61829), [#61855](https://github.com/openclaw/openclaw/pull/61855), [#61954](https://github.com/openclaw/openclaw/pull/61954))
+
+- **用途**: 緩衝無 phase 的 OpenAI WS 文字直到真正的 assistant phase 到達，對齊 replay 與 SSE history 序列追蹤，隱藏 commentary 與洩漏的 tool XML
+- **解決問題**: 使用者可見的 history 中出現 commentary 和 tool XML；follow-up 回覆未限定在 `final_answer` 文字
+- **影響**: 改善 history 的正確性與使用者體驗
+
+### ⭐⭐ iOS Gateway 結構化連線問題 ([#62650](https://github.com/openclaw/openclaw/pull/62650))
+
+- **用途**: 以結構化 gateway 連線問題取代字串匹配的連線錯誤 UI，保留可操作的 pairing/auth 失敗資訊
+- **解決問題**: 後續的通用斷線雜訊覆蓋了有用的 pairing/auth 失敗訊息
+- **影響**: 改善 iOS 使用者的連線問題診斷體驗
+
+### ⭐⭐ TUI 多項修復 ([#49130](https://github.com/openclaw/openclaw/pull/49130), [#59985](https://github.com/openclaw/openclaw/pull/59985), [#60043](https://github.com/openclaw/openclaw/pull/60043), [#61463](https://github.com/openclaw/openclaw/pull/61463))
+
+- **用途**: 修正 `/status` 路由、commentary 隱藏、async command notice metadata 清理、fallback streaming 保留、Kitty keyboard 狀態恢復
+- **解決問題**: TUI 中多項顯示與狀態管理問題
+- **影響**: 提升 TUI 的穩定性與使用體驗
+
+### ⭐⭐ web_fetch/web_search undici 8.0 HTTP/2 修復 ([#61738](https://github.com/openclaw/openclaw/pull/61738), [#61777](https://github.com/openclaw/openclaw/pull/61777))
+
+- **用途**: 修正 undici 8.0 預設啟用 HTTP/2 導致的 `TypeError: fetch failed`，SSRF-guard dispatcher 明確設定 `allowH2: false`
+- **解決問題**: DNS-pinning lookup 與 HTTP/2 不相容
+- **影響**: 恢復 web_fetch 和 web_search 的正常運作
+
+### ⭐⭐ Plugin Loader Windows 相容性修復 ([#62286](https://github.com/openclaw/openclaw/pull/62286))
+
+- **用途**: 集中化 bundled `dist/**` Jiti native-load 策略，修正 Windows `file://` 與 native-Jiti plugin loader 路徑
+- **解決問題**: Windows 上 onboarding 和 configure 流程觸發 `ERR_UNSUPPORTED_ESM_URL_SCHEME`
+- **影響**: 修復 Windows 平台的 plugin 載入
+
+### ⭐⭐ Docker Plugin 路徑修復 ([#62316](https://github.com/openclaw/openclaw/pull/62316))
+
+- **用途**: 停止強制 bundled plugin discovery 至 `/app/extensions`，使用編譯後的 `dist/extensions` artifacts
+- **解決問題**: Node 24 容器透過 source-only plugin entry path 啟動
+- **影響**: 修復 Docker 環境中的 plugin 載入
+
+### ⭐⭐ Plugins/Media Capability Merge ([#62205](https://github.com/openclaw/openclaw/pull/62205))
+
+- **用途**: 當 `plugins.allow` 設定時，capability fallback 將 bundled capability plugin id 合併至 allowlist
+- **解決問題**: OpenAI-compatible STT 等 media understanding provider 無法載入
+- **影響**: 修復 voice transcription 等 media 功能
+
+### ⭐⭐ Control UI 多項修復 ([#54842](https://github.com/openclaw/openclaw/pull/54842), [#61514](https://github.com/openclaw/openclaw/pull/61514), [#61598](https://github.com/openclaw/openclaw/pull/61598))
+
+- **用途**: 在 webchat 顯示 `/tts` 音訊回覆、偵測錯誤的 `?token=` auth link、修正窄螢幕上 Copy/Canvas/exec-approval UI 覆蓋問題
+- **解決問題**: 多項 Control UI 顯示與互動問題
+- **影響**: 改善 webchat 使用體驗
+
+### ⭐⭐ iOS/Watch Exec Approvals 修復 ([#61757](https://github.com/openclaw/openclaw/pull/61757))
+
+- **用途**: 修正 Apple Watch 在 iPhone 鎖定或背景時的 review 和 approval 復原
+- **解決問題**: Apple Watch 的 approval 在 iPhone 鎖定時無法正常運作
+- **影響**: 確保 Apple Watch exec approval 的可靠性
+
+### ⭐ Ollama Multi-Endpoint Streaming 修復 ([#61678](https://github.com/openclaw/openclaw/pull/61678))
+
+- **用途**: 在 streaming 時尊重所選 provider 的 `baseUrl`
+- **解決問題**: 多 Ollama 設定中所有 stream 都路由至第一個設定的端點
+- **影響**: 修復多 Ollama 端點的 streaming
+
+### ⭐ Slack Thread Mention 設定 ([#58276](https://github.com/openclaw/openclaw/pull/58276))
+
+- **用途**: 新增 `channels.slack.thread.requireExplicitMention` 設定
+- **解決問題**: 已要求 mention 的 Slack channel 無法在 bot 參與的 thread 中也要求明確 `@bot` mention
+- **影響**: 提供更細緻的 Slack thread mention 控制
+
+### ⭐ Matrix Onboarding 自動加入 ([#62168](https://github.com/openclaw/openclaw/pull/62168))
+
+- **用途**: 新增 invite auto-join 設定步驟，含明確的關閉警告與嚴格的 stable-target 驗證
+- **解決問題**: 新 Matrix 帳號靜默忽略被邀請的房間
+- **影響**: 改善 Matrix 的 onboarding 體驗
+
+### ⭐ Telegram Doctor 多帳號修復 ([#62263](https://github.com/openclaw/openclaw/pull/62263))
+
+- **用途**: 在多帳號正規化期間保持頂層 access-control fallback
+- **解決問題**: 現有的具名 bot 在 legacy default auth 提升後失去繼承的 allowlist
+- **影響**: 確保 Telegram 多帳號設定的向後相容性
+
+### ⭐ macOS Gateway 版本解析修復 ([#61111](https://github.com/openclaw/openclaw/pull/61111))
+
+- **用途**: 在 semver 解析前移除 CLI 版本輸出中的尾隨 commit metadata
+- **解決問題**: Mac app 無法辨識如 `OpenClaw 2026.4.2 (d74a122)` 的版本格式
+- **影響**: 修復 macOS app 的 gateway 版本偵測
+
+### ⭐ Anthropic Claude CLI 錯誤訊息改善
+
+- **用途**: 從結構化 CLI 輸出中提取巢狀 API 錯誤訊息
+- **解決問題**: Billing/auth/provider 失敗顯示不透明的 CLI 錯誤而非真正的 provider 錯誤
+- **影響**: 改善錯誤診斷體驗
+
+### ⭐ Exec Approval Timeout 後阻擋 ([#61739](https://github.com/openclaw/openclaw/pull/61739))
+
+- **用途**: `strictInlineEval` 指令在 approval timeout 後保持阻擋狀態
+- **解決問題**: Approval timeout 後指令 fall through 至自動執行
+- **影響**: 確保 timeout 後的安全行為
+
+### ⭐ Providers/xAI 端點辨識修復 ([#61377](https://github.com/openclaw/openclaw/pull/61377))
+
+- **用途**: 重新辨識 `api.grok.x.ai` 為 xAI-native 端點，修正 legacy `x_search` auth 解析
+- **解決問題**: 較舊的 xAI web-search 設定無法載入
+- **影響**: 恢復 xAI 設定的向後相容性
+
+### ⭐ Mistral Small 4 Reasoning 支援 ([#62162](https://github.com/openclaw/openclaw/pull/62162))
+
+- **用途**: 為 `mistral/mistral-small-latest` 發送 `reasoning_effort` 並標記為 reasoning-capable
+- **解決問題**: Mistral Small 4 的 adjustable reasoning 未對應 Chat Completions API
+- **影響**: 啟用 Mistral Small 4 的推理能力調整
+
+### ⭐ OpenAI TTS/Groq WAV 格式修復 ([#62233](https://github.com/openclaw/openclaw/pull/62233))
+
+- **用途**: 對 Groq-compatible speech 端點發送 `wav`，尊重明確的 `responseFormat` 覆寫
+- **解決問題**: Voice-note 輸出在非 `opus` 格式時被錯誤標記為 voice-compatible
+- **影響**: 修正 TTS 輸出格式處理
+
+### ⭐ Exa Search Onboarding 可見性
+
+- **用途**: 將 bundled Exa provider 標記為 setup-visible
+- **解決問題**: Exa Search 未出現在 onboarding 和 configure provider picker 中
+- **影響**: 使用者可在設定中發現 Exa Search
+
+### ⭐ Memory Vector Recall 警告 ([#61720](https://github.com/openclaw/openclaw/pull/61720))
+
+- **用途**: 當 `sqlite-vec` 不可用或 vector 寫入降級時顯示明確警告
+- **解決問題**: Memory indexing 和 dreaming 報告 false-success 或重新攝取 staged output
+- **影響**: 改善 memory 系統的可觀測性
+
+### ⭐ Discord 多項修復 ([#41536](https://github.com/openclaw/openclaw/pull/41536), [#61670](https://github.com/openclaw/openclaw/pull/61670))
+
+- **用途**: 恢復 forwarded referenced message、修正 gateway monitor socket 協定、停止 Codex-backed auto-thread title 的硬編碼 temperature、強化 voice receive 復原
+- **解決問題**: Discord 整合中的多項邊緣案例
+- **影響**: 提升 Discord 整合的穩定性
+
+### ⭐ 其他修復
+
+- Slack threading legacy 相容性 ([#61835](https://github.com/openclaw/openclaw/pull/61835))
+- Slack media SSRF-guarded dispatcher 修復 ([#62239](https://github.com/openclaw/openclaw/pull/62239))
+- Matrix multi-paragraph 格式修復 ([#60997](https://github.com/openclaw/openclaw/pull/60997))
+- Plugin channel/secret-contract loader 穩定性 ([#61832](https://github.com/openclaw/openclaw/pull/61832), [#61836](https://github.com/openclaw/openclaw/pull/61836), [#61853](https://github.com/openclaw/openclaw/pull/61853), [#61856](https://github.com/openclaw/openclaw/pull/61856))
+- Plugin provider hook 遞迴 stack overflow 修復 ([#61922](https://github.com/openclaw/openclaw/pull/61922), [#61938](https://github.com/openclaw/openclaw/pull/61938))
+- Ollama 空 default stub 警告修復
+- Gateway/container auto-bind 與 TLS 修復 ([#61818](https://github.com/openclaw/openclaw/pull/61818), [#61935](https://github.com/openclaw/openclaw/pull/61935))
+- Gateway OpenAI-compatible HTTP abort 修復 ([#54388](https://github.com/openclaw/openclaw/pull/54388))
+- Session model 選擇對齊
+- Discord ACP DM binding 修復
+- Compaction-wait abort 重播修復 ([#62600](https://github.com/openclaw/openclaw/pull/62600))
+- Approval lifecycle 重構 ([#62135](https://github.com/openclaw/openclaw/pull/62135))
+- Security/fetch-guard proxy hostname 修復 ([#62312](https://github.com/openclaw/openclaw/pull/62312))
+- Logging level 排序修復 ([#44646](https://github.com/openclaw/openclaw/pull/44646))
+- sessions_send threadId 修復 ([#62758](https://github.com/openclaw/openclaw/pull/62758))
+- Daemon/systemd sudo 範圍修復 ([#62337](https://github.com/openclaw/openclaw/pull/62337))
+- Docs/i18n 本地化連結修復 ([#61796](https://github.com/openclaw/openclaw/pull/61796))
+- Subagent lightContext 修復 ([#62264](https://github.com/openclaw/openclaw/pull/62264))
+- Cron jobId 載入修復 ([#62246](https://github.com/openclaw/openclaw/pull/62246))
+- Model fallback 404 分類修復 ([#62119](https://github.com/openclaw/openclaw/pull/62119))
+- BlueBubbles private-network opt-out 修復 ([#59373](https://github.com/openclaw/openclaw/pull/59373))
+- Heartbeat session pinning 修復 ([#61803](https://github.com/openclaw/openclaw/pull/61803))
+- Heartbeat prompt guidance 修復
+- Browser remote CDP retry 修復 ([#57397](https://github.com/openclaw/openclaw/pull/57397))
+- UI light mode scrollbar 修復 ([#61753](https://github.com/openclaw/openclaw/pull/61753))
+- Exec timed-out background command 修復
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 5 | 6 | 7 | 全新 infer CLI、memory-wiki 回歸、webhook ingress、可插拔 compaction、media 自動降級 |
+| 安全性 | 11 | 4 | 2 | 大量安全強化：env 清理、SSRF 防護、plugin 驗證、auth session 失效、workspace 限制 |
+| 錯誤修復 | 4 | 10 | 15+ | Context overflow 修復、OAuth 認證修復、Anthropic streaming 修復、跨平台相容性改善 |
+| **總計** | **20** | **20** | **24+** | 本版本為重大安全強化版本，同時帶來多項重要新功能與穩定性改善 |
+
+**發佈日期**: 2026-04-07
+**版本**: 2026.4.7
+**狀態**: Production Ready
+**GitHub Release**: [openclaw v2026.4.7](https://github.com/openclaw/openclaw/releases/tag/v2026.4.7)


### PR DESCRIPTION
## Summary

Add Traditional Chinese (zh-TW) release notes for OpenClaw v2026.4.7.

### Content

- **升級前必讀** section with 5 breaking changes and 5 feature highlights
- **功能更新** (Features): 5× ⭐⭐⭐ (with flowcharts), 6× ⭐⭐, 7× ⭐
- **安全性提升** (Security): 11× ⭐⭐⭐ (with flowcharts), 4× ⭐⭐, 2× ⭐
- **錯誤修復** (Bug Fixes): 4× ⭐⭐⭐ (with flowcharts), 10× ⭐⭐, 15+× ⭐
- Summary table and footer

### Key highlights

- New `openclaw infer` CLI hub for unified inference workflows
- Memory Wiki restored with full plugin/CLI/search stack
- Webhook ingress plugin for external automation
- Pluggable compaction provider registry
- 11 critical security fixes (env sanitization, SSRF guards, plugin verification, auth session invalidation)

### Upstream

- [OpenClaw v2026.4.7 Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.7)

Closes #469