### PR TITLE
release-notes: add OpenClaw v2026.4.20 notes

### DIFF
--- a/release-notes/2026-04-20.md
+++ b/release-notes/2026-04-20.md
@@ -1,0 +1,374 @@
+# OpenClaw v2026.4.20 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Cron runtime state 拆到 `jobs-state.json` ([#63105](https://github.com/openclaw/openclaw/pull/63105)) | 若你原本把 `jobs.json` 當成 runtime state 與 job definition 的混合來源，升級後 runtime execution state 會移到新檔案 | 若有 git-tracked cron 設定或自訂備份/同步腳本，確認它們同時理解 `jobs.json` 與 `jobs-state.json` 的新分工 |
+| owner / gateway / pairing / device 權限模型更嚴格 ([#69375](https://github.com/openclaw/openclaw/pull/69375), [#69373](https://github.com/openclaw/openclaw/pull/69373), [#69377](https://github.com/openclaw/openclaw/pull/69377)) | 某些過去能工作但實際過寬的配對、broadcast、config mutation 路徑，升級後可能被明確拒絕 | 升級後檢查 paired device、gateway broadcast consumer 與 agent-facing `gateway` tool 是否依賴過寬權限行為 |
+
+### 新功能亮點
+
+- **wizard / onboarding 體驗明顯改善**，包含更可掃描的安全提示、模型載入 spinner 與 API key placeholder ([#69553](https://github.com/openclaw/openclaw/pull/69553))
+- **tiered model pricing** 進入成本估算，並加入 Moonshot Kimi K2.6 / K2.5 預估成本 ([#67605](https://github.com/openclaw/openclaw/pull/67605))
+- **cron session backlog 防 OOM** 與 built-in cap / age prune 預設啟用 ([#69404](https://github.com/openclaw/openclaw/pull/69404))
+- **bundled Kimi 預設升到 `kimi-k2.6`**，並調整 thinking 行為 ([#69477](https://github.com/openclaw/openclaw/pull/69477), [#68816](https://github.com/openclaw/openclaw/pull/68816))
+- **Mattermost draft preview**、BlueBubbles group systemPrompt、plugin detached tasks 等能力持續擴充
+
+---
+
+## 概述
+
+### 功能更新 (Features)
+- ⭐⭐⭐ wizard / onboarding 介面與可掃描性改善 ([#69553](https://github.com/openclaw/openclaw/pull/69553))
+- ⭐⭐⭐ Sessions Maintenance 內建 cap / prune，避免 session backlog 在載入前先把 gateway 撐爆 ([#69404](https://github.com/openclaw/openclaw/pull/69404))
+- ⭐⭐ tiered model pricing 與 Moonshot Kimi 成本估算 ([#67605](https://github.com/openclaw/openclaw/pull/67605))
+- ⭐⭐ Cron execution state 拆到 `jobs-state.json` ([#63105](https://github.com/openclaw/openclaw/pull/63105))
+- ⭐⭐ bundled Kimi 預設對齊 `kimi-k2.6`，並補 thinking 行為控制 ([#69477](https://github.com/openclaw/openclaw/pull/69477), [#68816](https://github.com/openclaw/openclaw/pull/68816))
+- ⭐⭐ BlueBubbles groups 可注入 per-group `systemPrompt` ([#69198](https://github.com/openclaw/openclaw/pull/69198))
+- ⭐⭐ plugin executors 取得 detached task lifecycle contract ([#68915](https://github.com/openclaw/openclaw/pull/68915))
+- ⭐ Mattermost 以單一 draft preview 串流 thinking / tool activity / partial text ([#47838](https://github.com/openclaw/openclaw/pull/47838))
+- ⭐ Agents/compaction 可選擇送出 start / completion notices ([#67830](https://github.com/openclaw/openclaw/pull/67830))
+- ⭐ QA/CI 預設對失敗情境 fail fast，並新增 artifact-only 例外開關 ([#69122](https://github.com/openclaw/openclaw/pull/69122))
+
+### 安全性提升 (Security)
+- ⭐⭐⭐ paired-device session 只可看自己的 pairing list / approve / reject 操作 ([#69375](https://github.com/openclaw/openclaw/pull/69375))
+- ⭐⭐⭐ websocket broadcast events 改要求 `operator.read` 以上權限，未知事件預設也做 scope-gate ([#69373](https://github.com/openclaw/openclaw/pull/69373))
+- ⭐⭐⭐ agent-facing `gateway` tool 禁止 model-driven config mutation 改寫 operator-trusted paths ([#69377](https://github.com/openclaw/openclaw/pull/69377))
+- ⭐⭐ MCP stdio servers 封鎖 `NODE_OPTIONS` 等 interpreter-startup env keys ([#69540](https://github.com/openclaw/openclaw/pull/69540))
+- ⭐⭐ workspace `.env` 不再能偷偷注入任意 `OPENCLAW_*` runtime-control keys ([#473](https://github.com/openclaw/openclaw/pull/473))
+- ⭐⭐ QQBot direct-upload 路徑補 SSRF guard ([#69595](https://github.com/openclaw/openclaw/pull/69595))
+- ⭐⭐ gateway template-rendered mapping sessionKeys 補 allowRequestSessionKey gate ([#69381](https://github.com/openclaw/openclaw/pull/69381))
+- ⭐ fix(security) 移除 MINIMAX_API_HOST workspace env injection 路徑 ([#67300](https://github.com/openclaw/openclaw/pull/67300))
+
+### 錯誤修復 (Bug Fixes)
+- ⭐⭐⭐ `lossless-claw` 類第三方 context engine 的 `info.id` mismatch 不再被硬擋 ([#66678](https://github.com/openclaw/openclaw/pull/66678))
+- ⭐⭐⭐ packaged installs 會先修 bundled plugin runtime dependencies，降低「裝好了但 provider/channel 壞掉」機率 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
+- ⭐⭐ OpenAI Codex / Responses transport、reasoning payload、`/backend-api/codex` 路徑與 `/think off` 相容性修正 ([#45304](https://github.com/openclaw/openclaw/pull/45304), [#69336](https://github.com/openclaw/openclaw/pull/69336), [#61982](https://github.com/openclaw/openclaw/pull/61982))
+- ⭐⭐ `security=full` + `ask=off` 的 YOLO exec 恢復 direct interpreter stdin / heredoc 形式 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
+- ⭐⭐ Cron delivery / Telegram / pairing / TUI / startup 路徑大量穩定性修補 ([#69285](https://github.com/openclaw/openclaw/pull/69285), [#69587](https://github.com/openclaw/openclaw/pull/69587), [#69000](https://github.com/openclaw/openclaw/pull/69000), [#69431](https://github.com/openclaw/openclaw/pull/69431), [#69164](https://github.com/openclaw/openclaw/pull/69164), [#43392](https://github.com/openclaw/openclaw/pull/43392))
+- ⭐⭐ BlueBubbles 多條線修正，包括 timeout、typed client、reaction fallback、iMessage/SMS 偏好與 group/systemPrompt ([#69193](https://github.com/openclaw/openclaw/pull/69193), [#68234](https://github.com/openclaw/openclaw/pull/68234), [#64693](https://github.com/openclaw/openclaw/pull/64693), [#61781](https://github.com/openclaw/openclaw/pull/61781), [#69198](https://github.com/openclaw/openclaw/pull/69198))
+- ⭐⭐ Telegram / Slack / Matrix / Discord / Ollama / Active Memory / model selection 等整體穩定性提升 ([#68067](https://github.com/openclaw/openclaw/pull/68067), [#57737](https://github.com/openclaw/openclaw/pull/57737), [#50368](https://github.com/openclaw/openclaw/pull/50368), [#68954](https://github.com/openclaw/openclaw/pull/68954), [#68546](https://github.com/openclaw/openclaw/pull/68546), [#68570](https://github.com/openclaw/openclaw/pull/68570), [#68953](https://github.com/openclaw/openclaw/pull/68953), [#69370](https://github.com/openclaw/openclaw/pull/69370), [#69485](https://github.com/openclaw/openclaw/pull/69485), [#69365](https://github.com/openclaw/openclaw/pull/69365))
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ wizard / onboarding 介面體驗改善 ([#69553](https://github.com/openclaw/openclaw/pull/69553))
+- **用途**: 讓 setup security disclaimer、模型載入過程與 provider API key 輸入提示更容易閱讀與理解。
+- **解決問題**: onboarding wizard 先前在初始 model catalog load 期間可能看起來像空白頁，安全說明也不夠可掃描，容易讓新使用者卡住或忽略重點。
+- **影響**: 安裝與初始設定更順，尤其對第一次接觸 OpenClaw 的使用者更友善。
+
+```text
+┌──────────────────────────┐
+│ User enters setup wizard │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Show clearer warning banner   │
+│ and checklist-style guidance  │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Model catalog loads with      │
+│ visible spinner               │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ API key prompts now expose    │
+│ clearer placeholder guidance  │
+└───────────────────────────────┘
+```
+
+### ⭐⭐⭐ Sessions Maintenance 預設 cap / prune 防止 backlog OOM ([#69404](https://github.com/openclaw/openclaw/pull/69404))
+- **用途**: 對 sessions maintenance 預設啟用 built-in entry cap 與 age prune，並在 load time 先裁掉 oversized stores。
+- **解決問題**: 大量 cron / executor session backlog 可能在 write path 還沒來得及清理前，就先把 gateway 記憶體撐爆。
+- **影響**: 長期運行、cron-heavy 的部署更穩，尤其是 session store 容易累積的環境。
+
+```text
+┌──────────────────────────┐
+│ Gateway loads sessions   │
+│ store on startup         │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Check built-in entry caps     │
+│ and age-based prune rules     │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Oversized backlog is trimmed  │
+│ before normal write path runs │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Gateway avoids preload OOM    │
+│ from accumulated sessions     │
+└───────────────────────────────┘
+```
+
+### ⭐⭐ tiered model pricing 與 Kimi 成本估算 ([#67605](https://github.com/openclaw/openclaw/pull/67605))
+- **用途**: 讓 token-usage cost report 支援 tiered model pricing，並補上 bundled Moonshot Kimi K2.6 / K2.5 的估算。
+- **解決問題**: 原本成本估算對分層定價與新模型的覆蓋不夠完整。
+- **影響**: 成本追蹤更接近真實支出，對多 provider / 新模型使用者更有幫助。
+
+### ⭐⭐ Cron execution state 分離到 `jobs-state.json` ([#63105](https://github.com/openclaw/openclaw/pull/63105))
+- **用途**: 把 cron runtime execution state 從 `jobs.json` 拆出到 `jobs-state.json`。
+- **解決問題**: `jobs.json` 同時裝 definition 和 runtime noise，不利於 git-tracked job definitions 與人類閱讀。
+- **影響**: cron 設定與執行狀態邊界更清楚，也更容易做版本控管。
+
+### ⭐⭐ bundled Kimi 預設升級與 thinking 行為校正 ([#69477](https://github.com/openclaw/openclaw/pull/69477), [#68816](https://github.com/openclaw/openclaw/pull/68816))
+- **用途**: 將 bundled Moonshot setup / web search / media-understanding 對齊 `kimi-k2.6`，並允許 `thinking.keep = "all"` 僅在支援模型上生效。
+- **解決問題**: Kimi 預設與 thinking 行為若未對齊模型能力，容易出現不一致或隱性 fallback。
+- **影響**: Moonshot/Kimi 使用體驗更一致。
+
+### ⭐⭐ BlueBubbles groups 支援 per-group `systemPrompt` ([#69198](https://github.com/openclaw/openclaw/pull/69198))
+- **用途**: 將 group-specific behavioral instructions 注入每次 inbound context。
+- **解決問題**: 不同群組若有不同回覆規範，先前不容易在訊息層穩定套用。
+- **影響**: BlueBubbles 群聊客製行為更實用。
+
+### ⭐⭐ plugin detached tasks contract ([#68915](https://github.com/openclaw/openclaw/pull/68915))
+- **用途**: 讓 plugin executors 可以擁有 detached task lifecycle 與 cancellation。
+- **解決問題**: plugin 若要做 detached 任務，過去容易碰到 core task internals 邊界不清。
+- **影響**: plugin runtime 能力更完整。
+
+### ⭐ Mattermost draft preview 整合 thinking / tool activity / partial text ([#47838](https://github.com/openclaw/openclaw/pull/47838))
+- **用途**: 將串流中的 thinking、tool activity 與 partial text 聚合到單一 draft preview post。
+- **解決問題**: 分散更新容易讓使用者難以理解回覆進度。
+- **影響**: Mattermost 體驗更接近一致的 live reply。
+
+### ⭐ Agents/compaction notices ([#67830](https://github.com/openclaw/openclaw/pull/67830))
+- **用途**: 在 context compaction 開始與完成時送出 opt-in notice。
+- **解決問題**: 長對話 compaction 有時像黑箱，使用者不清楚系統正在做什麼。
+- **影響**: 提升可觀察性。
+
+### ⭐ QA/CI fail-fast 與 `--allow-failures` ([#69122](https://github.com/openclaw/openclaw/pull/69122))
+- **用途**: 讓 QA suite 預設在 scenario fail 時直接報失敗，另保留 artifact-only run 開關。
+- **解決問題**: CI 若預設容忍失敗，容易把真實問題埋掉。
+- **影響**: 自動化驗證更可靠。
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ paired-device sessions 權限收斂到自己的 pairing actions ([#69375](https://github.com/openclaw/openclaw/pull/69375))
+- **用途**: 限制 non-admin device-token session 只能看到並處理自己的 pairing list / approve / reject action。
+- **解決問題**: 先前 paired device 若能枚舉其他裝置或批准別人的 pairing request，等於把設備配對邊界放得太寬。
+- **影響**: device pairing 權限模型更符合最小權限原則。
+
+```text
+┌──────────────────────────┐
+│ Paired device session    │
+│ requests pairing action  │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Check whether request belongs │
+│ to this device's own scope    │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ If action targets another     │
+│ device's pairing flow         │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Reject access unless session  │
+│ is admin / shared-secret      │
+└───────────────────────────────┘
+```
+
+### ⭐⭐⭐ websocket broadcast events 需要 `operator.read` 以上 ([#69373](https://github.com/openclaw/openclaw/pull/69373))
+- **用途**: 對 chat / agent / tool-result broadcast event frame 強制要求 `operator.read` 或更高權限。
+- **解決問題**: pairing-scoped 或 node-role session 不應被動收到 session chat content。
+- **影響**: 降低被動資料外溢風險，也讓未知事件預設更保守。
+
+```text
+┌──────────────────────────┐
+│ Gateway prepares         │
+│ broadcast event frame    │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Determine event type and      │
+│ required scope                │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Client lacks operator.read    │
+│ or stronger                   │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Do not deliver chat / agent / │
+│ tool-result broadcast         │
+└───────────────────────────────┘
+```
+
+### ⭐⭐⭐ agent-facing `gateway` tool config mutation guard 擴大 ([#69377](https://github.com/openclaw/openclaw/pull/69377))
+- **用途**: 防止 model-driven `config.patch` / `config.apply` 改寫 sandbox、plugin trust、gateway auth/TLS、hook routing、MCP server、filesystem hardening 等 operator-trusted paths。
+- **解決問題**: 即使有 config mutation guard，若 per-agent override 或 trusted path 邊界漏掉，仍可能讓模型繞過操作員預期。
+- **影響**: 這是非常關鍵的 guardrail，能實際降低 agent 改寫高風險系統設定的機會。
+
+```text
+┌──────────────────────────┐
+│ Agent calls gateway tool │
+│ with config mutation     │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Inspect patch/apply target    │
+│ paths and nested overrides    │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Path touches operator-trusted │
+│ config surface                │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Reject mutation instead of    │
+│ letting model rewrite guard   │
+└───────────────────────────────┘
+```
+
+### ⭐⭐ MCP stdio server env keys guard ([#69540](https://github.com/openclaw/openclaw/pull/69540))
+- **用途**: 封鎖 `NODE_OPTIONS` 等 interpreter-startup env keys，但保留一般 credential / proxy env vars。
+- **解決問題**: 啟動層 env key 若不受控，會成為 stdio server 注入點。
+- **影響**: MCP 啟動面更安全。
+
+### ⭐⭐ workspace `.env` fail closed for `OPENCLAW_*` ([#473](https://github.com/openclaw/openclaw/pull/473))
+- **用途**: 阻止 untrusted workspace `.env` 注入任何 `OPENCLAW_*` runtime-control 變數。
+- **解決問題**: 新增 runtime-control 變數時，若沿用寬鬆 env 載入會有 silent inheritance 風險。
+- **影響**: workspace-local env 對核心行為的影響更受控。
+
+### ⭐⭐ QQBot upload SSRF guard ([#69595](https://github.com/openclaw/openclaw/pull/69595))
+- **用途**: 替 direct-upload URL path 加 SSRF guard。
+- **解決問題**: 上傳路徑若沒 guard，會成為網路探測或內部位址打點入口。
+- **影響**: QQBot upload surface 更安全。
+
+### ⭐⭐ allowRequestSessionKey gate 補進 template-rendered mapping sessionKeys ([#69381](https://github.com/openclaw/openclaw/pull/69381))
+- **用途**: 將 request sessionKey gate 一致套到 template-rendered mapping path。
+- **解決問題**: 若某條映射路徑沒檢查 sessionKey gate，就可能形成繞過。
+- **影響**: gateway sessionKey 邊界更一致。
+
+### ⭐ MINIMAX_API_HOST env injection 路徑移除 ([#67300](https://github.com/openclaw/openclaw/pull/67300))
+- **用途**: 阻止 workspace env 影響 MINIMAX_API_HOST 路由。
+- **解決問題**: env-driven URL routing 會讓 provider network path 更難受控。
+- **影響**: 降低非預期路由風險。
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ 第三方 context engine `info.id` mismatch 不再反覆炸 lane ([#66678](https://github.com/openclaw/openclaw/pull/66678))
+- **用途**: 放寬 strict-match contract，允許第三方 context engine 的 `info.id` 與註冊 slot id 不同。
+- **解決問題**: 2026.4.14 的 strict-match 變更直接打壞 `lossless-claw` 等 plugin，每個 turn 都可能報 `info.id must match registered id`。
+- **影響**: 對使用外部 context engine plugin 的人是實打實的救火修正。
+
+```text
+┌──────────────────────────┐
+│ Third-party context      │
+│ engine is registered     │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Runtime resolves engine and   │
+│ sees differing info.id        │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Old behavior: reject engine   │
+│ and fail every turn           │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ New behavior: allow valid     │
+│ third-party engine to proceed │
+└───────────────────────────────┘
+```
+
+### ⭐⭐⭐ packaged installs 先修 bundled plugin runtime deps ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
+- **用途**: 在 import 前先 repair active / default-enabled bundled plugin runtime dependencies。
+- **解決問題**: packaged install 常出現 core 裝好了，但 Discord / WhatsApp / Slack / Telegram / provider plugin 的 runtime tree 沒齊，導致一開機就壞。
+- **影響**: 安裝後可用性更高，也降低新手遇到 provider / channel 立刻壞掉的挫折感。
+
+```text
+┌──────────────────────────┐
+│ Packaged install starts  │
+│ bundled plugin load      │
+└──────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Check active/default-enabled  │
+│ plugin runtime dependencies   │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Repair missing deps inside    │
+│ each plugin runtime dir       │
+└───────────────────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ Import plugin after runtime   │
+│ tree is actually complete     │
+└───────────────────────────────┘
+```
+
+### ⭐⭐ OpenAI Codex / Responses 路徑與 reasoning 相容性修正 ([#45304](https://github.com/openclaw/openclaw/pull/45304), [#69336](https://github.com/openclaw/openclaw/pull/69336), [#61982](https://github.com/openclaw/openclaw/pull/61982))
+- **用途**: 校正 legacy transport override、ChatGPT/Codex OAuth Responses endpoint，並在 `/think off` 時移除不支援的 reasoning payload。
+- **解決問題**: Codex / GPT reasoning 路徑稍有不一致就會造成錯誤 transport、無效 payload 或相容性問題。
+- **影響**: OpenAI Codex / Responses 路徑更穩。
+
+### ⭐⭐ `security=full` + `ask=off` YOLO exec 恢復 direct interpreter stdin / heredoc ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
+- **用途**: 修正 promptless YOLO exec 在特定 preflight hardening 路徑下被誤拒的問題。
+- **解決問題**: 像 `node <<'NODE' ... NODE` 這類形式先前會被錯殺。
+- **影響**: 自動化 / power-user shell 流程恢復可用。
+
+### ⭐⭐ Cron / Telegram / pairing / TUI / startup 路徑穩定性補強 ([#69285](https://github.com/openclaw/openclaw/pull/69285), [#69587](https://github.com/openclaw/openclaw/pull/69587), [#69000](https://github.com/openclaw/openclaw/pull/69000), [#69431](https://github.com/openclaw/openclaw/pull/69431), [#69164](https://github.com/openclaw/openclaw/pull/69164), [#43392](https://github.com/openclaw/openclaw/pull/43392))
+- **用途**: 修正 no-delivery cron false failures、isolated delivery tool availability、Telegram direct-delivery dedupe、local pairing 決策與 gateway startup/TUI reconnect race。
+- **解決問題**: 這些邊界 bug 很容易讓使用者覺得 cron 或連線系統「偶爾怪怪的」。
+- **影響**: 多條控制面路徑更穩。
+
+### ⭐⭐ BlueBubbles 全面穩定性提升 ([#69193](https://github.com/openclaw/openclaw/pull/69193), [#68234](https://github.com/openclaw/openclaw/pull/68234), [#64693](https://github.com/openclaw/openclaw/pull/64693), [#61781](https://github.com/openclaw/openclaw/pull/61781), [#69198](https://github.com/openclaw/openclaw/pull/69198))
+- **用途**: 調高 outbound timeout、typed client 化、reaction fallback、iMessage over SMS 偏好與 per-group prompt。
+- **解決問題**: BlueBubbles 在 timeout、localhost/private-IP、tapback vocabulary 與收件路徑選擇上有很多真實世界邊界問題。
+- **影響**: iMessage/BlueBubbles 使用體驗大幅穩定。
+
+### ⭐⭐ 多通道 / provider / memory / model-selection 路徑修補 ([#68067](https://github.com/openclaw/openclaw/pull/68067), [#57737](https://github.com/openclaw/openclaw/pull/57737), [#50368](https://github.com/openclaw/openclaw/pull/50368), [#68954](https://github.com/openclaw/openclaw/pull/68954), [#68546](https://github.com/openclaw/openclaw/pull/68546), [#68570](https://github.com/openclaw/openclaw/pull/68570), [#68953](https://github.com/openclaw/openclaw/pull/68953), [#69370](https://github.com/openclaw/openclaw/pull/69370), [#69485](https://github.com/openclaw/openclaw/pull/69485), [#69365](https://github.com/openclaw/openclaw/pull/69365))
+- **用途**: 修補 reactions lifecycle、polling watchdog、Slack unresolved SecretRef、Matrix allowlists/commands、Discord partial channel metadata、Ollama defaults、memory recall failure fallback 與 transient auto-failover override 清理。
+- **解決問題**: 各條路各有小 bug，但都會在實際部署裡造成摩擦。
+- **影響**: 整體使用體驗更平滑。
+
+## Summary Table
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 2 | 5 | 3 | onboarding、session maintenance、cron state、Kimi、pricing 與 plugin tasks 都有實質進展 |
+| 安全性 | 3 | 4 | 1 | pairing、broadcast、gateway config mutation guard 與多條 env / SSRF / sessionKey 邊界同步收緊 |
+| 錯誤修復 | 2 | 4 | 0 | context engine、packaged install、Codex/Responses、cron、BlueBubbles 與多通道穩定性大量改善 |
+| **總計** | **7** | **13** | **4** | **這是一版內容很厚的穩定化更新，兼具 onboarding、session/cron 可維運性與多條高風險邊界收斂** |
+
+**發佈日期**: 2026-04-20
+**版本**: 2026.4.20
+**狀態**: Production Ready
+**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.4.20


### PR DESCRIPTION
## Summary
- add zh-TW release notes for OpenClaw v2026.4.20
- cover major onboarding, sessions-maintenance, cron-state, and Kimi changes
- summarize the most important security and stability fixes across pairing, gateway, cron, Codex, and BlueBubbles

## Why
OpenClaw v2026.4.20 is a dense release with several operator-visible changes and a large number of important fixes, so it is worth documenting in a structured zh-TW summary for claw-info readers.

Fixes #488