### PR TITLE
docs: add zh-TW release notes for OpenClaw v2026.4.21

### DIFF
--- a/release-notes/2026-04-21.md
+++ b/release-notes/2026-04-21.md
@@ -1,0 +1,143 @@
+# OpenClaw v2026.4.21 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.21)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Owner-enforced commands 授權收緊 ([#69774](https://github.com/openclaw/openclaw/pull/69774)) | 當 `enforceOwnerForCommands=true` 且未設定 `commands.ownerAllowFrom` 時，wildcard channel `allowFrom` 或空 owner-candidate 清單不再隱含 owner 授權，非 owner sender 將被拒絕 | 若需讓特定 sender 存取 owner-only 指令，請明確設定 `commands.ownerAllowFrom` 或使用 `operator.admin` scope |
+
+### 新功能亮點
+
+- **gpt-image-2 預設化** — bundled 圖片生成 provider 預設切換至 `gpt-image-2`，並支援 2K/4K 尺寸提示
+- **Owner 指令授權強化** — 修補 wildcard allowlist 繞過 owner-only 指令的安全漏洞
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐ gpt-image-2 預設化：bundled 圖片生成 provider 預設切換至 `gpt-image-2`，文件與工具 metadata 新增 2K/4K 尺寸提示
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Owner-enforced commands 授權修復：要求實際 owner 身份匹配或 `operator.admin` scope，防止非 owner 透過 wildcard allowlist 繞過 owner-only 指令 ([#69774](https://github.com/openclaw/openclaw/pull/69774))
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐ Plugins/doctor 依賴修復：修復 bundled plugin runtime 依賴路徑，讓打包安裝可恢復缺失的 channel/provider 依賴
+- ⭐⭐ 圖片生成失敗日誌：provider/model 候選失敗時以 warn 層級記錄，即使後續 provider 成功也能在 gateway log 中看到失敗原因
+- ⭐⭐ Slack 執行緒別名保留：outbound sends 保留 thread aliases，確保帶有 `threadTs` 的訊息留在正確的 Slack 執行緒 ([#62947](https://github.com/openclaw/openclaw/pull/62947))
+- ⭐ Browser accessibility ref 驗證：無效的 `ax<N>` ref 立即拒絕，不再等待 browser action timeout ([#69924](https://github.com/openclaw/openclaw/pull/69924))
+- ⭐ npm node-domexception override：在 root `package.json` `overrides` 中鏡像 `node-domexception` alias，消除 deprecated 依賴鏈警告
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐ gpt-image-2 預設化
+
+- **用途**：將 bundled 圖片生成 provider 預設切換至 `gpt-image-2`，並在文件與工具 metadata 中新增 2K/4K OpenAI 尺寸提示
+- **解決問題**：舊版預設使用較早的圖片生成模型，使用者無法直接使用最新的 `gpt-image-2` 及其高解析度選項
+- **影響**：開箱即用即可使用 `gpt-image-2`；文件與 tool metadata 明確標示 2K/4K 尺寸選項，提升圖片生成的 DX
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Owner-enforced commands 授權修復 ([#69774](https://github.com/openclaw/openclaw/pull/69774))
+
+- **用途**：收緊 `resolveCommandAuthorization` 的 owner 驗證邏輯，要求實際的 owner-candidate 匹配或內部 `operator.admin` scope
+- **解決問題**：當 plugin 啟用 `enforceOwnerForCommands=true` 但未設定 `commands.ownerAllowFrom` 時，wildcard channel `allowFrom`（`["*"]`）或空的 owner-candidate 清單會被錯誤地視為 owner 授權通過，導致非 owner sender 可觸及 owner-only 指令
+- **影響**：關閉權限提升漏洞；已有明確 `commands.ownerAllowFrom` 設定或使用 `operator.admin` 的部署不受影響
+
+```text
+┌──────────────────────────┐
+│  收到指令請求              │
+│  (enforceOwnerForCommands │
+│   = true)                 │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│  resolveCommandAuth      │
+│  檢查 sender 身份         │
+└────────────┬─────────────┘
+             │
+        ┌────┴────┐
+        │         │
+        ▼         ▼
+  owner 匹配   operator.admin
+  candidate?   scope?
+        │         │
+   ┌────┴────┐    │
+   │         │    │
+   ▼         ▼    ▼
+  Yes       No   Yes
+   │         │    │
+   ▼         │    ▼
+ ✅ 授權     │  ✅ 授權
+             │
+             ▼
+   ┌─────────────────┐
+   │ ❌ 拒絕          │
+   │ (wildcard/空清單  │
+   │  不再隱含 owner) │
+   └─────────────────┘
+```
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐ Plugins/doctor 依賴修復
+
+- **用途**：修復 bundled plugin 的 doctor 路徑，使其能正確解析 runtime 依賴
+- **解決問題**：打包安裝（packaged installs）在缺失 channel/provider 依賴時，doctor 無法正確恢復，需要安裝大量不相關的 core 依賴
+- **影響**：打包安裝的依賴恢復更精準，不再需要廣泛的 core 依賴安裝
+
+### ⭐⭐ 圖片生成失敗日誌改善
+
+- **用途**：在自動 provider fallback 前，以 warn 層級記錄失敗的 provider/model 候選
+- **解決問題**：當 OpenAI 圖片生成失敗但後續 provider 成功時，失敗原因在 gateway log 中不可見，增加除錯難度
+- **影響**：即使 fallback 成功，管理員也能在日誌中追蹤到哪個 provider 失敗及原因
+
+### ⭐⭐ Slack 執行緒別名保留 ([#62947](https://github.com/openclaw/openclaw/pull/62947))
+
+- **用途**：在 runtime outbound sends 中保留 thread aliases，確保帶有 `threadTs` 的 generic runtime sends 留在正確的 Slack 執行緒
+- **解決問題**：caller 提供 `threadTs` 時，outbound 訊息未正確路由至指定的 Slack thread
+- **影響**：Slack 整合中的執行緒訊息路由恢復正常，對話脈絡不再斷裂
+
+### ⭐ Browser accessibility ref 驗證 ([#69924](https://github.com/openclaw/openclaw/pull/69924))
+
+- **用途**：在 act paths 中立即拒絕無效的 `ax<N>` accessibility refs
+- **解決問題**：無效的 accessibility ref 會等到 browser action timeout 才失敗，浪費時間
+- **影響**：無效 ref 快速失敗，提升瀏覽器自動化的回應速度
+
+### ⭐ npm node-domexception override
+
+- **用途**：在 root `package.json` `overrides` 中鏡像 `node-domexception` alias
+- **解決問題**：npm install 時會出現 deprecated `google-auth-library → gaxios → node-fetch → fetch-blob → node-domexception` 依賴鏈警告
+- **影響**：消除安裝時的 deprecated 依賴警告，保持乾淨的安裝輸出
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 0 | 1 | 0 | gpt-image-2 預設化與 2K/4K 尺寸提示 |
+| 安全性 | 1 | 0 | 0 | Owner-enforced commands 授權漏洞修復 |
+| 錯誤修復 | 0 | 3 | 2 | Plugin doctor、圖片生成日誌、Slack 執行緒、browser ref、npm 依賴 |
+| **總計** | **1** | **4** | **2** | **7 項變更** |
+
+---
+
+**發佈日期**: 2026-04-21
+**版本**: 2026.4.21
+**狀態**: Production Ready
+**GitHub Release**: [v2026.4.21](https://github.com/openclaw/openclaw/releases/tag/v2026.4.21)


### PR DESCRIPTION
## Summary

新增 OpenClaw v2026.4.21 的 zh-TW 版本發佈說明。

## 內容

- **1 項安全性修復** (⭐⭐⭐): Owner-enforced commands 授權漏洞修復 ([#69774](https://github.com/openclaw/openclaw/pull/69774))
- **1 項功能更新** (⭐⭐): gpt-image-2 預設化與 2K/4K 尺寸提示
- **5 項錯誤修復**: Plugin doctor 依賴、圖片生成日誌、Slack 執行緒、browser ref 驗證、npm 依賴

## Checklist

- [x] GitHub release page reviewed
- [x] 升級前必讀 section included (auth breaking change)
- [x] All ⭐⭐⭐ breaking changes in Breaking Changes table
- [x] All items include star ratings, sorted descending
- [x] All items include PR/Issue numbers (or release link)
- [x] All items have 用途/解決問題/影響
- [x] All ⭐⭐⭐ items include ASCII flowchart
- [x] Overview items appear in detailed sections
- [x] Summary table completed
- [x] GitHub release link included
- [x] Professional tone, no persona language

Closes #489