### PR TITLE
release-notes: OpenClaw 2026.4.8

### DIFF
--- a/release-notes/2026-04-08.md
+++ b/release-notes/2026-04-08.md
@@ -1,0 +1,131 @@
+# OpenClaw v2026.4.8 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8)
+
+---
+
+## 概述
+
+本版本專注於錯誤修復與穩定性提升，涵蓋 Telegram、Slack、多個 bundled channels、Agents 執行層及網路代理等面向。
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Telegram/setup：修復已安裝 npm build 啟動時找不到 `dist/extensions/telegram/src/*` 的問題
+- ⭐⭐⭐ Bundled channels/setup：修復 10 個 bundled channels 啟動時缺少 sidecar 的問題
+- ⭐⭐ Bundled plugins：修正 bundled plugin 相容性 metadata 與版本不符問題
+- ⭐⭐ Agents/progress：保留 `update_plan` 工具並支援 opt-out flag
+- ⭐⭐ Agents/exec：修正 `/exec` 預設 host 政策顯示不正確的問題
+- ⭐⭐ Slack：支援 Socket Mode WebSocket 連線的 HTTP(S) proxy 設定
+- ⭐⭐ Slack/actions：修復 SecretRef-backed bot token 在 `downloadFile` 時失敗的問題
+- ⭐⭐ Network/fetch guard：修復 trusted env-proxy 模式下 DNS pinning 阻擋代理解析的問題
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Telegram/setup：修復 sidecar 載入問題 ([v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8))
+
+- **用途**: 透過 packaged top-level sidecars 載入 setup 與 secret contracts
+- **解決問題**: 已安裝的 npm build 在 gateway 啟動時嘗試 import 不存在的 `dist/extensions/telegram/src/*` 檔案而失敗
+- **影響**: Telegram channel 在 npm 安裝環境下可正常啟動，不再需要 source build
+
+```text
+┌─────────────────────────┐
+│   Gateway 啟動           │
+└─────────────────────────┘
+           │
+           ▼
+┌─────────────────────────┐     ┌──────────────────────────────┐
+│  載入 Telegram setup     │────►│  舊：import dist/extensions/  │
+└─────────────────────────┘     │  telegram/src/* (不存在)      │
+                                └──────────────────────────────┘
+                                              │ 修復後
+                                              ▼
+                                ┌──────────────────────────────┐
+                                │  新：import packaged          │
+                                │  top-level sidecars (存在)   │
+                                └──────────────────────────────┘
+                                              │
+                                              ▼
+                                ┌──────────────────────────────┐
+                                │  Gateway 正常啟動 ✓           │
+                                └──────────────────────────────┘
+```
+
+### ⭐⭐⭐ Bundled channels/setup：修復 10 個 channels 的 sidecar 載入問題 ([v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8))
+
+- **用途**: 透過 packaged top-level sidecars 載入各 channel 的 shared secret contracts
+- **解決問題**: BlueBubbles、Feishu、Google Chat、IRC、Matrix、Mattermost、Microsoft Teams、Nextcloud Talk、Slack、Zalo 在 npm 安裝環境下啟動時找不到 `dist/extensions/*/src/*` 而失敗
+- **影響**: 所有受影響的 bundled channels 在 npm 安裝環境下均可正常載入
+
+```text
+┌──────────────────────┐
+│  Gateway 啟動         │
+└──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  載入 10 個 bundled   │
+│  channels            │
+└──────────────────────┘
+           │
+    ┌──────┴──────┐
+    │ 舊路徑       │ 新路徑
+    ▼             ▼
+┌────────┐   ┌────────────────────┐
+│ 找不到  │   │ packaged sidecar   │
+│ src/*  │   │ 正常載入 ✓          │
+└────────┘   └────────────────────┘
+```
+
+### ⭐⭐ Bundled plugins：修正相容性 metadata ([v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8))
+
+- **用途**: 對齊 bundled plugin 的相容性 metadata 與 release 版本
+- **解決問題**: bundled channels 與 providers 在 OpenClaw 2026.4.8 上無法載入
+- **影響**: 所有 bundled plugins 可在本版本正常運作
+
+### ⭐⭐ Agents/progress：保留 `update_plan` 工具 ([v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8))
+
+- **用途**: 在 OpenAI-family runs 中保持 `update_plan` 可用，回傳精簡 success payload，並支援 `tools.experimental.planTool=false` opt-out
+- **解決問題**: `update_plan` 在某些情況下不可用，影響 agent 計畫追蹤
+- **影響**: OpenAI-family agent 可穩定使用計畫工具，並可依需求關閉
+
+### ⭐⭐ Agents/exec：修正 `/exec` 預設 host 政策顯示 ([v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8))
+
+- **用途**: 讓 `/exec` current-default 回報與實際 runtime 行為一致
+- **解決問題**: `host=auto` sessions 顯示過時且過嚴的預設值，而非正確的 host-aware fallback 政策（gateway/node 為 `full/off`，sandbox 為 `deny/off`）
+- **影響**: 使用者看到的預設政策資訊與實際行為一致，減少混淆
+
+### ⭐⭐ Slack：支援 Socket Mode 的 HTTP(S) proxy ([#62878](https://github.com/openclaw/openclaw/pull/62878))
+
+- **用途**: 讓 Slack Socket Mode WebSocket 連線遵循環境的 HTTP(S) proxy 設定，包含 NO_PROXY 排除規則
+- **解決問題**: 僅能透過 proxy 連線的部署環境無法建立 Socket Mode 連線，需要 monkey patch
+- **影響**: proxy-only 環境可直接使用 Slack Socket Mode，無需額外修補。感謝 @mjamiv 貢獻
+
+### ⭐⭐ Slack/actions：修復 SecretRef-backed bot token 的 `downloadFile` 問題 ([#62097](https://github.com/openclaw/openclaw/pull/62097))
+
+- **用途**: 將已解析的 read token 傳入 `downloadFile`
+- **解決問題**: 使用 SecretRef-backed bot token 時，raw config re-read 後 `downloadFile` 失敗
+- **影響**: Slack 檔案下載在 SecretRef token 設定下可正常運作。感謝 @martingarramon 貢獻
+
+### ⭐⭐ Network/fetch guard：修復 trusted env-proxy 模式下的 DNS pinning ([#59007](https://github.com/openclaw/openclaw/pull/59007))
+
+- **用途**: 在 trusted env-proxy 模式啟用時跳過 target DNS pinning
+- **解決問題**: proxy-only sandbox 中，DNS pinning 阻擋 trusted proxy 解析對外連線的 hostname
+- **影響**: proxy-only sandbox 可正常透過 trusted proxy 建立對外連線。感謝 @cluster2600 貢獻
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 0 | 0 | 0 | 無 |
+| 安全性 | 0 | 0 | 0 | 無 |
+| 錯誤修復 | 2 | 6 | 0 | 8 項修復 |
+| **總計** | **2** | **6** | **0** | **8** |
+
+**發佈日期**: 2026-04-08
+**版本**: 2026.4.8
+**狀態**: Production Ready
+**GitHub Release**: [v2026.4.8](https://github.com/openclaw/openclaw/releases/tag/v2026.4.8)


### PR DESCRIPTION
Closes #471

## Summary

Release notes for OpenClaw v2026.4.8 — bug fixes only, no breaking changes.

- 2 × ⭐⭐⭐ fixes (Telegram + 10 bundled channels sidecar loading)
- 6 × ⭐⭐ fixes (plugins metadata, agents/progress, agents/exec, Slack proxy, Slack token, network fetch guard)
