### PR TITLE
docs: add validated_by to 5 platform docs

### DIFF
--- a/docs/acp_codex.md
+++ b/docs/acp_codex.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # OpenClaw × ACP × Codex 整合指南

--- a/docs/aws_sso_refresh.md
+++ b/docs/aws_sso_refresh.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # AWS SSO Token 刷新策略

--- a/docs/bedrock_auth.md
+++ b/docs/bedrock_auth.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # Amazon Bedrock Authentication for OpenClaw

--- a/docs/bedrock_models.md
+++ b/docs/bedrock_models.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # Amazon Bedrock Models Configuration for OpenClaw

--- a/docs/bedrock_pricing.md
+++ b/docs/bedrock_pricing.md
@@ -1,5 +1,6 @@
 ---
 last_validated: 2026-04-02
+validated_by: masami-agent
 ---
 
 # Amazon Bedrock 模型定價比較


### PR DESCRIPTION
## Summary
- add `validated_by: masami-agent` to 5 docs that already had `last_validated`
- keep the diff metadata-only with no body content changes
- continue the frontmatter consistency cleanup for docs outside the earlier batches

## Files
- docs/acp_codex.md
- docs/aws_sso_refresh.md
- docs/bedrock_auth.md
- docs/bedrock_models.md
- docs/bedrock_pricing.md

## Testing
- not run (metadata-only changes)