### PR TITLE
docs: add last_validated frontmatter to approval-first-workflow.md

### DIFF
--- a/docs/core/approval-first-workflow.md
+++ b/docs/core/approval-first-workflow.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-13
+validated_by: masami-agent
+---
+
 # Approval-first 工作流（個人 OpenClaw Agent）
 
 ## TL;DR


### PR DESCRIPTION
## Summary

Add required `last_validated` frontmatter to `docs/core/approval-first-workflow.md` as requested in #398.

## Changes

- Added YAML frontmatter with `last_validated: 2026-04-13` and `validated_by: masami-agent`

## Validation

- Reviewed the document content — the approval-first workflow principles and examples remain accurate and up-to-date
- No upstream changes affect the content of this document
- Structure (TL;DR / core concepts / how-to / examples / anti-patterns / troubleshooting / see also) is intact

Closes #398