### PR TITLE
release-notes: OpenClaw v2026.4.22 zh-TW

### DIFF
--- a/release-notes/2026-04-22.md
+++ b/release-notes/2026-04-22.md
@@ -1,0 +1,615 @@
+# OpenClaw v2026.4.22 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.22)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Codex CLI auth import 路徑移除 | `openclaw models auth login` 不再從 `~/.codex` 複製 OAuth 憑證 | 改用瀏覽器登入或 device pairing；新增 ChatGPT device-code auth 選項 |
+| Config merge 語意變更 | `config set` 對 model/provider map 預設為 merge 而非 replace | 需要完整覆蓋時改用 `config set --replace`；一般使用者受益於 additive 行為 |
+| Codex Guardian mode 設定變更 | 移除 `OPENCLAW_CODEX_APP_SERVER_GUARDIAN` 環境變數 | 改用 plugin config `appServer.mode: "guardian"` 或 `OPENCLAW_CODEX_APP_SERVER_MODE=guardian` |
+
+### 新功能亮點
+
+- **xAI 圖片/TTS/STT**：完整支援 `grok-imagine-image` 圖片生成、六種語音 TTS、`grok-stt` 語音轉文字，以及 Voice Call 即時轉錄
+- **TUI 本地嵌入模式**：無需 Gateway 即可在終端機執行對話，保留 plugin 核准機制
+- **`/models add` 動態註冊**：從聊天中直接新增模型，無需重啟 Gateway
+- **診斷匯出**：一鍵產生隱私安全的診斷包，方便 bug report 附件
+- **騰訊雲 Provider**：新增 bundled 騰訊雲 plugin，含 TokenHub onboarding 與 `hy3-preview` 模型
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ xAI 圖片生成/TTS/STT 完整支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
+- ⭐⭐⭐ TUI 本地嵌入模式 ([#66767](https://github.com/openclaw/openclaw/pull/66767))
+- ⭐⭐⭐ `/models add` 動態模型註冊 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
+- ⭐⭐⭐ 診斷匯出功能 ([#70324](https://github.com/openclaw/openclaw/pull/70324))
+- ⭐⭐ 騰訊雲 Provider plugin ([#68460](https://github.com/openclaw/openclaw/pull/68460))
+- ⭐⭐ Amazon Bedrock Mantle Claude Opus 4.7 支援
+- ⭐⭐ WhatsApp 原生引用回覆與 per-group systemPrompt
+- ⭐⭐ Session 列表 mailbox 篩選 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
+- ⭐⭐ Control UI 個人化身份與佈局優化 ([#70362](https://github.com/openclaw/openclaw/pull/70362))
+- ⭐⭐ GPT-5 prompt overlay 共享化
+- ⭐⭐ STT Voice Call 串流轉錄擴展（Deepgram、ElevenLabs、Mistral）
+- ⭐ Tokenjuice 壓縮 plugin ([#69946](https://github.com/openclaw/openclaw/pull/69946))
+- ⭐ ACPX OpenClaw MCP bridge ([#70595](https://github.com/openclaw/openclaw/pull/70595))
+- ⭐ Claude CLI warm stdio session 與 resume ([#69679](https://github.com/openclaw/openclaw/pull/69679))
+- ⭐ Pi 套件更新至 0.68.1
+- ⭐ Plugin 啟動 Jiti 載入加速 82-90% ([#69925](https://github.com/openclaw/openclaw/pull/69925))
+- ⭐ Doctor plugin 啟動加速 74% ([#69840](https://github.com/openclaw/openclaw/pull/69840))
+- ⭐ 泰文翻譯支援
+- ⭐ `/status` Runner 欄位 ([#70595](https://github.com/openclaw/openclaw/pull/70595))
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ OpenShell sandbox symlink 穿越防護 ([#69798](https://github.com/openclaw/openclaw/pull/69798))
+- ⭐⭐⭐ Control UI config auth gate 強化 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
+- ⭐⭐⭐ Gateway session-history stream 重新驗證
+- ⭐⭐ Codex harness 權限核准 fail-closed 強化 ([#70356](https://github.com/openclaw/openclaw/pull/70356))
+- ⭐⭐ npm plugin 完整性漂移偵測
+- ⭐⭐ Gateway pairing 反向代理安全
+- ⭐⭐ `.env` dotenv 覆蓋阻擋（Matrix、Mattermost、IRC、Synology）([#70240](https://github.com/openclaw/openclaw/pull/70240))
+- ⭐⭐ Telegram `/models` 群組授權強化 ([#70235](https://github.com/openclaw/openclaw/pull/70235))
+- ⭐ Plugin 來源目錄逃逸阻擋 ([#69868](https://github.com/openclaw/openclaw/pull/69868))
+- ⭐ Matrix DM allowlist 隔離
+- ⭐ `uuid` 依賴安全更新至 14.0.0
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ WhatsApp 重複外送訊息防護 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
+- ⭐⭐⭐ Config merge 語意修復（防止 model/provider map 意外覆蓋）
+- ⭐⭐⭐ Config gateway 崩潰迴圈恢復
+- ⭐⭐ Telegram webhook/polling 可靠性修復 ([#70146](https://github.com/openclaw/openclaw/pull/70146), [#69873](https://github.com/openclaw/openclaw/pull/69873))
+- ⭐⭐ Discord partial thread 崩潰修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
+- ⭐⭐ Plugin 啟動/探索/載入穩定性強化
+- ⭐⭐ Gateway 重啟/續接可靠性修復 ([#63406](https://github.com/openclaw/openclaw/pull/63406))
+- ⭐⭐ Thinking defaults 提升至 medium ([#70281](https://github.com/openclaw/openclaw/pull/70281))
+- ⭐⭐ Moonshot Kimi K2.6 tool call ID 修復 ([#70030](https://github.com/openclaw/openclaw/pull/70030))
+- ⭐⭐ Slack Connect streaming fallback ([#70370](https://github.com/openclaw/openclaw/pull/70370))
+- ⭐ Memory LanceDB 熱重載修復
+- ⭐ Cron MCP runtime 清理 ([#69145](https://github.com/openclaw/openclaw/pull/69145))
+- ⭐ Browser Chrome MCP 逾時恢復 ([#69733](https://github.com/openclaw/openclaw/pull/69733))
+- ⭐ Bedrock prompt caching profile 解析修復 ([#69953](https://github.com/openclaw/openclaw/pull/69953))
+- ⭐ Gateway channel health 誤判重啟修復 ([#69833](https://github.com/openclaw/openclaw/pull/69833))
+- ⭐ 多項 live config 熱重載修復（Memory-LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Bedrock、Codex、GitHub Copilot）
+
+---
+
+## 功能更新詳細說明
+
+### ⭐⭐⭐ xAI 圖片生成/TTS/STT 完整支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
+
+- **用途**：為 xAI provider 新增圖片生成（`grok-imagine-image` / `grok-imagine-image-pro`）、參考圖片編輯、六種即時語音 TTS（MP3/WAV/PCM/G.711）、`grok-stt` 語音轉文字，以及 Voice Call 即時串流轉錄
+- **解決問題**：xAI 用戶過去僅能使用文字模型，無法利用 xAI 的多模態能力
+- **影響**：xAI 成為 OpenClaw 中首個同時支援圖片生成、TTS、STT 與即時轉錄的完整多模態 provider
+
+```text
+┌──────────────────┐
+│  使用者請求       │
+│  (文字/語音/圖片) │
+└────────┬─────────┘
+         │
+    ┌────┴─────┬──────────┐
+    │          │          │
+    ▼          ▼          ▼
+┌────────┐ ┌────────┐ ┌──────────┐
+│ 圖片   │ │  TTS   │ │   STT    │
+│ 生成   │ │ 語音   │ │ 語音轉文 │
+│ /編輯  │ │ 合成   │ │ 字/即時  │
+└────┬───┘ └────┬───┘ └────┬─────┘
+     │          │          │
+     ▼          ▼          ▼
+┌────────┐ ┌────────┐ ┌──────────┐
+│ grok-  │ │ 6 種   │ │ grok-stt │
+│ imagine│ │ 即時   │ │ + Voice  │
+│ -image │ │ 語音   │ │ Call 串流 │
+└────────┘ └────────┘ └──────────┘
+```
+
+### ⭐⭐⭐ TUI 本地嵌入模式 ([#66767](https://github.com/openclaw/openclaw/pull/66767))
+
+- **用途**：在終端機中直接執行對話，無需啟動 Gateway，同時保留 plugin 核准機制
+- **解決問題**：輕量使用場景（如快速提問、離線環境）仍需啟動完整 Gateway 才能互動
+- **影響**：大幅降低入門門檻；開發者可直接 `openclaw tui` 開始對話，需要 Gateway 功能的 API 呼叫會明確提示
+
+```text
+┌──────────────────┐
+│  openclaw tui    │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  偵測 Gateway 狀態    │
+└────────┬─────────────┘
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+┌────────┐ ┌──────────────┐
+│ 有     │ │ 無 Gateway   │
+│ Gateway│ │ → 本地嵌入   │
+│ → 連線 │ │   模式啟動   │
+└────────┘ └──────┬───────┘
+                  │
+                  ▼
+           ┌──────────────┐
+           │ Plugin 核准   │
+           │ 機制保留      │
+           │ (Gateway API  │
+           │  呼叫明確提示) │
+           └──────────────┘
+```
+
+### ⭐⭐⭐ `/models add` 動態模型註冊 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
+
+- **用途**：從聊天中直接執行 `/models add <provider> <modelId>` 註冊新模型，無需重啟 Gateway
+- **解決問題**：新增模型需要手動編輯 config 並重啟 Gateway，中斷所有進行中的對話
+- **影響**：模型管理即時化；`/models` 同時升級為 provider 瀏覽器，提供複製友善的指令範例
+
+```text
+┌──────────────────────────────┐
+│  /models add ollama llama4   │
+└──────────────┬───────────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  驗證 provider 與 modelId │
+└──────────────┬───────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  寫入 agents.defaults     │
+│  .models (merge 語意)     │
+└──────────────┬───────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  即時可用於 /models 與    │
+│  /model 切換（無需重啟）  │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ 診斷匯出功能 ([#70324](https://github.com/openclaw/openclaw/pull/70324))
+
+- **用途**：透過 `openclaw gateway diagnostics export` 一鍵產生隱私安全的診斷包，包含 sanitized logs、status、health、config 與 stability snapshots
+- **解決問題**：提交 bug report 時需手動收集多項資訊，且容易洩漏敏感資料
+- **影響**：bug report 流程標準化；聊天內容、webhook body、工具輸出、憑證等均自動遮蔽
+
+```text
+┌───────────────────────────────────┐
+│  openclaw gateway diagnostics     │
+│  export                           │
+└──────────────┬────────────────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  收集診斷資料             │
+│  • stability recording   │
+│  • sanitized logs        │
+│  • status/health snapshot│
+│  • config shape          │
+└──────────────┬───────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  隱私遮蔽                 │
+│  • 移除聊天文字           │
+│  • 移除 webhook body     │
+│  • 移除憑證/cookie       │
+│  • 移除帳號/訊息 ID      │
+└──────────────┬───────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  輸出 ZIP 診斷包          │
+│  (可安全附加至 bug report)│
+└──────────────────────────┘
+```
+
+### ⭐⭐ 騰訊雲 Provider Plugin ([#68460](https://github.com/openclaw/openclaw/pull/68460))
+
+- **用途**：新增 bundled 騰訊雲 provider plugin，含 TokenHub onboarding、文件、`hy3-preview` 模型目錄與分層定價
+- **解決問題**：中國大陸用戶缺乏原生支援的國產雲端 LLM provider
+- **影響**：騰訊雲用戶可直接透過 OpenClaw 使用混元模型
+
+### ⭐⭐ Amazon Bedrock Mantle — Claude Opus 4.7
+
+- **用途**：透過 Mantle 的 Anthropic Messages 路由新增 Claude Opus 4.7，使用 provider-owned bearer-auth streaming
+- **解決問題**：Bedrock 用戶無法透過標準 AWS bearer token 呼叫 Opus 4.7
+- **影響**：Bedrock 用戶可直接使用最新 Claude 模型；IAM-backed bearer token 支援 runtime 自動刷新
+
+### ⭐⭐ WhatsApp 原生引用回覆與 per-group systemPrompt ([#59553](https://github.com/openclaw/openclaw/pull/59553))
+
+- **用途**：新增可設定的原生引用回覆（`replyToMode`）與 per-group/per-direct `systemPrompt` 注入
+- **解決問題**：WhatsApp 對話缺乏引用上下文；不同群組無法設定不同的行為指令
+- **影響**：支援 `"*"` wildcard fallback 與帳號級覆蓋，帳號 map 完整取代 root map
+
+### ⭐⭐ Session 列表 Mailbox 篩選 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
+
+- **用途**：`sessions_list` 新增 label、agent、search 篩選，以及 visibility-scoped 衍生標題與最後訊息預覽
+- **解決問題**：大量 session 時難以快速找到目標對話
+- **影響**：session 管理體驗接近 email client 的 mailbox 模式
+
+### ⭐⭐ Control UI 個人化身份與佈局優化 ([#70362](https://github.com/openclaw/openclaw/pull/70362))
+
+- **用途**：新增 browser-local 個人身份（名稱 + 本地安全頭像），統一 chat/avatar 渲染路徑，優化 Quick Settings 與窄螢幕佈局
+- **解決問題**：操作者缺乏個人化識別；窄螢幕下控制項被裁切
+- **影響**：提升操作者體驗，個人化不再浪費空間
+
+### ⭐⭐ GPT-5 Prompt Overlay 共享化
+
+- **用途**：將 GPT-5 prompt overlay 移至共享 provider runtime，所有相容 GPT-5 模型（OpenAI、OpenRouter、OpenCode、Codex 等）統一接收行為與 heartbeat 指引
+- **解決問題**：各 provider 的 GPT-5 行為不一致
+- **影響**：新增 `agents.defaults.promptOverlays.gpt5.personality` 全域 toggle
+
+### ⭐⭐ STT Voice Call 串流轉錄擴展
+
+- **用途**：為 Deepgram、ElevenLabs、Mistral 新增 Voice Call 串流轉錄；ElevenLabs 另增 Scribe v2 批次音訊轉錄
+- **解決問題**：即時語音轉錄僅限 OpenAI 與 xAI
+- **影響**：更多 STT provider 可用於 Voice Call 場景
+
+### ⭐ Tokenjuice 壓縮 Plugin ([#69946](https://github.com/openclaw/openclaw/pull/69946))
+
+- **用途**：opt-in plugin，壓縮 Pi embedded run 中 `exec` 和 `bash` 工具的冗長輸出
+- **解決問題**：工具輸出佔用過多 context window
+- **影響**：減少 token 消耗，提升長對話穩定性
+
+### ⭐ ACPX OpenClaw MCP Bridge
+
+- **用途**：新增 `openClawToolsMcpBridge` 選項，為選定的內建工具（如 `cron`）注入 MCP server
+- **解決問題**：ACP 模式下無法使用部分 OpenClaw 內建工具
+- **影響**：ACP 整合更完整
+
+### ⭐ Claude CLI Warm Stdio Session 與 Resume ([#69679](https://github.com/openclaw/openclaw/pull/69679))
+
+- **用途**：`claude-cli` 預設使用 warm stdio session，Gateway 重啟後自動 resume
+- **解決問題**：每次 Gateway 重啟都需要重新建立 Claude CLI session
+- **影響**：Claude CLI 對話連續性提升
+
+### ⭐ Plugin 啟動 Jiti 載入加速 82-90% ([#69925](https://github.com/openclaw/openclaw/pull/69925))
+
+- **用途**：bundled plugin 優先使用原生 Jiti 載入，TypeScript 保留 transform 路徑
+- **解決問題**：plugin 啟動時間過長
+- **影響**：啟動速度顯著提升
+
+### ⭐ Doctor Plugin 啟動加速 74% ([#69840](https://github.com/openclaw/openclaw/pull/69840))
+
+- **用途**：lazy-load doctor plugin 路徑，優先使用已建置的 `dist/*` runtime
+- **解決問題**：`doctor --non-interactive` 執行時間過長
+- **影響**：診斷流程更快速
+
+### ⭐ `/status` Runner 欄位 ([#70595](https://github.com/openclaw/openclaw/pull/70595))
+
+- **用途**：`/status` 新增 `Runner:` 欄位，顯示 session 使用的 runtime（embedded Pi、CLI-backed、ACP harness）
+- **解決問題**：無法從 status 判斷 session 的執行環境
+- **影響**：除錯與監控更直觀
+
+---
+
+## 安全性提升詳細說明
+
+### ⭐⭐⭐ OpenShell Sandbox Symlink 穿越防護 ([#69798](https://github.com/openclaw/openclaw/pull/69798))
+
+- **用途**：pin 已開啟的 file descriptor 進行驗證讀取，走訪 ancestor chain 偵測 symlink parent，並在讀取後重新檢查 file identity，防止 parent symlink swap 將 sandbox 內讀取重導至 host 檔案
+- **解決問題**：parent symlink 替換可繞過 sandbox 的 allowed mount root 限制，讀取 host 上的任意檔案
+- **影響**：sandbox 檔案讀取安全性大幅提升；無 fd-path readlink 的平台也受保護
+
+```text
+┌──────────────────────┐
+│  Sandbox 檔案讀取請求 │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  開啟檔案 → pin fd   │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  走訪 ancestor chain      │
+│  偵測 symlink parent      │
+│  (無 fd-path readlink     │
+│   時使用 ancestor walk)   │
+└──────────┬───────────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  驗證路徑在 allowed       │
+│  mount root 內            │
+└──────────┬───────────────┘
+           │
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+┌─────────┐ ┌──────────┐
+│ 通過 →  │ │ 拒絕 →   │
+│ 讀取 fd │ │ 關閉 fd  │
+└─────────┘ └──────────┘
+```
+
+### ⭐⭐⭐ Control UI Config Auth Gate 強化 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
+
+- **用途**：`gateway.auth` 啟用時，`/__openclaw/control-ui-config.json` 需通過認證才能存取
+- **解決問題**：未認證的呼叫者可讀取 bootstrap metadata
+- **影響**：防止未授權存取 Control UI 設定資訊
+
+```text
+┌──────────────────────────────┐
+│  GET /__openclaw/             │
+│  control-ui-config.json      │
+└──────────────┬───────────────┘
+               │
+               ▼
+┌──────────────────────────┐
+│  gateway.auth 啟用？      │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+┌─────────┐ ┌──────────┐
+│ 是 →    │ │ 否 →     │
+│ 驗證    │ │ 直接回傳 │
+│ 認證    │ └──────────┘
+└────┬────┘
+┌────┴────┐
+│         │
+▼         ▼
+通過 →   拒絕 →
+回傳     403
+```
+
+### ⭐⭐⭐ Gateway Session-History Stream 重新驗證
+
+- **用途**：SSE keepalive 與 transcript 更新前重新檢查 auth 與 `chat.history` scope
+- **解決問題**：auth 撤銷後，已建立的 session-history stream 仍可繼續接收事件
+- **影響**：撤銷權限後立即生效，不再需要等待連線自然斷開
+
+```text
+┌──────────────────────┐
+│  SSE keepalive /      │
+│  transcript 更新      │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  重新檢查 auth 狀態   │
+│  + chat.history scope │
+└──────────┬───────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+┌─────────┐ ┌──────────┐
+│ 有效 →  │ │ 已撤銷 → │
+│ 繼續    │ │ 關閉     │
+│ 推送    │ │ stream   │
+└─────────┘ └──────────┘
+```
+
+### ⭐⭐ Codex Harness 權限核准 Fail-Closed 強化 ([#70356](https://github.com/openclaw/openclaw/pull/70356))
+
+- **用途**：未知的 app-server approval method 預設拒絕，而非路由至 OpenClaw approval grants
+- **解決問題**：未來新增的 approval shape 可能被錯誤地自動核准
+- **影響**：安全性預設為拒絕，防止未知權限類型被意外授予
+
+### ⭐⭐ npm Plugin 完整性漂移偵測
+
+- **用途**：pinned npm plugin 或 hook-pack 更新時偵測 integrity drift，發現時 fail closed
+- **解決問題**：供應鏈攻擊可能透過修改已安裝的 plugin 內容
+- **影響**：`openclaw update --json` 會揭露被中止的 plugin drift 詳情
+
+### ⭐⭐ Gateway Pairing 反向代理安全
+
+- **用途**：偵測 forwarded header（`Forwarded`、`X-Forwarded-*`、`X-Real-IP`）作為 proxied WebSocket 流量，阻止 loopback shared-secret auto-pairing
+- **解決問題**：反向代理拓撲可能利用 loopback helper 自動配對路徑
+- **影響**：Browser/Control-UI 客戶端維持既有的 approval-required 流程
+
+### ⭐⭐ `.env` Dotenv 覆蓋阻擋 ([#70240](https://github.com/openclaw/openclaw/pull/70240))
+
+- **用途**：阻擋 workspace `.env` 覆蓋 Matrix、Mattermost、IRC、Synology 端點設定
+- **解決問題**：clone 的 workspace 可透過 `.env` 將 bundled connector 流量重導至惡意端點
+- **影響**：防止本地 `.env` 劫持通訊通道
+
+### ⭐⭐ Telegram `/models` 群組授權強化 ([#70235](https://github.com/openclaw/openclaw/pull/70235))
+
+- **用途**：群組中的 model-picker callback 需要與 `/models` 相同的授權
+- **解決問題**：未授權的群組成員可透過 inline button 瀏覽或變更 session model
+- **影響**：群組模型管理權限一致化
+
+### ⭐ Plugin 來源目錄逃逸阻擋 ([#69868](https://github.com/openclaw/openclaw/pull/69868))
+
+- **用途**：拒絕逃逸 package 目錄的 plugin source entry
+- **解決問題**：惡意 plugin 可能透過路徑逃逸存取 package 外的檔案
+- **影響**：plugin 載入安全邊界更嚴格
+
+### ⭐ Matrix DM Allowlist 隔離
+
+- **用途**：Matrix DM allowlist 狀態不再影響 room control-command 授權
+- **解決問題**：受信任的 DM sender 可能意外獲得 room-command 存取權
+- **影響**：DM 與 room 權限完全隔離
+
+### ⭐ `uuid` 依賴安全更新至 14.0.0
+
+- **用途**：覆蓋 transitive `uuid` 依賴至 14.0.0
+- **解決問題**：清除跨依賴的 runtime advisory
+- **影響**：消除已知安全警告
+
+---
+
+## 錯誤修復詳細說明
+
+### ⭐⭐⭐ WhatsApp 重複外送訊息防護 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
+
+- **用途**：外送訊息期間持有 in-memory active-delivery claim，防止 concurrent reconnect drain 重複驅動同一 pending queue entry
+- **解決問題**：30 分鐘 inbound-silence watchdog 在 mid-delivery 時觸發，導致 cron 訊息重複發送 7-12 倍
+- **影響**：claim 為 process-local，crash-replay 機制保留；WhatsApp cron 訊息不再重複
+
+```text
+┌──────────────────────┐
+│  外送訊息開始         │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  取得 active-delivery │
+│  claim (in-memory)    │
+└──────────┬───────────┘
+           │
+      ┌────┴──────────────┐
+      │                   │
+      ▼                   ▼
+┌───────────┐    ┌────────────────┐
+│ 正常送出  │    │ Reconnect drain│
+│ → 釋放    │    │ 偵測到 claim   │
+│   claim   │    │ → 跳過此 entry │
+└───────────┘    └────────────────┘
+```
+
+### ⭐⭐⭐ Config Merge 語意修復
+
+- **用途**：新增 `config set --merge` 進行 additive 更新，`--replace` 進行完整覆蓋；保護 model/provider map 寫入避免意外全部取代
+- **解決問題**：`openclaw models auth login` 重新認證 OAuth provider 時會清除其他 provider 的 aliases 與 per-model params（[#65920](https://github.com/openclaw/openclaw/issues/65920)、[#68392](https://github.com/openclaw/openclaw/issues/68392)、[#68653](https://github.com/openclaw/openclaw/issues/68653)）
+- **影響**：預設行為從 replace 改為 merge；需要 rename key 的 migration（如 Anthropic → Claude CLI）可 opt-in `replaceDefaultModels`
+
+```text
+┌──────────────────────────┐
+│  config set 寫入請求      │
+└──────────────┬───────────┘
+               │
+          ┌────┴────┐
+          │         │
+          ▼         ▼
+┌──────────────┐ ┌──────────────┐
+│ --merge      │ │ --replace    │
+│ (預設)       │ │ (明確指定)   │
+│ additive     │ │ 完整覆蓋     │
+│ 合併既有 map │ │ 取代整個 map │
+└──────────────┘ └──────────────┘
+```
+
+### ⭐⭐⭐ Config Gateway 崩潰迴圈恢復
+
+- **用途**：偵測 critical clobber signatures（missing metadata、missing `gateway.mode`、sharp size drops），自動還原 last-known-good config
+- **解決問題**：config 被意外損壞時 Gateway 進入無限崩潰迴圈
+- **影響**：有效備份存在時自動恢復；另修復 `openclaw doctor --fix` 或啟動時意外加入非 JSON 前綴的 config
+
+```text
+┌──────────────────────┐
+│  Gateway 啟動         │
+│  讀取 config          │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  檢查 clobber signatures │
+│  • missing metadata      │
+│  • missing gateway.mode  │
+│  • sharp size drop       │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+┌─────────┐ ┌──────────────────┐
+│ 正常 →  │ │ 偵測到損壞 →     │
+│ 繼續    │ │ 還原 last-known- │
+│ 啟動    │ │ good backup      │
+└─────────┘ └──────────────────┘
+```
+
+### ⭐⭐ Telegram Webhook/Polling 可靠性修復 ([#70146](https://github.com/openclaw/openclaw/pull/70146), [#69873](https://github.com/openclaw/openclaw/pull/69873))
+
+- **用途**：webhook callback timeout 降至 5s 讓 Telegram 及早收到 200；polling 遇到 409 conflict 後重建 HTTP transport
+- **解決問題**：長時間 update 處理導致 Telegram 重試；409 conflict 後 polling 在已終止的 keep-alive socket 上無限迴圈
+- **影響**：Telegram 通道穩定性顯著提升
+
+### ⭐⭐ Discord Partial Thread 崩潰修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
+
+- **用途**：在 slash-command、reaction、model-picker 路徑中使用 safe accessor 讀取 `channel.parentId`
+- **解決問題**：partial `GuildThreadChannel` 的 prototype getter 拋出 `Cannot access rawData on partial Channel`
+- **影響**：`/new` 等指令在 thread 內執行不再崩潰
+
+### ⭐⭐ Plugin 啟動/探索/載入穩定性強化
+
+- **用途**：多項修復涵蓋 plugin install 時自動加入 `plugins.allow`、bundled channel catalog drift 容錯、plugin 依賴隔離
+- **解決問題**：allowlisted config 重啟後不載入已安裝 plugin；一個損壞的 bundled channel 可導致 CLI 崩潰
+- **影響**：plugin 生態系統穩定性全面提升
+
+### ⭐⭐ Gateway 重啟/續接可靠性修復 ([#63406](https://github.com/openclaw/openclaw/pull/63406))
+
+- **用途**：跨 Gateway 重啟保留 group/channel chat context、one-shot continuation instructions、restart sentinel 原子寫入
+- **解決問題**：重啟後 agent turn 遺失 prompt/routing/tool-status；continuation reply 無法回到原始 chat
+- **影響**：Gateway 重啟對使用者幾乎透明
+
+### ⭐⭐ Thinking Defaults 提升至 Medium
+
+- **用途**：reasoning-capable 模型的隱含 thinking level 從 `off`/`low` 提升至 `medium`
+- **解決問題**：未明確設定時，reasoning 模型的思考能力被低估
+- **影響**：`/status` 顯示與 runtime 一致的 resolved default
+
+### ⭐⭐ Moonshot Kimi K2.6 Tool Call ID 修復 ([#70030](https://github.com/openclaw/openclaw/pull/70030))
+
+- **用途**：停止 strict-sanitize Kimi 原生 tool_call ID（形如 `functions.<name>:<index>`），新增 `sanitizeToolCallIds` opt-out
+- **解決問題**：多輪 agentic flow 在 2-3 輪 tool-calling 後因 mangled ID 而中斷
+- **影響**：Kimi K2.6 多輪工具呼叫穩定運作
+
+### ⭐⭐ Slack Connect Streaming Fallback ([#70370](https://github.com/openclaw/openclaw/pull/70370))
+
+- **用途**：Slack Connect stream 被拒絕時 fallback 至一般 Slack reply
+- **解決問題**：短回覆在 SDK flush 前被拒絕時消失或誤報成功
+- **影響**：Slack Connect 環境下的回覆可靠性提升
+
+### ⭐ Memory LanceDB 熱重載修復
+
+- **用途**：多項修復確保 `memory-lancedb` plugin 的 auto-recall/auto-capture hooks 在 live config 變更時正確啟停
+- **解決問題**：停用 plugin 後 hooks 仍在運作；啟用 hooks 需要重啟
+- **影響**：live config 變更即時生效
+
+### ⭐ Cron MCP Runtime 清理 ([#69145](https://github.com/openclaw/openclaw/pull/69145))
+
+- **用途**：統一 cron run 結束、session rollover、`deleteAfterRun` fallback 的 MCP runtime 清理路徑
+- **解決問題**：孤立的 MCP process 累積
+- **影響**：資源洩漏風險降低
+
+### ⭐ Browser Chrome MCP 逾時恢復 ([#69733](https://github.com/openclaw/openclaw/pull/69733))
+
+- **用途**：`navigate_page` 逾時後重置 cached session；click 逾時傳播 abort signal
+- **解決問題**：一次卡住的導航/點擊會 poison browser profile 直到 Gateway 重啟
+- **影響**：瀏覽器工具自動恢復，無需手動重啟
+
+### ⭐ Bedrock Prompt Caching Profile 解析修復 ([#69953](https://github.com/openclaw/openclaw/pull/69953))
+
+- **用途**：解析 opaque application inference profile target 後再注入 cache point；暫時性 lookup 失敗改為重試
+- **解決問題**：false negative 被 cache 導致整個 process 期間 prompt caching 失效
+- **影響**：Bedrock prompt caching 可靠性提升
+
+### ⭐ Gateway Channel Health 誤判重啟修復 ([#69833](https://github.com/openclaw/openclaw/pull/69833))
+
+- **用途**：stale-socket recovery 改為基於 provider-proven transport activity 而非 inbound app-event freshness
+- **解決問題**：安靜的 Slack/Discord/Telegram/Matrix 通道因無用戶流量而被誤判為 stale 並重啟
+- **影響**：低流量通道不再被不必要地重啟
+
+### ⭐ 多項 Live Config 熱重載修復
+
+- **用途**：Memory-LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Amazon Bedrock、Codex、GitHub Copilot 等 plugin 均改為從 live runtime snapshot 讀取 config
+- **解決問題**：toggling plugin config 需要重啟才能生效
+- **影響**：所有主要 plugin 的 config 變更即時生效
+
+---
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 4 | 7 | 8 | xAI 多模態、TUI 本地模式、/models add、診斷匯出、騰訊雲/Bedrock Mantle、WhatsApp/Session/UI 強化 |
+| 安全性 | 3 | 5 | 3 | Sandbox symlink 防護、Control UI auth gate、session-history 重驗、fail-closed 核准、dotenv 阻擋 |
+| 錯誤修復 | 3 | 7 | 6 | WhatsApp 重複訊息、config merge/恢復、Telegram/Discord 穩定性、plugin 載入、live config 熱重載 |
+| **總計** | **10** | **19** | **17** | **46 項重點更新** |
+
+**發佈日期**: 2026-04-22
+**版本**: 2026.4.22
+**狀態**: Production Ready
+**GitHub Release**: [v2026.4.22](https://github.com/openclaw/openclaw/releases/tag/v2026.4.22)


### PR DESCRIPTION
## Summary

Add zh-TW release notes for OpenClaw v2026.4.22.

### Contents
- 升級前必讀: 3 breaking changes + 5 highlights
- 功能更新: 4⭐⭐⭐ + 7⭐⭐ + 8⭐ = 19 items
- 安全性提升: 3⭐⭐⭐ + 5⭐⭐ + 3⭐ = 11 items
- 錯誤修復: 3⭐⭐⭐ + 7⭐⭐ + 6⭐ = 16 items
- Total: 46 items with ASCII flowcharts for all ⭐⭐⭐ items

Closes #492