### PR TITLE
docs: add release notes for OpenClaw v2026.4.15 (zh-TW)

### DIFF
--- a/release-notes/2026-04-15.md
+++ b/release-notes/2026-04-15.md
@@ -1,0 +1,576 @@
+# OpenClaw v2026.4.15 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.15)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Dreaming 儲存模式預設改為 `separate` | 夢境階段區塊不再寫入 `memory/YYYY-MM-DD.md`，改存至 `memory/dreaming/{phase}/` | 若需舊行為，設定 `plugins.entries.memory-core.config.dreaming.storage.mode: "inline"` |
+| Gateway 工具名稱碰撞拒絕 | 客戶端工具名稱若與內建工具正規化碰撞，將回傳 `400 invalid_request_error` | 檢查自訂工具名稱是否與內建工具重複，重新命名衝突項目 |
+| Skills snapshot 版本失效 | 修改 `skills.*` 設定後，舊 session 的 skillsSnapshot 會被強制刷新 | 無需手動操作，但升級後既有 session 可能重新載入 skills |
+
+### 新功能亮點
+
+- **Google TTS**：Gemini 文字轉語音支援，含語音選擇與 WAV/PCM 輸出
+- **Model Auth 狀態卡**：Control UI 新增 OAuth token 健康度與 rate-limit 壓力一覽
+- **LanceDB 雲端儲存**：memory-lancedb 支援遠端物件儲存，不再限於本地磁碟
+- **GitHub Copilot Embedding**：記憶搜尋新增 Copilot embedding provider
+- **本地模型精簡模式**：`localModelLean: true` 減少弱模型的預設工具與 prompt 大小
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ Dreaming 儲存模式改為 `separate`，日常記憶檔不再被夢境區塊佔據 ([#66412](https://github.com/openclaw/openclaw/pull/66412))
+- ⭐⭐⭐ Gateway 工具名稱碰撞防護，拒絕與內建工具正規化碰撞的客戶端工具 ([#67303](https://github.com/openclaw/openclaw/pull/67303))
+- ⭐⭐ Google TTS：Gemini 文字轉語音，含語音選擇與 WAV/PCM 輸出 ([#67515](https://github.com/openclaw/openclaw/pull/67515))
+- ⭐⭐ Control UI Model Auth 狀態卡：OAuth token 健康度與 rate-limit 壓力一覽 ([#66211](https://github.com/openclaw/openclaw/pull/66211))
+- ⭐⭐ Memory/LanceDB 雲端儲存支援 ([#63502](https://github.com/openclaw/openclaw/pull/63502))
+- ⭐⭐ GitHub Copilot embedding provider 用於記憶搜尋 ([#61718](https://github.com/openclaw/openclaw/pull/61718))
+- ⭐⭐ Agents 本地模型精簡模式 `localModelLean: true` ([#66495](https://github.com/openclaw/openclaw/pull/66495))
+- ⭐ Anthropic/models 預設選擇與 `opus` 別名更新
+- ⭐ Packaging/plugins 精簡：bundled plugin runtime deps 本地化 ([#67099](https://github.com/openclaw/openclaw/pull/67099))
+- ⭐ QA/Matrix 拆分為獨立 `qa-matrix` runner ([#66723](https://github.com/openclaw/openclaw/pull/66723))
+- ⭐ Docs/showcase 改版：hero、section jump links、響應式影片格 ([#48493](https://github.com/openclaw/openclaw/pull/48493))
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Gateway 工具信任錨定：`MEDIA:` passthrough 僅限當次註冊的內建工具原始名稱 ([#67303](https://github.com/openclaw/openclaw/pull/67303))
+- ⭐⭐⭐ Exec 核准提示中的密鑰遮蔽 ([#61077](https://github.com/openclaw/openclaw/issues/61077), [#64790](https://github.com/openclaw/openclaw/pull/64790))
+- ⭐⭐⭐ Workspace 檔案操作透過 `fs-safe` 路由，拒絕 symlink 別名 ([#66636](https://github.com/openclaw/openclaw/pull/66636))
+- ⭐⭐⭐ MCP loopback bearer 改用 constant-time 比對，拒絕非 loopback 瀏覽器請求 ([#66665](https://github.com/openclaw/openclaw/pull/66665))
+- ⭐⭐⭐ Gateway bearer 每次請求重新解析，secret 輪換即時生效 ([#66651](https://github.com/openclaw/openclaw/pull/66651))
+- ⭐⭐ Webchat 音訊嵌入路徑強制 localRoots 限制 ([#67298](https://github.com/openclaw/openclaw/pull/67298))
+- ⭐⭐ Matrix DM pairing-store 不再授權 room control 指令 ([#67294](https://github.com/openclaw/openclaw/pull/67294))
+- ⭐⭐ Feishu webhook 強化：缺少 `encryptKey` 拒絕啟動，空白 token 拒絕 ([#66707](https://github.com/openclaw/openclaw/pull/66707))
+- ⭐⭐ Memory QMD `memory_get` 限制只讀取正規記憶檔案 ([#66026](https://github.com/openclaw/openclaw/pull/66026))
+- ⭐⭐ Webchat 拒絕遠端 `file://` URL 媒體嵌入 ([#67293](https://github.com/openclaw/openclaw/pull/67293))
+- ⭐ CLI plugin `--dangerously-force-unsafe-install` 不再 fallback 至 hook-pack ([#58909](https://github.com/openclaw/openclaw/pull/58909))
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Skills snapshot 版本失效修復：設定變更後強制刷新，避免 "Tool not found" 迴圈 ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+- ⭐⭐⭐ Unknown-tool stream guard 預設啟用，防止幻覺工具無限迴圈 ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+- ⭐⭐⭐ Gateway 啟動 SIGUSR1 重啟迴圈修復 ([#67557](https://github.com/openclaw/openclaw/pull/67557))
+- ⭐⭐ BlueBubbles catchup 新增 per-message retry 上限與持久化 GUID 去重 ([#67426](https://github.com/openclaw/openclaw/pull/67426), [#66816](https://github.com/openclaw/openclaw/pull/66816))
+- ⭐⭐ Ollama chat 修復 `ollama/` prefix 導致 404 ([#67457](https://github.com/openclaw/openclaw/pull/67457))
+- ⭐⭐ WhatsApp 重連 auth bootstrap race 修復 ([#67464](https://github.com/openclaw/openclaw/pull/67464))
+- ⭐⭐ TUI streaming watchdog：30s 無 delta 自動重置為 idle ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+- ⭐⭐ Agents failover：HTML error pages 正確分類為上游傳輸失敗 ([#67642](https://github.com/openclaw/openclaw/pull/67642))
+- ⭐⭐ OpenAI Codex 模型正規化：stale transport metadata 自動修復 ([#67635](https://github.com/openclaw/openclaw/pull/67635))
+- ⭐⭐ Agents replay：Anthropic 相容 provider 不再收到畸形 tool-result ID ([#67620](https://github.com/openclaw/openclaw/pull/67620))
+- ⭐ Docker build 修復 pnpm v10+ virtual-store layout ([#67143](https://github.com/openclaw/openclaw/pull/67143))
+- ⭐ Matrix E2EE 無密碼 token-auth bot 啟動修復 ([#66228](https://github.com/openclaw/openclaw/pull/66228))
+- ⭐ Cron announce `NO_REPLY` 洩漏修復 ([#65004](https://github.com/openclaw/openclaw/pull/65004), [#65016](https://github.com/openclaw/openclaw/pull/65016))
+- ⭐ Discord tool-call text 清理 Gemma-style `<function>` payload ([#67318](https://github.com/openclaw/openclaw/pull/67318))
+- ⭐ Dashboard exec approval modal overflow 修復 ([#67082](https://github.com/openclaw/openclaw/pull/67082))
+- ⭐ CLI/configure stale-hash race 修復 ([#64188](https://github.com/openclaw/openclaw/issues/64188), [#66528](https://github.com/openclaw/openclaw/pull/66528))
+- ⭐ Agents compaction 小 context window 模型不再觸發無限迴圈 ([#65671](https://github.com/openclaw/openclaw/pull/65671))
+- ⭐ OpenRouter Qwen3 reasoning_details 解析修復 ([#66905](https://github.com/openclaw/openclaw/pull/66905))
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Dreaming 儲存模式預設改為 `separate` ([#66412](https://github.com/openclaw/openclaw/pull/66412))
+
+- **用途**：將 `dreaming.storage.mode` 預設值從 `inline` 改為 `separate`，夢境階段區塊存至 `memory/dreaming/{phase}/YYYY-MM-DD.md`
+- **解決問題**：日常記憶檔 `memory/YYYY-MM-DD.md` 被大量夢境結構化輸出佔據，每日掃描器需與數百行 phase-block 競爭
+- **影響**：日常記憶檔更乾淨，掃描效率提升。需舊行為者可設定 `plugins.entries.memory-core.config.dreaming.storage.mode: "inline"`。**此為 Breaking Change**
+
+```text
+┌─────────────────────────┐
+│  Dreaming 階段產出       │
+│  (Light Sleep / REM)    │
+└───────────┬─────────────┘
+            │
+      ┌─────┴──────┐
+      │ mode?      │
+      └─────┬──────┘
+       ┌────┴────┐
+       │         │
+       ▼         ▼
+  "separate"   "inline"
+  (新預設)     (舊行為)
+       │         │
+       ▼         ▼
+┌────────────┐ ┌──────────────────┐
+│ memory/    │ │ memory/          │
+│ dreaming/  │ │ YYYY-MM-DD.md    │
+│ {phase}/   │ │ (混合日常+夢境)   │
+│ YYYY-MM-DD │ └──────────────────┘
+│ .md        │
+└────────────┘
+```
+
+### ⭐⭐⭐ Gateway 工具名稱碰撞防護 ([#67303](https://github.com/openclaw/openclaw/pull/67303))
+
+- **用途**：錨定 `MEDIA:` tool-result passthrough 於當次註冊的內建工具原始名稱，拒絕名稱正規化碰撞的客戶端工具定義
+- **解決問題**：客戶端工具若命名類似內建工具，可繼承其 local-media 信任權限
+- **影響**：JSON 與 SSE 路徑均回傳 `400 invalid_request_error`，消除工具名稱偽裝攻擊向量。**此為 Breaking Change**
+
+```text
+┌──────────────────────┐
+│  客戶端工具定義        │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  名稱正規化碰撞檢查       │
+│  • vs 內建工具            │
+│  • vs 同請求其他客戶端工具 │
+└──────────┬───────────────┘
+           │
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+   無碰撞     碰撞偵測
+      │         │
+      ▼         ▼
+   正常處理   400 invalid_
+              request_error
+```
+
+### ⭐⭐ Google TTS：Gemini 文字轉語音 ([#67515](https://github.com/openclaw/openclaw/pull/67515))
+
+- **用途**：在 bundled `google` plugin 中新增 Gemini TTS 支援，含 provider 註冊、語音選擇、WAV 回覆輸出與 PCM 電話輸出
+- **解決問題**：Google 生態系使用者缺乏原生 TTS 整合
+- **影響**：新增語音合成選項，支援多種輸出格式
+
+### ⭐⭐ Control UI Model Auth 狀態卡 ([#66211](https://github.com/openclaw/openclaw/pull/66211))
+
+- **用途**：Overview 頁面新增 Model Auth 狀態卡，顯示 OAuth token 健康度與 provider rate-limit 壓力，token 即將過期時顯示注意提示
+- **解決問題**：使用者無法快速掌握 OAuth token 狀態與 provider 限流情況
+- **影響**：透過 `models.authStatus` gateway method（去除憑證、60s 快取）即時掌握認證狀態
+
+### ⭐⭐ Memory/LanceDB 雲端儲存 ([#63502](https://github.com/openclaw/openclaw/pull/63502))
+
+- **用途**：`memory-lancedb` 新增雲端儲存支援，持久化記憶索引可運行於遠端物件儲存
+- **解決問題**：記憶索引僅限本地磁碟，無法跨機器共享或持久化
+- **影響**：支援遠端物件儲存後端，適合多節點或雲端部署場景
+
+### ⭐⭐ GitHub Copilot Embedding Provider ([#61718](https://github.com/openclaw/openclaw/pull/61718))
+
+- **用途**：新增 GitHub Copilot embedding provider 用於記憶搜尋，並提供專用 Copilot embedding host helper
+- **解決問題**：plugin 需自行處理 Copilot transport、token refresh 與 payload 驗證
+- **影響**：plugin 可重用 transport 並遵循遠端覆寫與安全驗證
+
+### ⭐⭐ Agents 本地模型精簡模式 ([#66495](https://github.com/openclaw/openclaw/pull/66495))
+
+- **用途**：新增實驗性 `agents.defaults.experimental.localModelLean: true`，移除 `browser`、`cron`、`message` 等重量級預設工具
+- **解決問題**：弱本地模型的 prompt 過大，影響回應品質
+- **影響**：減少 prompt 大小，不影響正常路徑
+
+### ⭐ Anthropic/Models 預設更新
+
+- **用途**：更新 Anthropic 預設選擇、`opus` 別名、Claude CLI 預設值，bundled image understanding 指向 Claude Opus 4.7
+- **解決問題**：預設模型選擇未跟上最新 Anthropic 模型
+- **影響**：開箱即用體驗更佳
+
+### ⭐ Packaging/Plugins 精簡 ([#67099](https://github.com/openclaw/openclaw/pull/67099))
+
+- **用途**：將 bundled plugin runtime deps 本地化至所屬 extension，精簡 docs payload，收緊安裝/package-manager 護欄
+- **解決問題**：core 攜帶 extension 擁有的 runtime 依賴，發佈包過大
+- **影響**：發佈包更精簡，core 不再承擔 extension 的 runtime 負擔
+
+### ⭐ QA/Matrix 拆分 ([#66723](https://github.com/openclaw/openclaw/pull/66723))
+
+- **用途**：將 Matrix live QA 拆分為 source-linked `qa-matrix` runner，repo-private `qa-*` 不進入發佈包
+- **解決問題**：QA 測試資源混入發佈包
+- **影響**：發佈包更乾淨
+
+### ⭐ Docs/Showcase 改版 ([#48493](https://github.com/openclaw/openclaw/pull/48493))
+
+- **用途**：新增可掃描 hero、完整 section jump links、響應式社群範例影片格
+- **解決問題**：文件首頁缺乏視覺引導與社群範例展示
+- **影響**：文件瀏覽體驗提升
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Gateway 工具信任錨定與碰撞拒絕 ([#67303](https://github.com/openclaw/openclaw/pull/67303))
+
+- **用途**：`MEDIA:` tool-result passthrough 僅信任當次註冊的內建工具原始名稱，拒絕名稱碰撞的客戶端工具
+- **解決問題**：客戶端工具可透過命名偽裝繼承內建工具的 local-media 信任
+- **影響**：消除工具名稱偽裝攻擊向量，JSON/SSE 雙路徑均受保護
+
+```text
+┌──────────────────────┐
+│  Tool-result 請求     │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  信任錨定檢查             │
+│  raw name == 內建工具?    │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+   匹配內建    非內建工具
+   工具名稱         │
+      │             ▼
+      ▼       ┌──────────────┐
+  允許 MEDIA  │ 碰撞檢查      │
+  passthrough │ normalize →  │
+              │ 比對內建+其他 │
+              └──────┬───────┘
+                ┌────┴────┐
+                │         │
+                ▼         ▼
+             無碰撞    碰撞 → 400
+```
+
+### ⭐⭐⭐ Exec 核准提示密鑰遮蔽 ([#61077](https://github.com/openclaw/openclaw/issues/61077), [#64790](https://github.com/openclaw/openclaw/pull/64790))
+
+- **用途**：在 exec approval prompts 中遮蔽密鑰，防止 inline 核准審查洩漏憑證
+- **解決問題**：exec 核准提示的 rendered prompt content 可能包含明文密鑰
+- **影響**：核准流程中的敏感資訊不再外洩
+
+```text
+┌──────────────────┐
+│  Exec 指令請求    │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  產生核准提示          │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  密鑰偵測與遮蔽       │
+│  credential → [REDACTED] │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  安全的核准 UI 顯示   │
+└──────────────────────┘
+```
+
+### ⭐⭐⭐ Workspace 檔案操作 fs-safe 路由 ([#66636](https://github.com/openclaw/openclaw/pull/66636))
+
+- **用途**：`agents.files.get/set` 與 workspace listing 透過 `fs-safe` helpers 路由，拒絕 symlink 別名，從 file descriptor 解析 real path
+- **解決問題**：symlink swap 可在 `open` 與 `realpath` 之間重導驗證路徑至非預期 inode
+- **影響**：TOCTOU symlink 攻擊向量被封堵
+
+```text
+┌──────────────────┐
+│  檔案操作請求     │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  openFileWithinRoot  │
+│  (開啟檔案)           │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  從 fd 解析 realpath  │
+│  (非路徑 realpath)    │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  驗證 realpath        │
+│  在允許根目錄內?       │
+└────────┬─────────────┘
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+  允許操作   拒絕 (symlink
+             逃逸偵測)
+```
+
+### ⭐⭐⭐ MCP Loopback Constant-Time 比對 ([#66665](https://github.com/openclaw/openclaw/pull/66665))
+
+- **用途**：`/mcp` bearer 比對從 `!==` 改為 `safeEqualSecret` constant-time 比對，並在 auth gate 前拒絕非 loopback 瀏覽器請求
+- **解決問題**：timing side-channel 可能洩漏 bearer token 資訊
+- **影響**：與 codebase 其他 auth surface 一致，loopback origin 仍正常通過
+
+### ⭐⭐⭐ Gateway Bearer 每次請求重新解析 ([#66651](https://github.com/openclaw/openclaw/pull/66651))
+
+- **用途**：HTTP server 與 HTTP upgrade handler 透過 `getResolvedAuth()` 每次請求解析 bearer，與 WebSocket 路徑一致
+- **解決問題**：`secrets.reload` 或 config hot-reload 後，舊 secret 在 HTTP 路徑上仍有效直到 gateway 重啟
+- **影響**：secret 輪換即時生效於 `/v1/*`、`/tools/invoke`、plugin HTTP routes、canvas upgrade path
+
+### ⭐⭐ Webchat 音訊嵌入 localRoots 限制 ([#67298](https://github.com/openclaw/openclaw/pull/67298))
+
+- **用途**：webchat audio embedding path 強制 localRoots containment
+- **解決問題**：音訊嵌入路徑可能存取 localRoots 外的檔案
+- **影響**：音訊嵌入受限於允許的根目錄
+
+### ⭐⭐ Matrix DM Pairing-Store 授權限縮 ([#67294](https://github.com/openclaw/openclaw/pull/67294))
+
+- **用途**：阻止 DM pairing-store 條目授權 room control 指令
+- **解決問題**：DM pairing-store 可能被用於授權 room 層級的控制指令
+- **影響**：room 路徑更窄，不影響 room auth 行為
+
+### ⭐⭐ Feishu Webhook 強化 ([#66707](https://github.com/openclaw/openclaw/pull/66707))
+
+- **用途**：缺少 `encryptKey` 時拒絕啟動 webhook transport，無 key 時拒絕未簽名請求，空白 card-action token 在 dedupe 前丟棄
+- **解決問題**：缺少加密金鑰時 webhook 仍可啟動並接受未簽名請求
+- **影響**：defense-in-depth 強化，已關閉的 monitor-account 層之上再加一層
+
+### ⭐⭐ Memory QMD `memory_get` 路徑限制 ([#66026](https://github.com/openclaw/openclaw/pull/66026))
+
+- **用途**：`memory_get` 僅允許讀取正規記憶檔案與已索引 QMD workspace 文件的精確路徑
+- **解決問題**：QMD memory backend 可被當作通用 workspace 檔案讀取 shim，繞過 `read` tool-policy 拒絕
+- **影響**：記憶工具不再是檔案讀取的後門
+
+### ⭐⭐ Webchat 拒絕遠端 `file://` URL ([#67293](https://github.com/openclaw/openclaw/pull/67293))
+
+- **用途**：媒體嵌入路徑拒絕遠端 host 的 `file://` URL
+- **解決問題**：`file://` URL 可能被用於存取遠端 host 的本地檔案
+- **影響**：媒體嵌入安全性提升
+
+### ⭐ CLI Plugin 安裝安全 ([#58909](https://github.com/openclaw/openclaw/pull/58909))
+
+- **用途**：`--dangerously-force-unsafe-install` 在安全掃描失敗後不再 fallback 至 hook-pack 安裝
+- **解決問題**：強制不安全安裝仍可能透過 hook-pack fallback 執行
+- **影響**：保留非安全 fallback 行為，僅阻止安全掃描失敗後的 hook-pack 路徑
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Skills Snapshot 版本失效修復 ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+
+- **用途**：`skills.*` 設定變更時自動遞增 cached skills-snapshot 版本，強制既有 session 刷新 skill list
+- **解決問題**：移除 bundled skill 後，舊 snapshot 仍存活，模型持續呼叫已停用工具，產生 "Tool not found" 迴圈直到 timeout
+- **影響**：設定變更即時反映於所有 session，消除工具迴圈問題
+
+```text
+┌──────────────────────┐
+│  skills.* 設定變更    │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  遞增 skillsSnapshot     │
+│  版本號                   │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  既有 session 偵測        │
+│  版本不符                 │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  強制重新載入 skill list  │
+│  (已停用工具不再出現)     │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ Unknown-Tool Stream Guard 預設啟用 ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+
+- **用途**：預設啟用 unknown-tool stream guard，不再需要明確設定 `tools.loopDetection.enabled: true`
+- **解決問題**：預設設定下保護未啟用，幻覺或已移除工具會無限迴圈 "Tool X not found" 直到 timeout
+- **影響**：僅觸發於客觀上未註冊的工具，無誤報風險。仍可透過 `tools.loopDetection.unknownToolThreshold` 調整（預設 10）
+
+```text
+┌──────────────────────┐
+│  模型呼叫工具 X       │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  工具 X 已註冊?           │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+    已註冊    未註冊
+    正常執行      │
+              ▼
+        ┌──────────────┐
+        │ 累計失敗次數  │
+        │ >= threshold │
+        │ (預設 10)?   │
+        └──────┬───────┘
+          ┌────┴────┐
+          │         │
+          ▼         ▼
+        未達閾值   達閾值
+        繼續重試   終止迴圈
+```
+
+### ⭐⭐⭐ Gateway 啟動 SIGUSR1 重啟迴圈修復 ([#67557](https://github.com/openclaw/openclaw/pull/67557))
+
+- **用途**：修復 plugin auto-enable 為唯一啟動 config write 時，config hash guard 未被捕獲，chokidar 將每次啟動寫入視為外部變更觸發 reload → restart 迴圈
+- **解決問題**：Linux/systemd 上的假性 SIGUSR1 重啟迴圈，重複循環後損壞 manifest.db
+- **影響**：啟動穩定性恢復，manifest.db 不再被損壞
+
+```text
+┌──────────────────┐
+│  Gateway 啟動     │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  Plugin auto-enable  │
+│  config write        │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  捕獲 config hash        │
+│  (修復前：未捕獲)         │
+└────────┬─────────────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  chokidar 偵測變更        │
+│  → hash 比對 → 忽略       │
+│  (修復前：視為外部變更     │
+│   → reload → restart)    │
+└──────────────────────────┘
+```
+
+### ⭐⭐ BlueBubbles Catchup Per-Message Retry 上限 ([#67426](https://github.com/openclaw/openclaw/pull/67426), [#66870](https://github.com/openclaw/openclaw/issues/66870))
+
+- **用途**：新增 `catchup.maxFailureRetries`（預設 10），持續失敗的訊息在 N 次後跳過，cursor 繼續前進
+- **解決問題**：malformed payload 的訊息永久卡住 catchup cursor
+- **影響**：暫時性失敗仍從同一點重試，持續性失敗不再阻塞整個 catchup 流程
+
+### ⭐⭐ Ollama Chat Provider Prefix 修復 ([#67457](https://github.com/openclaw/openclaw/pull/67457))
+
+- **用途**：從 Ollama chat request model id 中移除 `ollama/` provider prefix
+- **解決問題**：`ollama/qwen3:14b-q8_0` 等設定在 Ollama API 上 404
+- **影響**：Ollama 模型設定正常運作
+
+### ⭐⭐ WhatsApp Web-Session Auth Bootstrap Race 修復 ([#67464](https://github.com/openclaw/openclaw/pull/67464))
+
+- **用途**：重新開啟 socket 前先排空 pending per-auth creds save queue
+- **解決問題**：重連時 auth bootstrap 與進行中的 `creds.json` 寫入競爭，錯誤地從 backup 還原
+- **影響**：WhatsApp 重連穩定性提升
+
+### ⭐⭐ TUI Streaming Watchdog ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+
+- **用途**：新增客戶端 streaming watchdog，30s 無 delta 後自動重置 `streaming` 狀態為 `idle`
+- **解決問題**：遺失或延遲的 `state: "final"` chat event 導致 TUI 永久卡在 `streaming`
+- **影響**：可透過 `streamingWatchdogMs` 設定（`0` 停用），shutdown 時 `dispose()` 清除 timer
+
+### ⭐⭐ Agents Failover HTML Error Pages 分類 ([#67642](https://github.com/openclaw/openclaw/pull/67642))
+
+- **用途**：將 HTML provider error pages 正確分類為上游傳輸失敗（CDN-style 5xx），不誤判為 API rate limits
+- **解決問題**：HTML 401/403 的 auth remediation 與 407 的 proxy remediation 仍保留
+- **影響**：model fallback 在 CDN 錯誤時正確觸發
+
+### ⭐⭐ OpenAI Codex 模型 Transport Metadata 正規化 ([#67635](https://github.com/openclaw/openclaw/pull/67635))
+
+- **用途**：正規化 stale native transport metadata，缺少 `api` 或指向 `chatgpt.com` 的 legacy 行自動修復為 canonical Codex transport
+- **解決問題**：legacy `openai-codex` 行透過損壞的 HTML/Cloudflare 路徑路由請求
+- **影響**：Codex 模型路由自動修復
+
+### ⭐⭐ Agents Replay Tool-Result ID 修復 ([#67620](https://github.com/openclaw/openclaw/pull/67620))
+
+- **用途**：strict replay tool-call ID sanitization 後重新執行 tool/result pairing
+- **解決問題**：Anthropic 相容 provider（如 MiniMax）在 compaction/retry 流程中收到畸形 orphan tool-result ID
+- **影響**：replay 流程與 Anthropic 相容 provider 的相容性修復
+
+### ⭐ Docker Build pnpm v10+ 相容修復 ([#67143](https://github.com/openclaw/openclaw/pull/67143))
+
+- **用途**：以 `find` 驗證 native bindings 取代 hardcoded `.pnpm/...` 路徑
+- **解決問題**：pnpm v10+ virtual-store layout 導致 image build 失敗
+- **影響**：Docker build 相容 pnpm v10+
+
+### ⭐ Matrix E2EE 無密碼 Token-Auth Bot 啟動修復 ([#66228](https://github.com/openclaw/openclaw/pull/66228))
+
+- **用途**：無密碼 token-auth bot 保守啟動 bootstrap，仍嘗試 guarded repair pass
+- **解決問題**：啟動 bootstrap 要求 `channels.matrix.password`，無密碼 bot 無法啟動
+- **影響**：token-auth bot 正常啟動，文件記錄 password-UIA 限制
+
+### ⭐ Cron Announce `NO_REPLY` 洩漏修復 ([#65004](https://github.com/openclaw/openclaw/pull/65004), [#65016](https://github.com/openclaw/openclaw/pull/65016))
+
+- **用途**：抑制以 `NO_REPLY` 結尾的混合內容 cron announce，case-insensitive 清理
+- **解決問題**：trailing silent sentinels 洩漏摘要文字至目標頻道
+- **影響**：cron announce 不再洩漏 `NO_REPLY` 文字
+
+### ⭐ Discord Tool-Call Text 清理 ([#67318](https://github.com/openclaw/openclaw/pull/67318))
+
+- **用途**：從可見 assistant text 中移除 Gemma-style `<function>...</function>` tool-call payloads
+- **解決問題**：tool-call payload 出現在使用者可見的回覆中
+- **影響**：Discord 回覆更乾淨
+
+### ⭐ Dashboard Exec Approval Modal Overflow ([#67082](https://github.com/openclaw/openclaw/pull/67082))
+
+- **用途**：限制 exec approval modal 在桌面端的 overflow
+- **解決問題**：長指令內容將 action buttons 推出可視範圍
+- **影響**：核准 modal UI 修復
+
+### ⭐ CLI/Configure Stale-Hash Race 修復 ([#64188](https://github.com/openclaw/openclaw/issues/64188), [#66528](https://github.com/openclaw/openclaw/pull/66528))
+
+- **用途**：寫入後重新讀取 persisted config hash
+- **解決問題**：config 更新因 stale-hash race 失敗
+- **影響**：config 更新可靠性提升
+
+### ⭐ Agents Compaction 小 Context Window 修復 ([#65671](https://github.com/openclaw/openclaw/pull/65671))
+
+- **用途**：將 compaction reserve-token floor 限制在 model context window 內
+- **解決問題**：小 context 本地模型（如 Ollama 16K）觸發 context-overflow 或無限 compaction 迴圈
+- **影響**：小 context 模型正常運作
+
+### ⭐ OpenRouter Qwen3 Reasoning Details 解析 ([#66905](https://github.com/openclaw/openclaw/pull/66905))
+
+- **用途**：解析 `reasoning_details` stream deltas 為 thinking content，不跳過同 chunk 的 tool calls
+- **解決問題**：Qwen3 在 OpenRouter 上回覆為空，混合 reasoning/tool-call chunks 無法正常執行
+- **影響**：Qwen3 on OpenRouter 正常運作
+
+### ⭐ Agents CLI Transcripts 持久化 ([#67490](https://github.com/openclaw/openclaw/pull/67490))
+
+- **用途**：將成功的 CLI-backed turns 持久化至 session transcript
+- **解決問題**：google-gemini-cli 回覆未出現在 session history 與 Control UI
+- **影響**：CLI-backed 回覆正常記錄
+
+### ⭐ Agents Tilde Path 解析 ([#62804](https://github.com/openclaw/openclaw/pull/62804))
+
+- **用途**：非 workspace host tilde paths 解析至 OS home directory
+- **解決問題**：`OPENCLAW_HOME` 不同時 `~/...` host edit/write 操作失敗或讀取錯誤檔案
+- **影響**：tilde path 操作正確
+
+### ⭐ Speech/TTS Provider 路由修復 ([#62846](https://github.com/openclaw/openclaw/pull/62846))
+
+- **用途**：自動啟用 bundled Microsoft 與 ElevenLabs speech providers，TTS directive tokens 優先路由至明確或活躍 provider
+- **解決問題**：`[[tts:speed=1.2]]` 等覆寫靜默落入錯誤 provider
+- **影響**：TTS 覆寫正確路由
+
+### ⭐ Bundled Plugin Lazy Cache 分區 ([#67200](https://github.com/openclaw/openclaw/pull/67200))
+
+- **用途**：依 active bundled root 分區 lazy caches
+- **解決問題**：`OPENCLAW_BUNDLED_PLUGINS_DIR` 切換後重用 stale plugin/setup/secrets/runtime state
+- **影響**：bundled plugin 切換正確
+
+### ⭐ LM Studio Exponential Backoff ([#67401](https://github.com/openclaw/openclaw/pull/67401))
+
+- **用途**：inference-preload wrapper 新增 exponential backoff（5s → 10s → … → 5min cooldown）
+- **解決問題**：model-load 失敗時每 ~2s 產生 WARN，每個 chat request 都觸發
+- **影響**：cooldown 期間跳過 preload，chat request 直接進入 stream
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 2 | 5 | 4 | Dreaming 儲存模式改版、工具碰撞防護、Google TTS、LanceDB 雲端、Copilot embedding、本地模型精簡 |
+| 安全性 | 5 | 5 | 1 | 工具信任錨定、密鑰遮蔽、fs-safe 路由、MCP constant-time、Gateway bearer 即時解析 |
+| 錯誤修復 | 3 | 7 | 13 | Skills snapshot 刷新、unknown-tool guard、SIGUSR1 迴圈、BlueBubbles catchup、Ollama prefix、多項穩定性修復 |
+| **總計** | **10** | **17** | **18** | **本版本共 45 項重點更新** |
+
+---
+
+**發佈日期**: 2026-04-15
+**版本**: 2026.4.15
+**狀態**: Production Ready
+**GitHub Release**: [v2026.4.15](https://github.com/openclaw/openclaw/releases/tag/v2026.4.15)


### PR DESCRIPTION
## Summary

新增 OpenClaw v2026.4.15 版本發佈說明（zh-TW）。

## 內容

- **升級前必讀**：3 項 Breaking Changes（Dreaming 儲存模式、工具名稱碰撞拒絕、Skills snapshot 版本失效）
- **功能更新**：11 項（2 ⭐⭐⭐ / 5 ⭐⭐ / 4 ⭐）
- **安全性提升**：11 項（5 ⭐⭐⭐ / 5 ⭐⭐ / 1 ⭐）
- **錯誤修復**：23 項（3 ⭐⭐⭐ / 7 ⭐⭐ / 13 ⭐）
- 所有 ⭐⭐⭐ 項目均含 ASCII flowchart
- Summary table 與 footer 完整

## References

- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.4.15
- Guidelines: `release-notes/GUIDELINES.md`

Closes #484