### PR TITLE
docs: add back-link from exec howto to field notes troubleshooting companion

### DIFF
--- a/docs/howto/exec-strategy-patterns.md
+++ b/docs/howto/exec-strategy-patterns.md
@@ -286,3 +286,11 @@ B = 效率第一，但風險高
 C = 日常命令放行，危險操作保留閘門
 ```
 
+
+
+---
+
+## 延伸閱讀
+
+- **[exec 權限策略：實戰踩坑記錄（Field Notes）](../../usecases/exec-strategy-field-notes.md)**  
+  本篇的配套實戰記錄。如果你已讀完上方的策略框架，正在排查 `approval-timeout` 或 `allowlist miss` 的具體問題，這份 field notes 包含完整的兩層診斷路徑、排查死路記錄與 `openclaw sandbox explain` 的使用方式。


### PR DESCRIPTION
## Summary

Adds a cross-reference at the bottom of `docs/howto/exec-strategy-patterns.md` pointing to the field notes companion doc (`usecases/exec-strategy-field-notes.md`).

## Why

Promised as follow-up in PR #446 review response. The field notes doc is positioned as a troubleshooting companion to this howto — readers who hit `approval-timeout` or `allowlist miss` after reading the howto should have a clear path to the first-hand debugging record.

The reverse link (field notes → howto) already exists. This completes the bidirectional cross-reference.

## Change

- Added an "延伸閱讀" section at the end of the howto with a direct link and one-line description of when to use the field notes doc.