### PR TITLE
release-notes: OpenClaw v2026.4.10

### DIFF
--- a/release-notes/2026-04-10.md
+++ b/release-notes/2026-04-10.md
@@ -1,0 +1,236 @@
+# OpenClaw v2026.4.10 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.10)
+
+## ⚠️ 升級前必讀
+
+本版本無 Breaking Changes，但包含多項重要安全強化與架構調整，建議閱讀以下亮點後再升級。
+
+### 新功能亮點
+
+- **Active Memory Plugin**：全新記憶子代理，自動在主回覆前注入相關記憶，無需手動觸發
+- **本地 MLX Talk 模式**：macOS 可使用本地語音合成，支援中斷處理與系統語音備援
+- **Codex Provider 整合**：`codex/gpt-*` 模型使用 Codex 管理的 OAuth 認證與原生執行緒
+- **SSRF 全面強化**：瀏覽器、沙箱、媒體、工具等多層面 SSRF 防禦大幅升級
+- **Microsoft Teams 擴充**：新增 pin/unpin/read/react 等訊息動作
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ Active Memory Plugin：自動記憶子代理，支援多種上下文模式與 `/verbose` 即時檢視 ([#63286](https://github.com/openclaw/openclaw/pull/63286))
+- ⭐⭐⭐ Codex Provider：bundled Codex provider 與 app-server harness，原生執行緒與模型探索 ([#64298](https://github.com/openclaw/openclaw/pull/64298))
+- ⭐⭐ 本地 MLX Talk 模式：macOS 實驗性本地語音合成，支援中斷與備援 ([#63539](https://github.com/openclaw/openclaw/pull/63539))
+- ⭐⭐ Microsoft Teams 訊息動作：pin、unpin、read、react、列出 reactions ([#53432](https://github.com/openclaw/openclaw/pull/53432))
+- ⭐⭐ `commands.list` RPC：遠端客戶端可探索 runtime 原生、文字、skill、plugin 指令 ([#62656](https://github.com/openclaw/openclaw/pull/62656))
+- ⭐⭐ Seedance 2.0 模型支援：新增 fal provider 的 Seedance 2.0 模型參數
+- ⭐⭐ `openclaw exec-policy` 指令：`show`/`preset`/`set` 子指令同步 exec 核准設定 ([#64050](https://github.com/openclaw/openclaw/pull/64050))
+- ⭐ QA/Matrix 測試通道：可拋棄式 Matrix homeserver 的 live QA 通道 ([#64489](https://github.com/openclaw/openclaw/pull/64489))
+- ⭐ QA/Telegram 測試通道：私人群組 bot-to-bot 驗證 ([#64303](https://github.com/openclaw/openclaw/pull/64303))
+- ⭐ QA/Multipass：`--runner multipass` 在可拋棄式 Linux VM 中執行 QA ([#63426](https://github.com/openclaw/openclaw/pull/63426))
+- ⭐ 每 provider `allowPrivateNetwork` 設定：信任自架 OpenAI 相容端點 ([#63671](https://github.com/openclaw/openclaw/pull/63671))
+- ⭐ Feishu 標準化：統一 user agent，將 bot 註冊為 AI agent ([#63835](https://github.com/openclaw/openclaw/pull/63835))
+- ⭐ Matrix MSC4357 live markers：支援 typewriter 動畫效果 ([#63513](https://github.com/openclaw/openclaw/pull/63513))
+- ⭐ Strict-agentic Pi 執行合約：GPT-5 系列 plan-only 回合持續執行直到真正阻塞 ([#64241](https://github.com/openclaw/openclaw/pull/64241))
+- ⭐ Docs i18n 強化：分塊翻譯、拒絕截斷輸出、Pi 翻譯 session 恢復 ([#62969](https://github.com/openclaw/openclaw/pull/62969))
+- ⭐ Claude CLI Skills 傳遞：將合格的 OpenClaw skills 注入 CLI 執行 ([#62686](https://github.com/openclaw/openclaw/pull/62686))
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ 瀏覽器/沙箱 SSRF 全面強化：hostname allowlist、CDP 探索、noVNC、marker-span 清理等多層防禦 ([#61404](https://github.com/openclaw/openclaw/pull/61404), [#63332](https://github.com/openclaw/openclaw/pull/63332), [#63882](https://github.com/openclaw/openclaw/pull/63882))
+- ⭐⭐⭐ 工具安全強化：exec preflight、host env denylist、plugin 安裝依賴掃描、Gmail token 遮蔽、oversized WebSocket frame 處理 ([#62333](https://github.com/openclaw/openclaw/pull/62333), [#62661](https://github.com/openclaw/openclaw/pull/62661))
+- ⭐⭐ Telegram `allowFrom` 驗證強化：sender 驗證與 `/whoami` allowlist 同步
+- ⭐⭐ Dreaming 需要 `operator.admin` 才能持久化 `/dreaming on|off` ([#63872](https://github.com/openclaw/openclaw/pull/63872))
+- ⭐⭐ Hook 安全：agent hook 系統事件標記為不信任，清理 hook 顯示名稱 ([#64372](https://github.com/openclaw/openclaw/pull/64372))
+- ⭐ QQBot 媒體儲存邊界：所有出站本地檔案路徑強制媒體儲存邊界 ([#63271](https://github.com/openclaw/openclaw/pull/63271))
+- ⭐ 媒體安全：sender-scoped `toolsBySender` 政策套用至出站 host-media 讀取 ([#64459](https://github.com/openclaw/openclaw/pull/64459))
+- ⭐ Feishu webhook：透過 pre-auth guard 讀取 webhook body ([#63835](https://github.com/openclaw/openclaw/pull/63835))
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Microsoft Teams 媒體下載全面修復：個人 DM、Bot Framework、OneDrive/SharePoint、Graph-backed chat ID ([#54932](https://github.com/openclaw/openclaw/pull/54932) 等多個 PR)
+- ⭐⭐⭐ WhatsApp 重連穩定性：跨重連保持 inbound replies、media、composing indicators ([#30806](https://github.com/openclaw/openclaw/pull/30806), [#62892](https://github.com/openclaw/openclaw/pull/62892))
+- ⭐⭐⭐ Gateway 執行緒路由：Slack/Telegram/Mattermost/Matrix/ACP 等 subagent、cron、stream-relay 訊息正確回到原始執行緒 ([#54840](https://github.com/openclaw/openclaw/pull/54840) 等)
+- ⭐⭐ CLI/WhatsApp media sends：`--media` 透過 `sendMedia` 路徑路由，修復靜默丟棄檔案問題 ([#64478](https://github.com/openclaw/openclaw/pull/64478))
+- ⭐⭐ iMessage self-chat：正確區分 DM 與 self-chat，修復 reflected echo 問題 ([#61619](https://github.com/openclaw/openclaw/pull/61619) 等)
+- ⭐⭐ Gateway 啟動穩定性：WebSocket RPC 在 channel/plugin sidecar 啟動期間保持可用 ([#63480](https://github.com/openclaw/openclaw/pull/63480))
+- ⭐⭐ 模型 fallback 保留：跨暫時性主模型失敗與設定重載保留 `/models` 選擇 ([#61472](https://github.com/openclaw/openclaw/pull/61472))
+- ⭐⭐ BTW 修復：tool-use 回合後 `/btw` 繼續運作，清理 replayed tool blocks ([#64218](https://github.com/openclaw/openclaw/pull/64218) 等)
+- ⭐⭐ Cron 時間戳修復：`nextRunAtMs <= 0` 視為無效，自我修復損壞的零時間戳 ([#63507](https://github.com/openclaw/openclaw/pull/63507))
+- ⭐⭐ Skills/TaskFlow frontmatter 修復：還原有效的 frontmatter fences ([#64166](https://github.com/openclaw/openclaw/pull/64166))
+- ⭐⭐ Windows exec 掛起修復：子程序退出後正確結束 supervisor 等待 ([#64072](https://github.com/openclaw/openclaw/pull/64072))
+- ⭐⭐ Daemon/launchd：`openclaw gateway stop` 持久化而不解除安裝 LaunchAgent ([#64447](https://github.com/openclaw/openclaw/pull/64447))
+- ⭐ Matrix 多帳號 room scoping、crypto migrations、block streaming 修復 ([#58449](https://github.com/openclaw/openclaw/pull/58449) 等)
+- ⭐ vLLM 推理模型修復：忽略空 `tool_calls`、修復 `tool_choice` 導致的無限掛起 ([#61197](https://github.com/openclaw/openclaw/pull/61197))
+- ⭐ Discord TTS：透過原生 voice-note 路徑路由，傳送 Opus 語音訊息 ([#64096](https://github.com/openclaw/openclaw/pull/64096))
+- ⭐ Gemini tool schema：移除孤立的 `required` 條目，修復 provider 驗證拒絕 ([#64284](https://github.com/openclaw/openclaw/pull/64284))
+- ⭐ Qwen XML tool call 清理：從可見回覆中移除 `<tool_call>` 原始輸出 ([#63999](https://github.com/openclaw/openclaw/pull/63999))
+- ⭐ Daemon systemd 重啟風暴防護：設定錯誤時以 `EX_CONFIG` 退出 ([#63913](https://github.com/openclaw/openclaw/pull/63913))
+- ⭐ OpenAI compat `/v1/chat/completions`：回傳真實 `usage`，修復 stream usage chunk ([#62986](https://github.com/openclaw/openclaw/pull/62986))
+- ⭐ Heartbeat 模板修復：忽略 Markdown fence markers，避免不必要的 API 呼叫 ([#61690](https://github.com/openclaw/openclaw/pull/61690))
+
+---
+
+## 功能更新詳細說明
+
+### ⭐⭐⭐ Active Memory Plugin ([#63286](https://github.com/openclaw/openclaw/pull/63286))
+
+- **用途**：在主回覆前自動執行記憶子代理，主動拉取相關偏好、上下文與過去細節
+- **解決問題**：使用者不再需要手動說「記住這個」或「搜尋記憶」，記憶自動注入
+- **影響**：對話連貫性大幅提升；支援 message/recent/full context 模式、`/verbose` 即時檢視、進階 prompt/thinking 覆寫調整，以及 opt-in 逐字稿持久化供除錯
+
+```text
+┌─────────────────┐
+│  收到使用者訊息  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Active Memory 子代理 │
+│  (主回覆前執行)       │
+└────────┬────────────┘
+         │ 語意搜尋相關記憶
+         ▼
+┌─────────────────────┐
+│  注入記憶上下文       │
+│  (偏好/過去細節/脈絡) │
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  主 LLM 回覆         │
+│  (已具備完整記憶脈絡) │
+└─────────────────────┘
+```
+
+### ⭐⭐⭐ Codex Provider & App-Server Harness ([#64298](https://github.com/openclaw/openclaw/pull/64298))
+
+- **用途**：新增 bundled Codex provider，`codex/gpt-*` 模型使用 Codex 管理的 OAuth 認證、原生執行緒、模型探索與 compaction；`openai/gpt-*` 維持原有 OpenAI provider 路徑
+- **解決問題**：Codex 與 OpenAI 路徑混用導致的認證與執行緒管理問題
+- **影響**：Codex 用戶獲得原生整合體驗，兩條路徑互不干擾
+
+```text
+┌──────────────────┐
+│  模型選擇         │
+└────────┬─────────┘
+         │
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+codex/gpt-*  openai/gpt-*
+    │         │
+    ▼         ▼
+┌─────────┐ ┌──────────┐
+│ Codex   │ │ OpenAI   │
+│ OAuth   │ │ Provider │
+│ 原生執緒 │ │ (原路徑) │
+└─────────┘ └──────────┘
+```
+
+---
+
+## 安全性提升詳細說明
+
+### ⭐⭐⭐ 瀏覽器/沙箱 SSRF 全面強化 ([#61404](https://github.com/openclaw/openclaw/pull/61404) 等)
+
+- **用途**：全面強化瀏覽器與沙箱的 SSRF 防禦，涵蓋 hostname allowlist、互動驅動重定向、subframe、CDP 探索、noVNC、marker-span 清理、Docker CDP source-range 強制執行
+- **解決問題**：多個潛在的 SSRF 攻擊向量，防止惡意頁面存取內部網路資源
+- **影響**：大幅降低透過瀏覽器自動化功能進行 SSRF 攻擊的風險
+
+```text
+┌──────────────────┐
+│  瀏覽器導航請求   │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  Strict SSRF 檢查     │
+│  • hostname allowlist │
+│  • IP literal 驗證    │
+│  • RFC1918 封鎖       │
+└────────┬─────────────┘
+         │
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+ 允許通過    拒絕並記錄
+    │
+    ▼
+┌──────────────────┐
+│  CDP/noVNC 路由  │
+│  (pinned fetch)  │
+└──────────────────┘
+```
+
+### ⭐⭐⭐ 工具安全強化 ([#62333](https://github.com/openclaw/openclaw/pull/62333) 等)
+
+- **用途**：強化 exec preflight 讀取、host env denylist、node 輸出邊界、outbound host-media 讀取、profile-mutation 授權、plugin 安裝依賴掃描、ACPX tool hooks、Gmail watcher token 遮蔽、oversized realtime WebSocket frame 處理
+- **解決問題**：多個工具層面的安全漏洞，防止未授權的資源存取與資料洩漏
+- **影響**：工具執行環境更安全，敏感資訊（如 Gmail token）不再洩漏至日誌
+
+---
+
+## 錯誤修復詳細說明
+
+### ⭐⭐⭐ Microsoft Teams 媒體下載全面修復
+
+- **用途**：修復個人 DM、Bot Framework `a:` 對話、OneDrive/SharePoint 共享檔案、Graph-backed chat ID 的媒體下載；接受 Bot Framework audience tokens；防止 feedback-learning 檔名衝突；長工具鏈保持 typing indicators；新增 SSO sign-in callbacks；注入 thread replies 的 parent context；cron 公告傳送至 Teams conversation ID
+- **解決問題**：Teams 媒體下載在多種情境下失敗的問題
+- **影響**：Teams 整合的媒體功能全面恢復正常
+
+```text
+┌──────────────────────┐
+│  Teams 媒體請求       │
+└────────┬─────────────┘
+         │
+    ┌────┴──────────────┐
+    │                   │
+    ▼                   ▼
+個人 DM              群組/頻道
+    │                   │
+    ▼                   ▼
+Bot Framework       Graph API
+audience token      chat ID 解析
+    │                   │
+    └────────┬──────────┘
+             │
+             ▼
+    ┌─────────────────┐
+    │  OneDrive/      │
+    │  SharePoint     │
+    │  下載路徑        │
+    └────────┬────────┘
+             │
+             ▼
+    ┌─────────────────┐
+    │  媒體成功傳遞    │
+    └─────────────────┘
+```
+
+### ⭐⭐⭐ Gateway 執行緒路由修復
+
+- **用途**：保留 Slack、Telegram、Mattermost、Matrix、ACP、restart-sentinel、agent announce 的傳遞目標，確保 subagent、cron、stream-relay、session fallback、restart 訊息回到原始執行緒/topic/room
+- **解決問題**：多平台訊息路由錯誤，訊息未能回到正確的對話執行緒
+- **影響**：多代理、cron 排程、串流中繼等場景的訊息路由可靠性大幅提升
+
+```text
+┌──────────────────┐
+│  Subagent/Cron   │
+│  訊息產生         │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  執行緒路由解析        │
+│  (保留原始 thread/    │
+│   topic/room 目標)    │
+└────────┬─────────────┘
+         │
+    ┌────┴──────────────────┐
+    │         │             │
+    ▼         ▼             ▼
+ Slack     Telegram      Matrix
+ thread    topic         room
+```


### PR DESCRIPTION
Closes #477

## Summary

Release notes for OpenClaw v2026.4.10 in zh-TW, following `release-notes/GUIDELINES.md`.

## Highlights covered

- ⭐⭐⭐ Active Memory Plugin (auto memory sub-agent before main reply)
- ⭐⭐⭐ Codex Provider & App-Server Harness
- ⭐⭐⭐ Browser/Sandbox SSRF hardening
- ⭐⭐⭐ Tools security hardening
- ⭐⭐⭐ Microsoft Teams media download fixes
- ⭐⭐⭐ Gateway thread routing fixes
- ⭐⭐⭐ WhatsApp reconnect stability
- All ⭐⭐⭐ items include ASCII flowcharts grounded in upstream source
- No breaking changes → 升級前必讀 section lists highlights only
