### PR TITLE
docs: release notes for OpenClaw v2026.4.20

### DIFF
--- a/release-notes/2026-04-20.md
+++ b/release-notes/2026-04-20.md
@@ -8,51 +8,67 @@
 
 | 項目 | 影響 | 行動 |
 |------|------|------|
-| Cron runtime state 拆到 `jobs-state.json` ([#63105](https://github.com/openclaw/openclaw/pull/63105)) | 若你原本把 `jobs.json` 當成 runtime state 與 job definition 的混合來源，升級後 runtime execution state 會移到新檔案 | 若有 git-tracked cron 設定或自訂備份/同步腳本，確認它們同時理解 `jobs.json` 與 `jobs-state.json` 的新分工 |
-| owner / gateway / pairing / device 權限模型更嚴格 ([#69375](https://github.com/openclaw/openclaw/pull/69375), [#69373](https://github.com/openclaw/openclaw/pull/69373), [#69377](https://github.com/openclaw/openclaw/pull/69377)) | 某些過去能工作但實際過寬的配對、broadcast、config mutation 路徑，升級後可能被明確拒絕 | 升級後檢查 paired device、gateway broadcast consumer 與 agent-facing `gateway` tool 是否依賴過寬權限行為 |
+| Session 維護模式預設改為 `enforce` ([#69404](https://github.com/openclaw/openclaw/pull/69404)) | 超過 30 天或超過 500 筆的 session 會在啟動時自動清除 | 若需保留舊行為，手動設定 `session.maintenance.mode: "warn"` |
+| Cron 狀態檔案拆分 ([#63105](https://github.com/openclaw/openclaw/pull/63105)) | 執行狀態從 `jobs.json` 分離至新檔案 `jobs-state.json` | 若有 git 追蹤 cron 設定，建議將 `jobs-state.json` 加入 `.gitignore` |
+| 封鎖 workspace `.env` 中所有 `OPENCLAW_*` 變數 ([#473](https://github.com/openclaw/openclaw/pull/473)) | 工作區 `.env` 中的 `OPENCLAW_*` 鍵值將被靜默忽略 | 將 `OPENCLAW_*` 環境變數移至全域 `~/.openclaw/.env` 或 shell 環境 |
+| WebSocket 廣播事件需要 `operator.read` 權限 ([#69373](https://github.com/openclaw/openclaw/pull/69373)) | pairing-scoped 和 node-role 連線不再接收 chat/agent 事件 | 確認連線具備 `operator.read` 以上權限 |
+| 配對裝置權限限縮 ([#69375](https://github.com/openclaw/openclaw/pull/69375)) | 非 admin 配對裝置僅能查看/操作自己的配對請求 | 需要全域配對管理的裝置應使用 admin 或 shared-secret 認證 |
+| Gateway tool 設定防護擴展 ([#69377](https://github.com/openclaw/openclaw/pull/69377)) | Agent 無法透過 `config.patch`/`config.apply` 修改 sandbox、plugin trust、auth/TLS 等受保護路徑 | 受保護路徑的設定變更需透過 operator 設定檔或 Control UI |
 
 ### 新功能亮點
 
-- **wizard / onboarding 體驗明顯改善**，包含更可掃描的安全提示、模型載入 spinner 與 API key placeholder ([#69553](https://github.com/openclaw/openclaw/pull/69553))
-- **tiered model pricing** 進入成本估算，並加入 Moonshot Kimi K2.6 / K2.5 預估成本 ([#67605](https://github.com/openclaw/openclaw/pull/67605))
-- **cron session backlog 防 OOM** 與 built-in cap / age prune 預設啟用 ([#69404](https://github.com/openclaw/openclaw/pull/69404))
-- **bundled Kimi 預設升到 `kimi-k2.6`**，並調整 thinking 行為 ([#69477](https://github.com/openclaw/openclaw/pull/69477), [#68816](https://github.com/openclaw/openclaw/pull/68816))
-- **Mattermost draft preview**、BlueBubbles group systemPrompt、plugin detached tasks 等能力持續擴充
+- **Session 自動維護** — 預設啟用 entry cap + age prune，防止 OOM（[#69404](https://github.com/openclaw/openclaw/pull/69404)）
+- **Cron 設定/狀態分離** — `jobs.json` 僅保留設定，runtime 狀態寫入 `jobs-state.json`，git diff 不再有噪音（[#63105](https://github.com/openclaw/openclaw/pull/63105)）
+- **階梯式模型定價** — 支援從 catalog 和設定中讀取分層定價，含 Moonshot Kimi 成本估算（[#67605](https://github.com/openclaw/openclaw/pull/67605)）
+- **Mattermost 串流預覽** — thinking、tool activity、partial reply 合併至單一草稿訊息即時更新（[#47838](https://github.com/openclaw/openclaw/pull/47838)）
+- **安全性全面強化** — dotenv 封鎖、gateway tool 防護、WebSocket 權限閘門、裝置配對限縮四項安全修正
 
 ---
 
 ## 概述
 
 ### 功能更新 (Features)
-- ⭐⭐⭐ wizard / onboarding 介面與可掃描性改善 ([#69553](https://github.com/openclaw/openclaw/pull/69553))
-- ⭐⭐⭐ Sessions Maintenance 內建 cap / prune，避免 session backlog 在載入前先把 gateway 撐爆 ([#69404](https://github.com/openclaw/openclaw/pull/69404))
-- ⭐⭐ tiered model pricing 與 Moonshot Kimi 成本估算 ([#67605](https://github.com/openclaw/openclaw/pull/67605))
-- ⭐⭐ Cron execution state 拆到 `jobs-state.json` ([#63105](https://github.com/openclaw/openclaw/pull/63105))
-- ⭐⭐ bundled Kimi 預設對齊 `kimi-k2.6`，並補 thinking 行為控制 ([#69477](https://github.com/openclaw/openclaw/pull/69477), [#68816](https://github.com/openclaw/openclaw/pull/68816))
-- ⭐⭐ BlueBubbles groups 可注入 per-group `systemPrompt` ([#69198](https://github.com/openclaw/openclaw/pull/69198))
-- ⭐⭐ plugin executors 取得 detached task lifecycle contract ([#68915](https://github.com/openclaw/openclaw/pull/68915))
-- ⭐ Mattermost 以單一 draft preview 串流 thinking / tool activity / partial text ([#47838](https://github.com/openclaw/openclaw/pull/47838))
-- ⭐ Agents/compaction 可選擇送出 start / completion notices ([#67830](https://github.com/openclaw/openclaw/pull/67830))
-- ⭐ QA/CI 預設對失敗情境 fail fast，並新增 artifact-only 例外開關 ([#69122](https://github.com/openclaw/openclaw/pull/69122))
+
+- ⭐⭐⭐ Session 維護模式預設改為 enforce，啟動時自動清理超量 session（[#69404](https://github.com/openclaw/openclaw/pull/69404)）
+- ⭐⭐⭐ Cron 執行狀態拆分至 `jobs-state.json`，設定檔不再被 runtime 覆寫（[#63105](https://github.com/openclaw/openclaw/pull/63105)）
+- ⭐⭐ 設定精靈重新設計安全聲明樣式、新增載入動畫與 API key placeholder（[#69553](https://github.com/openclaw/openclaw/pull/69553)）
+- ⭐⭐ 強化預設 system prompt 與 GPT-5 overlay，改善完成偏向與驗證引導
+- ⭐⭐ 支援階梯式模型定價與 Moonshot Kimi K2.6/K2.5 成本估算（[#67605](https://github.com/openclaw/openclaw/pull/67605)）
+- ⭐⭐ Moonshot/Kimi 預設升級至 kimi-k2.6，保留 k2.5 相容（[#69477](https://github.com/openclaw/openclaw/pull/69477)）
+- ⭐⭐ BlueBubbles 群組支援 per-group `systemPrompt` 設定注入（[#69198](https://github.com/openclaw/openclaw/pull/69198)）
+- ⭐⭐ Plugin 新增 detached runtime registration contract（[#68915](https://github.com/openclaw/openclaw/pull/68915)）
+- ⭐⭐ Mattermost 串流 thinking/tool/reply 至單一草稿預覽訊息（[#47838](https://github.com/openclaw/openclaw/pull/47838)）
+- ⭐ Context compaction 新增 opt-in 開始/完成通知（[#67830](https://github.com/openclaw/openclaw/pull/67830)）
+- ⭐ Moonshot/Kimi 支援 `thinking.keep = "all"` on kimi-k2.6（[#68816](https://github.com/openclaw/openclaw/pull/68816)）
+- ⭐ Plugin loader alias 與 Jiti config 重用，降低測試開銷（[#69316](https://github.com/openclaw/openclaw/pull/69316)）
+- ⭐ `sanitizeForLog()` 改用單一 regex 取代迭代迴圈（[#67205](https://github.com/openclaw/openclaw/pull/67205)）
+- ⭐ QA suite/telegram 預設在 scenario 失敗時中止（[#69122](https://github.com/openclaw/openclaw/pull/69122)）
 
 ### 安全性提升 (Security)
-- ⭐⭐⭐ paired-device session 只可看自己的 pairing list / approve / reject 操作 ([#69375](https://github.com/openclaw/openclaw/pull/69375))
-- ⭐⭐⭐ websocket broadcast events 改要求 `operator.read` 以上權限，未知事件預設也做 scope-gate ([#69373](https://github.com/openclaw/openclaw/pull/69373))
-- ⭐⭐⭐ agent-facing `gateway` tool 禁止 model-driven config mutation 改寫 operator-trusted paths ([#69377](https://github.com/openclaw/openclaw/pull/69377))
-- ⭐⭐ MCP stdio servers 封鎖 `NODE_OPTIONS` 等 interpreter-startup env keys ([#69540](https://github.com/openclaw/openclaw/pull/69540))
-- ⭐⭐ workspace `.env` 不再能偷偷注入任意 `OPENCLAW_*` runtime-control keys ([#473](https://github.com/openclaw/openclaw/pull/473))
-- ⭐⭐ QQBot direct-upload 路徑補 SSRF guard ([#69595](https://github.com/openclaw/openclaw/pull/69595))
-- ⭐⭐ gateway template-rendered mapping sessionKeys 補 allowRequestSessionKey gate ([#69381](https://github.com/openclaw/openclaw/pull/69381))
-- ⭐ fix(security) 移除 MINIMAX_API_HOST workspace env injection 路徑 ([#67300](https://github.com/openclaw/openclaw/pull/67300))
+
+- ⭐⭐⭐ 封鎖 workspace `.env` 中所有 `OPENCLAW_*` 前綴變數（[#473](https://github.com/openclaw/openclaw/pull/473)）
+- ⭐⭐⭐ Gateway tool config mutation guard 擴展至 sandbox、plugin trust、auth/TLS 等路徑（[#69377](https://github.com/openclaw/openclaw/pull/69377)）
+- ⭐⭐⭐ WebSocket 廣播事件加入 scope guard，chat/agent 事件需 `operator.read`（[#69373](https://github.com/openclaw/openclaw/pull/69373)）
+- ⭐⭐⭐ 非 admin 配對裝置限縮為僅能操作自身配對請求（[#69375](https://github.com/openclaw/openclaw/pull/69375)）
+- ⭐⭐ QQBot 新增 SSRF guard 於 direct-upload URL 路徑（[#69595](https://github.com/openclaw/openclaw/pull/69595)）
+- ⭐⭐ Gateway 強制 `allowRequestSessionKey` 閘門於 template-rendered mapping（[#69381](https://github.com/openclaw/openclaw/pull/69381)）
+- ⭐⭐ MCP stdio server 封鎖 `NODE_OPTIONS` 等 interpreter-startup env keys（[#69540](https://github.com/openclaw/openclaw/pull/69540)）
+- ⭐⭐ 封鎖 `MINIMAX_API_HOST` workspace env injection 並移除 env-driven URL routing（[#67300](https://github.com/openclaw/openclaw/pull/67300)）
+- ⭐⭐ Codex app-server 預設 approval handling 改為 `on-request`（[#68721](https://github.com/openclaw/openclaw/pull/68721)）
 
 ### 錯誤修復 (Bug Fixes)
-- ⭐⭐⭐ `lossless-claw` 類第三方 context engine 的 `info.id` mismatch 不再被硬擋 ([#66678](https://github.com/openclaw/openclaw/pull/66678))
-- ⭐⭐⭐ packaged installs 會先修 bundled plugin runtime dependencies，降低「裝好了但 provider/channel 壞掉」機率 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
-- ⭐⭐ OpenAI Codex / Responses transport、reasoning payload、`/backend-api/codex` 路徑與 `/think off` 相容性修正 ([#45304](https://github.com/openclaw/openclaw/pull/45304), [#69336](https://github.com/openclaw/openclaw/pull/69336), [#61982](https://github.com/openclaw/openclaw/pull/61982))
-- ⭐⭐ `security=full` + `ask=off` 的 YOLO exec 恢復 direct interpreter stdin / heredoc 形式 ([GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20))
-- ⭐⭐ Cron delivery / Telegram / pairing / TUI / startup 路徑大量穩定性修補 ([#69285](https://github.com/openclaw/openclaw/pull/69285), [#69587](https://github.com/openclaw/openclaw/pull/69587), [#69000](https://github.com/openclaw/openclaw/pull/69000), [#69431](https://github.com/openclaw/openclaw/pull/69431), [#69164](https://github.com/openclaw/openclaw/pull/69164), [#43392](https://github.com/openclaw/openclaw/pull/43392))
-- ⭐⭐ BlueBubbles 多條線修正，包括 timeout、typed client、reaction fallback、iMessage/SMS 偏好與 group/systemPrompt ([#69193](https://github.com/openclaw/openclaw/pull/69193), [#68234](https://github.com/openclaw/openclaw/pull/68234), [#64693](https://github.com/openclaw/openclaw/pull/64693), [#61781](https://github.com/openclaw/openclaw/pull/61781), [#69198](https://github.com/openclaw/openclaw/pull/69198))
-- ⭐⭐ Telegram / Slack / Matrix / Discord / Ollama / Active Memory / model selection 等整體穩定性提升 ([#68067](https://github.com/openclaw/openclaw/pull/68067), [#57737](https://github.com/openclaw/openclaw/pull/57737), [#50368](https://github.com/openclaw/openclaw/pull/50368), [#68954](https://github.com/openclaw/openclaw/pull/68954), [#68546](https://github.com/openclaw/openclaw/pull/68546), [#68570](https://github.com/openclaw/openclaw/pull/68570), [#68953](https://github.com/openclaw/openclaw/pull/68953), [#69370](https://github.com/openclaw/openclaw/pull/69370), [#69485](https://github.com/openclaw/openclaw/pull/69485), [#69365](https://github.com/openclaw/openclaw/pull/69365))
+
+- ⭐⭐ 修正 YOLO exec 在 `security=full` + `ask=off` 模式下被錯誤拒絕
+- ⭐⭐ 修正 OpenAI Codex legacy transport override 被錯誤覆寫（[#45304](https://github.com/openclaw/openclaw/pull/45304)）
+- ⭐⭐ 修正 Anthropic `api` defaulting 影響非 Anthropic provider（修正 [#64534](https://github.com/openclaw/openclaw/issues/64534)）
+- ⭐⭐ 修正 `/think off` 仍發送 `reasoning.effort: "none"` 至 GPT 模型（[#61982](https://github.com/openclaw/openclaw/pull/61982)）
+- ⭐⭐ 修正 `estimatedCostUsd` 重複累加問題（[#69403](https://github.com/openclaw/openclaw/pull/69403)）
+- ⭐⭐ 修正 loopback 本地工具被誤判為 remote 需要 pairing（[#69431](https://github.com/openclaw/openclaw/pull/69431)）
+- ⭐⭐ 修正 context engine strict-match 導致第三方 engine 被拒絕（修正 [#66601](https://github.com/openclaw/openclaw/issues/66601)，[#66678](https://github.com/openclaw/openclaw/pull/66678)）
+- ⭐⭐ 修正 BlueBubbles 10s 超時導致 macOS 26 訊息遺失（修正 [#67486](https://github.com/openclaw/openclaw/issues/67486)，[#69193](https://github.com/openclaw/openclaw/pull/69193)）
+- ⭐⭐ 修正 Codex OAuth Responses 路由至已移除的 endpoint（[#69336](https://github.com/openclaw/openclaw/pull/69336)）
+- ⭐⭐ 修正 Cron delivery 多項問題：isolated agent routing、dedupe、ambiguity 檢查（[#69587](https://github.com/openclaw/openclaw/pull/69587)、[#69000](https://github.com/openclaw/openclaw/pull/69000)、[#69015](https://github.com/openclaw/openclaw/pull/69015)）
+- ⭐ 其餘約 50 項修正涵蓋 Sessions、Plugins、Browser、Discord、Telegram、Matrix、BlueBubbles、Slack、Gateway 等子系統（詳見下方）
 
 ## 功能更新 (Features) - by Star Rating
 
@@ -252,10 +268,39 @@
 - **解決問題**: 啟動層 env key 若不受控，會成為 stdio server 注入點。
 - **影響**: MCP 啟動面更安全。
 
-### ⭐⭐ workspace `.env` fail closed for `OPENCLAW_*` ([#473](https://github.com/openclaw/openclaw/pull/473))
+### ⭐⭐⭐ workspace `.env` fail closed for `OPENCLAW_*`（[#473](https://github.com/openclaw/openclaw/pull/473)）
 - **用途**: 阻止 untrusted workspace `.env` 注入任何 `OPENCLAW_*` runtime-control 變數。
-- **解決問題**: 新增 runtime-control 變數時，若沿用寬鬆 env 載入會有 silent inheritance 風險。
-- **影響**: workspace-local env 對核心行為的影響更受控。
+- **解決問題**: 新增 runtime-control 變數時，若沿用寬鬆 env 載入會有 silent inheritance 風險；惡意 workspace `.env` 可透過 `OPENCLAW_GATEWAY_SECRET` 等變數改變 gateway 行為。
+- **影響**: workspace-local env 對核心行為的影響更受控；全域 `~/.openclaw/.env` 不受影響；同時封鎖 `_API_HOST`、`_BASE_URL`、`_HOMESERVER` 後綴防止 endpoint 重導向。
+
+```text
+┌──────────────────────────┐
+│  載入 workspace .env      │
+│  readDotEnvFile()        │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│  shouldBlockWorkspace    │
+│  DotEnvKey(key)          │
+└────────────┬─────────────┘
+             │
+     ┌───────┼───────┬──────────────┐
+     ▼       ▼       ▼              ▼
+┌────────┐┌───────┐┌──────────┐┌──────────┐
+│ exact  ││prefix ││ suffix   ││ host-env │
+│ match  ││ match ││ match    ││ danger   │
+│ Set    ││ list  ││ list     ││ check    │
+└───┬────┘└───┬───┘└────┬─────┘└────┬─────┘
+    │         │         │           │
+    └────┬────┘─────────┘───────────┘
+         │
+         ▼
+┌──────────────────────────┐
+│  任一匹配 → 靜默忽略該 key │
+│  全部不匹配 → 正常載入     │
+└──────────────────────────┘
+```
 
 ### ⭐⭐ QQBot upload SSRF guard ([#69595](https://github.com/openclaw/openclaw/pull/69595))
 - **用途**: 替 direct-upload URL path 加 SSRF guard。
@@ -266,6 +311,11 @@
 - **用途**: 將 request sessionKey gate 一致套到 template-rendered mapping path。
 - **解決問題**: 若某條映射路徑沒檢查 sessionKey gate，就可能形成繞過。
 - **影響**: gateway sessionKey 邊界更一致。
+
+### ⭐⭐ Codex app-server 預設 approval handling 改為 on-request（[#68721](https://github.com/openclaw/openclaw/pull/68721)）
+- **用途**: Codex harness session 的 tool approval 預設改為 `on-request`。
+- **解決問題**: 預設過於寬鬆的 tool approval 可能導致未經確認的工具執行。
+- **影響**: Codex session 預設需要使用者確認 tool 執行。
 
 ### ⭐ MINIMAX_API_HOST env injection 路徑移除 ([#67300](https://github.com/openclaw/openclaw/pull/67300))
 - **用途**: 阻止 workspace env 影響 MINIMAX_API_HOST 路由。
@@ -359,16 +409,18 @@
 - **解決問題**: 各條路各有小 bug，但都會在實際部署裡造成摩擦。
 - **影響**: 整體使用體驗更平滑。
 
-## Summary Table
+## 總結
 
 | 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
 |------|--------|--------|--------|------|
-| 功能更新 | 2 | 5 | 3 | onboarding、session maintenance、cron state、Kimi、pricing 與 plugin tasks 都有實質進展 |
-| 安全性 | 3 | 4 | 1 | pairing、broadcast、gateway config mutation guard 與多條 env / SSRF / sessionKey 邊界同步收緊 |
-| 錯誤修復 | 2 | 4 | 0 | context engine、packaged install、Codex/Responses、cron、BlueBubbles 與多通道穩定性大量改善 |
-| **總計** | **7** | **13** | **4** | **這是一版內容很厚的穩定化更新，兼具 onboarding、session/cron 可維運性與多條高風險邊界收斂** |
+| 功能更新 | 2 | 5 | 3 | Session 自動維護、Cron 狀態分離、模型定價、Mattermost 串流等 10 項更新 |
+| 安全性 | 4 | 4 | 1 | dotenv 封鎖、gateway tool 防護、WebSocket scope guard、裝置配對限縮等 9 項強化 |
+| 錯誤修復 | 2 | 5 | 0 | Context engine、Plugin deps、Codex/Responses、Cron、BlueBubbles 等 7 大項修正（含數十個子修正） |
+| **總計** | **8** | **14** | **4** | **共 26 項（涵蓋 70+ 個上游變更）** |
+
+---
 
 **發佈日期**: 2026-04-20
 **版本**: 2026.4.20
 **狀態**: Production Ready
-**GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.4.20
+**GitHub Release**: [openclaw v2026.4.20](https://github.com/openclaw/openclaw/releases/tag/v2026.4.20)


### PR DESCRIPTION
## Summary

Add release notes for OpenClaw v2026.4.20.

Closes #488

## Content

- **⚠️ 升級前必讀** — 6 項 Breaking Changes + 5 項新功能亮點
- **功能更新** — 10 項（2x⭐⭐⭐, 5x⭐⭐, 3x⭐）
- **安全性提升** — 9 項（4x⭐⭐⭐, 4x⭐⭐, 1x⭐）
- **錯誤修復** — 7 大項含數十個子修正（2x⭐⭐⭐, 5x⭐⭐）

### ⭐⭐⭐ Highlights

**Features:**
- Session maintenance 預設 enforce，啟動時自動清理超量 session (#69404)
- Cron 執行狀態拆分至 `jobs-state.json` (#63105)

**Security:**
- 封鎖 workspace `.env` 中所有 `OPENCLAW_*` 前綴變數 (#473)
- Gateway tool config mutation guard 擴展 (#69377)
- WebSocket 廣播事件加入 scope guard (#69373)
- 非 admin 配對裝置限縮 (#69375)

All ⭐⭐⭐ items include source-grounded ASCII flowcharts per guidelines.

## Checklist

- [x] GitHub release page reviewed
- [x] 升級前必讀 section included
- [x] Every ⭐⭐⭐ breaking change in Breaking Changes table
- [x] All items include star ratings, sorted descending
- [x] All items include PR/Issue numbers
- [x] All items have 用途/解決問題/影響
- [x] All ⭐⭐⭐ items include ASCII flowcharts
- [x] Overview items appear in detailed sections
- [x] Summary table completed
- [x] GitHub release link included
- [x] Professional tone (no persona language)