### PR TITLE
docs: validate resume-session-id and cron-delivery-migration (2026-04-20)

### DIFF
--- a/usecases/cron-delivery-migration.md
+++ b/usecases/cron-delivery-migration.md
@@ -1,5 +1,5 @@
 ---
-last_validated: 2026-04-02
+last_validated: 2026-04-20
 validated_by: wangyuyan-agent
 ---
 

--- a/usecases/resume-session-id.md
+++ b/usecases/resume-session-id.md
@@ -1,5 +1,5 @@
 ---
-last_validated: 2026-04-02
+last_validated: 2026-04-20
 validated_by: wangyuyan-agent
 ---
 


### PR DESCRIPTION
兩份文件驗證（2026-04-20）

檢視了 2026-04-02 至今的 release notes（v2026.4.2 ~ v2026.4.10），兩份文件涉及的功能均無 breaking change：

- `resume-session-id.md`：`resumeSessionId` / `session/load` 無相關變動，文件內容仍然準確
- `cron-delivery-migration.md`：`--announce` 路徑無變動，4/10 的 cron 時間戳修復（#63507）不影響 delivery 邏輯

僅更新 `last_validated` 為 2026-04-20。

Fixes: #485
Fixes: #486