### PR TITLE
docs: add release notes for OpenClaw v2026.4.22 (zh-TW)

### DIFF
--- a/release-notes/2026-04-22.md
+++ b/release-notes/2026-04-22.md
@@ -8,17 +8,17 @@
 
 | 項目 | 影響 | 行動 |
 |------|------|------|
-| Codex CLI auth import 路徑移除 | `openclaw models auth login` 不再從 `~/.codex` 複製 OAuth 憑證 | 改用瀏覽器登入或 device pairing；新增 ChatGPT device-code auth 選項 |
-| Config merge 語意變更 | `config set` 對 model/provider map 預設為 merge 而非 replace | 需要完整覆蓋時改用 `config set --replace`；一般使用者受益於 additive 行為 |
-| Codex Guardian mode 設定變更 | 移除 `OPENCLAW_CODEX_APP_SERVER_GUARDIAN` 環境變數 | 改用 plugin config `appServer.mode: "guardian"` 或 `OPENCLAW_CODEX_APP_SERVER_MODE=guardian` |
+| Codex CLI auth import 移除 | OpenClaw 不再從 `~/.codex` 複製 OAuth 材料至 agent auth stores | 改用瀏覽器登入或 device pairing ([#70390](https://github.com/openclaw/openclaw/pull/70390)) |
+| Codex Guardian mode 設定變更 | `OPENCLAW_CODEX_APP_SERVER_GUARDIAN` 捷徑移除 | 改用 plugin config `appServer.mode: "guardian"` 或 `OPENCLAW_CODEX_APP_SERVER_MODE=guardian` |
+| Thinking 預設值提升至 medium | reasoning-capable 模型的隱含預設從 `off`/`low` 提升至 `medium` | 若需舊行為，明確設定 thinking level 為 `off` 或 `low` |
 
 ### 新功能亮點
 
-- **xAI 圖片/TTS/STT**：完整支援 `grok-imagine-image` 圖片生成、六種語音 TTS、`grok-stt` 語音轉文字，以及 Voice Call 即時轉錄
-- **TUI 本地嵌入模式**：無需 Gateway 即可在終端機執行對話，保留 plugin 核准機制
-- **`/models add` 動態註冊**：從聊天中直接新增模型，無需重啟 Gateway
-- **診斷匯出**：一鍵產生隱私安全的診斷包，方便 bug report 附件
-- **騰訊雲 Provider**：新增 bundled 騰訊雲 plugin，含 TokenHub onboarding 與 `hy3-preview` 模型
+- **xAI 全方位媒體**：image generation、TTS（6 種語音）、STT、realtime 語音轉錄
+- **TUI 本地嵌入模式**：無需 Gateway 即可在終端機聊天，保留 plugin approval gates
+- **`/models add` 指令**：從聊天中直接註冊模型，無需重啟 Gateway
+- **WhatsApp per-group systemPrompt**：每群組/每 DM 獨立行為指令，支援 `"*"` wildcard
+- **Plugin 啟動 Jiti 優化**：bundled plugin 載入時間減少 82-90%
 
 ---
 
@@ -26,577 +26,634 @@
 
 ### 功能更新 (Features)
 
-- ⭐⭐⭐ xAI 圖片生成/TTS/STT 完整支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
-- ⭐⭐⭐ TUI 本地嵌入模式 ([#66767](https://github.com/openclaw/openclaw/pull/66767))
-- ⭐⭐⭐ `/models add` 動態模型註冊 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
-- ⭐⭐⭐ 診斷匯出功能 ([#70324](https://github.com/openclaw/openclaw/pull/70324))
-- ⭐⭐ 騰訊雲 Provider plugin ([#68460](https://github.com/openclaw/openclaw/pull/68460))
-- ⭐⭐ Amazon Bedrock Mantle Claude Opus 4.7 支援
-- ⭐⭐ WhatsApp 原生引用回覆與 per-group systemPrompt
-- ⭐⭐ Session 列表 mailbox 篩選 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
-- ⭐⭐ Control UI 個人化身份與佈局優化 ([#70362](https://github.com/openclaw/openclaw/pull/70362))
-- ⭐⭐ GPT-5 prompt overlay 共享化
-- ⭐⭐ STT Voice Call 串流轉錄擴展（Deepgram、ElevenLabs、Mistral）
-- ⭐ Tokenjuice 壓縮 plugin ([#69946](https://github.com/openclaw/openclaw/pull/69946))
-- ⭐ ACPX OpenClaw MCP bridge ([#70595](https://github.com/openclaw/openclaw/pull/70595))
-- ⭐ Claude CLI warm stdio session 與 resume ([#69679](https://github.com/openclaw/openclaw/pull/69679))
-- ⭐ Pi 套件更新至 0.68.1
-- ⭐ Plugin 啟動 Jiti 載入加速 82-90% ([#69925](https://github.com/openclaw/openclaw/pull/69925))
-- ⭐ Doctor plugin 啟動加速 74% ([#69840](https://github.com/openclaw/openclaw/pull/69840))
-- ⭐ 泰文翻譯支援
-- ⭐ `/status` Runner 欄位 ([#70595](https://github.com/openclaw/openclaw/pull/70595))
+- ⭐⭐⭐ xAI image generation / TTS / STT 全方位媒體支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
+- ⭐⭐⭐ TUI 本地嵌入模式：無 Gateway 終端機聊天 ([#66767](https://github.com/openclaw/openclaw/pull/66767))
+- ⭐⭐⭐ Codex CLI auth import 移除（Breaking Change）([#70390](https://github.com/openclaw/openclaw/pull/70390))
+- ⭐⭐ `/models add <provider> <modelId>` 從聊天註冊模型 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
+- ⭐⭐ WhatsApp native reply quoting 與 per-group/per-direct `systemPrompt` ([#59553](https://github.com/openclaw/openclaw/pull/59553))
+- ⭐⭐ `sessions_list` mailbox-style 篩選器 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
+- ⭐⭐ Control UI 個人身份設定（名稱 + 本地 avatar）([#70362](https://github.com/openclaw/openclaw/pull/70362))
+- ⭐⭐ Gateway 診斷匯出：sanitized logs/status/health/config/stability snapshots ([#70324](https://github.com/openclaw/openclaw/pull/70324))
+- ⭐⭐ Tencent Cloud provider plugin（TokenHub onboarding、hy3-preview）([#68460](https://github.com/openclaw/openclaw/pull/68460))
+- ⭐⭐ Amazon Bedrock Mantle Claude Opus 4.7 ([#70595](https://github.com/openclaw/openclaw/pull/70595))
+- ⭐⭐ GPT-5 prompt overlay 共享至所有相容 provider
+- ⭐⭐ Tokenjuice：壓縮 Pi embedded runs 中的 exec/bash 工具結果 ([#69946](https://github.com/openclaw/openclaw/pull/69946))
+- ⭐⭐ Plugin 啟動 Jiti 優化：bundled plugin 載入減少 82-90% ([#69925](https://github.com/openclaw/openclaw/pull/69925))
+- ⭐ STT Voice Call streaming：Deepgram、ElevenLabs、Mistral
+- ⭐ ACPX MCP bridge：`openClawToolsMcpBridge` 注入 core MCP server
+- ⭐ CLI doctor plugins 啟動加速 ~74% ([#69840](https://github.com/openclaw/openclaw/pull/69840))
+- ⭐ OpenAI native `web_search` 自動啟用
+- ⭐ Onboarding 自動安裝缺失 plugin
+- ⭐ Docs 泰文翻譯支援
+- ⭐ OpenAI-compatible 本地後端 streaming-usage 標記 ([#68711](https://github.com/openclaw/openclaw/pull/68711))
 
 ### 安全性提升 (Security)
 
-- ⭐⭐⭐ OpenShell sandbox symlink 穿越防護 ([#69798](https://github.com/openclaw/openclaw/pull/69798))
-- ⭐⭐⭐ Control UI config auth gate 強化 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
-- ⭐⭐⭐ Gateway session-history stream 重新驗證
-- ⭐⭐ Codex harness 權限核准 fail-closed 強化 ([#70356](https://github.com/openclaw/openclaw/pull/70356))
-- ⭐⭐ npm plugin 完整性漂移偵測
-- ⭐⭐ Gateway pairing 反向代理安全
-- ⭐⭐ `.env` dotenv 覆蓋阻擋（Matrix、Mattermost、IRC、Synology）([#70240](https://github.com/openclaw/openclaw/pull/70240))
-- ⭐⭐ Telegram `/models` 群組授權強化 ([#70235](https://github.com/openclaw/openclaw/pull/70235))
-- ⭐ Plugin 來源目錄逃逸阻擋 ([#69868](https://github.com/openclaw/openclaw/pull/69868))
-- ⭐ Matrix DM allowlist 隔離
-- ⭐ `uuid` 依賴安全更新至 14.0.0
+- ⭐⭐⭐ OpenShell sandbox symlink 防護：pin fd + ancestor chain walk ([#69798](https://github.com/openclaw/openclaw/pull/69798))
+- ⭐⭐⭐ dotenv endpoint blocking：Matrix/Mattermost/IRC/Synology 端點設定 ([#70240](https://github.com/openclaw/openclaw/pull/70240))
+- ⭐⭐⭐ Control UI auth：`/__openclaw/control-ui-config.json` 需認證 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
+- ⭐⭐⭐ Codex Guardian mode fail-closed：未知 approval method 拒絕 ([#70356](https://github.com/openclaw/openclaw/pull/70356))
+- ⭐⭐ Telegram model-picker auth：群組 callback 需相同 `/models` 授權 ([#70235](https://github.com/openclaw/openclaw/pull/70235))
+- ⭐⭐ Plugin discovery escape rejection ([#69868](https://github.com/openclaw/openclaw/pull/69868))
+- ⭐⭐ npm plugin integrity drift fail-closed
+- ⭐⭐ Gateway pairing：forwarded-header 偵測阻止 loopback auto-pairing
+- ⭐⭐ Session history auth：SSE keepalive 前重新檢查認證
+- ⭐ Codex ACP 隔離 `CODEX_HOME` 避免 clobber 使用者 auth ([#70234](https://github.com/openclaw/openclaw/issues/70234))
+- ⭐ Codex approval prompt 顯示 sanitized permission targets ([#70340](https://github.com/openclaw/openclaw/pull/70340))
 
 ### 錯誤修復 (Bug Fixes)
 
-- ⭐⭐⭐ WhatsApp 重複外送訊息防護 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
-- ⭐⭐⭐ Config merge 語意修復（防止 model/provider map 意外覆蓋）
-- ⭐⭐⭐ Config gateway 崩潰迴圈恢復
-- ⭐⭐ Telegram webhook/polling 可靠性修復 ([#70146](https://github.com/openclaw/openclaw/pull/70146), [#69873](https://github.com/openclaw/openclaw/pull/69873))
-- ⭐⭐ Discord partial thread 崩潰修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
-- ⭐⭐ Plugin 啟動/探索/載入穩定性強化
-- ⭐⭐ Gateway 重啟/續接可靠性修復 ([#63406](https://github.com/openclaw/openclaw/pull/63406))
-- ⭐⭐ Thinking defaults 提升至 medium ([#70281](https://github.com/openclaw/openclaw/pull/70281))
-- ⭐⭐ Moonshot Kimi K2.6 tool call ID 修復 ([#70030](https://github.com/openclaw/openclaw/pull/70030))
-- ⭐⭐ Slack Connect streaming fallback ([#70370](https://github.com/openclaw/openclaw/pull/70370))
-- ⭐ Memory LanceDB 熱重載修復
-- ⭐ Cron MCP runtime 清理 ([#69145](https://github.com/openclaw/openclaw/pull/69145))
-- ⭐ Browser Chrome MCP 逾時恢復 ([#69733](https://github.com/openclaw/openclaw/pull/69733))
-- ⭐ Bedrock prompt caching profile 解析修復 ([#69953](https://github.com/openclaw/openclaw/pull/69953))
-- ⭐ Gateway channel health 誤判重啟修復 ([#69833](https://github.com/openclaw/openclaw/pull/69833))
-- ⭐ 多項 live config 熱重載修復（Memory-LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Bedrock、Codex、GitHub Copilot）
+- ⭐⭐⭐ Config clobber 防護：missing metadata/gateway.mode/sharp size drop 時還原 last-known-good ([#70336](https://github.com/openclaw/openclaw/issues/70336))
+- ⭐⭐⭐ MCP process tree 清理：stdio MCP 關閉時終止 process tree ([#68809](https://github.com/openclaw/openclaw/issues/68809), [#69465](https://github.com/openclaw/openclaw/issues/69465))
+- ⭐⭐⭐ Linux OOM score：child processes 提升 `oom_score_adj`，保護 Gateway ([#70419](https://github.com/openclaw/openclaw/pull/70419))
+- ⭐⭐ WhatsApp outbound 重複傳送修復：in-memory delivery claim 防止 reconnect drain 重複 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
+- ⭐⭐ Moonshot/Kimi K2.6 tool-call ID 修復：停止 strict-sanitize 原生 ID ([#70030](https://github.com/openclaw/openclaw/pull/70030))
+- ⭐⭐ Config `$include` 寫入修復：plugin install/update 寫入 included 檔案 ([#41050](https://github.com/openclaw/openclaw/issues/41050))
+- ⭐⭐ Config reload 從 source config 規劃，避免 false restart ([#68732](https://github.com/openclaw/openclaw/issues/68732))
+- ⭐⭐ Models auth merge：re-auth 不再覆蓋其他 provider 的 aliases ([#70435](https://github.com/openclaw/openclaw/pull/70435))
+- ⭐⭐ Slack Connect streaming fallback 修復 ([#70370](https://github.com/openclaw/openclaw/pull/70370))
+- ⭐⭐ Gateway stale-socket recovery 改用 transport activity 判斷 ([#69833](https://github.com/openclaw/openclaw/pull/69833))
+- ⭐⭐ Pi embedded runs tool allowlist 修復（Pi 0.68.1 相容）([#70281](https://github.com/openclaw/openclaw/pull/70281))
+- ⭐⭐ 多項 live config hot-reload 修復（LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Bedrock、Codex、GitHub Copilot）
+- ⭐ Discord partial channel 修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
+- ⭐ Telegram webhook timeout 降至 5s ([#70146](https://github.com/openclaw/openclaw/pull/70146))
+- ⭐ Telegram polling 409 重建 HTTP transport ([#69873](https://github.com/openclaw/openclaw/pull/69873))
+- ⭐ Claude CLI session OAuth refresh 穩定性 ([#70452](https://github.com/openclaw/openclaw/pull/70452))
+- ⭐ Browser Chrome MCP navigate/click timeout 修復 ([#69733](https://github.com/openclaw/openclaw/pull/69733), [#63524](https://github.com/openclaw/openclaw/pull/63524))
+- ⭐ Ollama thinking control 轉發 `/think off` ([#69967](https://github.com/openclaw/openclaw/pull/69967))
+- ⭐ OpenAI-compatible malformed tool-call argument 修復 ([#70294](https://github.com/openclaw/openclaw/pull/70294))
 
 ---
 
-## 功能更新詳細說明
+## 功能更新 (Features) - by Star Rating
 
-### ⭐⭐⭐ xAI 圖片生成/TTS/STT 完整支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
+### ⭐⭐⭐ xAI 全方位媒體支援 ([#68694](https://github.com/openclaw/openclaw/pull/68694))
 
-- **用途**：為 xAI provider 新增圖片生成（`grok-imagine-image` / `grok-imagine-image-pro`）、參考圖片編輯、六種即時語音 TTS（MP3/WAV/PCM/G.711）、`grok-stt` 語音轉文字，以及 Voice Call 即時串流轉錄
-- **解決問題**：xAI 用戶過去僅能使用文字模型，無法利用 xAI 的多模態能力
-- **影響**：xAI 成為 OpenClaw 中首個同時支援圖片生成、TTS、STT 與即時轉錄的完整多模態 provider
+- **用途**：新增 xAI image generation（`grok-imagine-image` / `grok-imagine-image-pro`）、reference-image edits、6 種 xAI 語音 TTS（MP3/WAV/PCM/G.711）、`grok-stt` 音訊轉錄、xAI realtime Voice Call streaming 轉錄
+- **解決問題**：xAI 生態系缺乏原生圖片生成、語音合成與語音辨識整合
+- **影響**：xAI 用戶獲得完整的多媒體能力，涵蓋圖片、語音、即時轉錄
 
 ```text
 ┌──────────────────┐
-│  使用者請求       │
-│  (文字/語音/圖片) │
+│  xAI Provider     │
 └────────┬─────────┘
          │
-    ┌────┴─────┬──────────┐
-    │          │          │
-    ▼          ▼          ▼
-┌────────┐ ┌────────┐ ┌──────────┐
-│ 圖片   │ │  TTS   │ │   STT    │
-│ 生成   │ │ 語音   │ │ 語音轉文 │
-│ /編輯  │ │ 合成   │ │ 字/即時  │
-└────┬───┘ └────┬───┘ └────┬─────┘
-     │          │          │
-     ▼          ▼          ▼
-┌────────┐ ┌────────┐ ┌──────────┐
-│ grok-  │ │ 6 種   │ │ grok-stt │
-│ imagine│ │ 即時   │ │ + Voice  │
-│ -image │ │ 語音   │ │ Call 串流 │
-└────────┘ └────────┘ └──────────┘
+    ┌────┴────────────────┬──────────────┐
+    │                     │              │
+    ▼                     ▼              ▼
+┌──────────┐     ┌──────────────┐  ┌─────────┐
+│ Image Gen│     │ TTS          │  │ STT     │
+│ • imagine│     │ • 6 voices   │  │ • batch │
+│ • pro    │     │ • MP3/WAV/   │  │ • Voice │
+│ • edits  │     │   PCM/G.711  │  │   Call  │
+└──────────┘     └──────────────┘  │   realtime│
+                                   └─────────┘
 ```
 
 ### ⭐⭐⭐ TUI 本地嵌入模式 ([#66767](https://github.com/openclaw/openclaw/pull/66767))
 
-- **用途**：在終端機中直接執行對話，無需啟動 Gateway，同時保留 plugin 核准機制
-- **解決問題**：輕量使用場景（如快速提問、離線環境）仍需啟動完整 Gateway 才能互動
-- **影響**：大幅降低入門門檻；開發者可直接 `openclaw tui` 開始對話，需要 Gateway 功能的 API 呼叫會明確提示
+- **用途**：在終端機中直接執行聊天，無需啟動 Gateway，同時保留 plugin approval gates
+- **解決問題**：輕量使用場景仍需啟動完整 Gateway
+- **影響**：開發者可快速進入聊天，降低入門門檻
 
 ```text
 ┌──────────────────┐
-│  openclaw tui    │
+│  TUI 啟動         │
+└────────┬─────────┘
+         │
+    ┌────┴────┐
+    │ Gateway │
+    │ 可用?   │
+    └────┬────┘
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+  有 GW     無 GW
+  正常連線   本地嵌入模式
+              │
+              ▼
+        ┌──────────────┐
+        │ 本地 LLM 執行 │
+        │ + plugin     │
+        │   approval   │
+        │   gates 保留  │
+        └──────────────┘
+```
+
+### ⭐⭐⭐ Codex CLI Auth Import 移除（Breaking Change）([#70390](https://github.com/openclaw/openclaw/pull/70390))
+
+- **用途**：移除 onboarding 與 provider discovery 中的 Codex CLI auth import 路徑，不再從 `~/.codex` 複製 OAuth 材料至 agent auth stores
+- **解決問題**：跨工具 OAuth 材料複製帶來的安全與一致性風險
+- **影響**：**Breaking Change** — 需改用瀏覽器登入或 device pairing
+
+```text
+┌──────────────────────┐
+│  Codex 認證           │
+└──────────┬───────────┘
+           │
+      ┌────┴────┐
+      │ 舊路徑   │
+      │ (已移除) │
+      └────┬────┘
+           │ ✗ ~/.codex → agent auth
+           │
+      ┌────┴────────────┐
+      │ 新路徑           │
+      └────┬────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+  瀏覽器     Device
+  OAuth      Pairing
+  登入       (headless)
+```
+
+### ⭐⭐ `/models add` 指令 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
+
+- **用途**：從聊天中直接 `/models add <provider> <modelId>` 註冊模型，無需重啟 Gateway
+- **解決問題**：新增模型需手動編輯設定並重啟
+- **影響**：模型管理更便捷，`/models` 保持為簡單 provider 瀏覽器
+
+### ⭐⭐ WhatsApp Native Reply Quoting + Per-Group SystemPrompt ([#59553](https://github.com/openclaw/openclaw/pull/59553))
+
+- **用途**：WhatsApp 對話支援 native reply quoting（`replyToMode`），並可設定 per-group/per-direct `systemPrompt`，支援 `"*"` wildcard fallback 與 account-scoped overrides
+- **解決問題**：WhatsApp 群組無法設定獨立行為指令，回覆缺乏引用上下文
+- **影響**：每個群組/DM 可有獨立的 AI 行為設定
+
+### ⭐⭐ Sessions List Mailbox-Style 篩選器 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
+
+- **用途**：`sessions_list` 新增 label、agent、search 篩選器，加上 visibility-scoped derived title 與 last-message previews
+- **解決問題**：session 列表缺乏篩選與預覽能力
+- **影響**：session 管理體驗大幅提升
+
+### ⭐⭐ Control UI 個人身份設定 ([#70362](https://github.com/openclaw/openclaw/pull/70362))
+
+- **用途**：新增 browser-local 個人身份（名稱 + 本地 avatar），統一 user identity rendering，收緊 Quick Settings 與窄螢幕 chat layouts
+- **解決問題**：operator 無法個人化 Control UI 顯示
+- **影響**：個人化不再浪費空間或裁切控制項
+
+### ⭐⭐ Gateway 診斷匯出 ([#70324](https://github.com/openclaw/openclaw/pull/70324))
+
+- **用途**：預設啟用 payload-free stability recording，新增 support-ready 診斷匯出（sanitized logs/status/health/config/stability snapshots）
+- **解決問題**：bug report 缺乏結構化診斷資料
+- **影響**：問題回報更高效
+
+### ⭐⭐ Tencent Cloud Provider Plugin ([#68460](https://github.com/openclaw/openclaw/pull/68460))
+
+- **用途**：新增 bundled Tencent Cloud provider plugin，含 TokenHub onboarding、docs、`hy3-preview` model catalog、tiered Hy3 pricing metadata
+- **解決問題**：缺乏 Tencent Cloud 原生整合
+- **影響**：中國大陸用戶新增 provider 選項
+
+### ⭐⭐ Amazon Bedrock Mantle Claude Opus 4.7
+
+- **用途**：透過 Mantle 的 Anthropic Messages route 新增 Claude Opus 4.7，provider-owned bearer-auth streaming
+- **解決問題**：AWS bearer tokens 被當作 Anthropic API keys 使用
+- **影響**：Bedrock 用戶可正確呼叫 Claude Opus 4.7
+
+### ⭐⭐ GPT-5 Prompt Overlay 共享
+
+- **用途**：將 GPT-5 prompt overlay 移至 shared provider runtime，所有相容 GPT-5 模型透過 OpenAI/OpenRouter/OpenCode/Codex 等 provider 獲得相同行為與 heartbeat guidance
+- **解決問題**：GPT-5 行為指引僅限 OpenAI plugin
+- **影響**：新增 `agents.defaults.promptOverlays.gpt5.personality` 全域 toggle
+
+### ⭐⭐ Tokenjuice ([#69946](https://github.com/openclaw/openclaw/pull/69946))
+
+- **用途**：bundled opt-in plugin，壓縮 Pi embedded runs 中的 noisy `exec` 和 `bash` 工具結果
+- **解決問題**：工具輸出佔用過多 context window
+- **影響**：context 使用更高效
+
+### ⭐⭐ Plugin 啟動 Jiti 優化 ([#69925](https://github.com/openclaw/openclaw/pull/69925))
+
+- **用途**：built bundled plugin dist modules 優先使用 native Jiti loading，source TypeScript 保留 transform path
+- **解決問題**：bundled plugin 載入時間過長
+- **影響**：載入時間減少 82-90%
+
+### ⭐ STT Voice Call Streaming：Deepgram、ElevenLabs、Mistral
+
+- **用途**：新增 Deepgram、ElevenLabs、Mistral 的 Voice Call streaming 轉錄；ElevenLabs 另增 Scribe v2 batch 音訊轉錄
+- **解決問題**：Voice Call streaming STT 僅支援 OpenAI 與 xAI
+- **影響**：更多 STT provider 選擇
+
+### ⭐ ACPX MCP Bridge
+
+- **用途**：新增 `openClawToolsMcpBridge` 選項，注入 core OpenClaw MCP server 供選定內建工具使用（首先支援 `cron`）
+- **解決問題**：ACP 環境缺乏 OpenClaw 內建工具的 MCP 存取
+- **影響**：ACP 環境可透過 MCP 使用 cron 等工具
+
+### ⭐ CLI Doctor Plugins 啟動加速 ([#69840](https://github.com/openclaw/openclaw/pull/69840))
+
+- **用途**：lazy-load doctor plugin paths，優先使用 installed plugin `dist/*` runtime entries
+- **解決問題**：`doctor --non-interactive` 啟動過慢
+- **影響**：啟動時間減少約 74%
+
+### ⭐ OpenAI Native `web_search` 自動啟用
+
+- **用途**：direct OpenAI Responses models 啟用 web search 時自動使用 OpenAI 原生 `web_search` tool
+- **解決問題**：需手動設定 managed search provider
+- **影響**：明確設定的 provider（如 Brave）仍使用 managed `web_search` tool
+
+### ⭐ Onboarding 自動安裝缺失 Plugin
+
+- **用途**：setup 期間自動安裝缺失的 provider 與 channel plugins
+- **解決問題**：首次設定需手動恢復 plugin
+- **影響**：首次設定體驗更順暢
+
+### ⭐ OpenAI-Compatible 本地後端 Streaming-Usage 標記 ([#68711](https://github.com/openclaw/openclaw/pull/68711))
+
+- **用途**：標記 vLLM、SGLang、llama.cpp、LM Studio 等已知本地後端為 streaming-usage compatible
+- **解決問題**：本地後端 token accounting 退化為 unknown/stale totals
+- **影響**：token 計量更準確
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ OpenShell Sandbox Symlink 防護 ([#69798](https://github.com/openclaw/openclaw/pull/69798))
+
+- **用途**：pin verified file reads 至已開啟的 descriptor，walk ancestor chain 偵測 symlinked parents，re-check file identity 防止 parent symlink swap
+- **解決問題**：parent symlink swap 可將 in-sandbox reads 重導至 host files（allowed mount root 外）
+- **影響**：sandbox 檔案讀取的 TOCTOU 攻擊向量被封堵
+
+```text
+┌──────────────────┐
+│  Sandbox 檔案讀取 │
 └────────┬─────────┘
          │
          ▼
 ┌──────────────────────┐
-│  偵測 Gateway 狀態    │
+│  開啟檔案 → 取得 fd   │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  從 fd 驗證 identity  │
+│  (非路徑 realpath)    │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  Walk ancestor chain  │
+│  偵測 symlinked       │
+│  parents              │
+└────────┬─────────────┘
+         │
+         ▼
+┌──────────────────────┐
+│  Re-check identity    │
+│  → 在 mount root 內?  │
 └────────┬─────────────┘
     ┌────┴────┐
     │         │
     ▼         ▼
-┌────────┐ ┌──────────────┐
-│ 有     │ │ 無 Gateway   │
-│ Gateway│ │ → 本地嵌入   │
-│ → 連線 │ │   模式啟動   │
-└────────┘ └──────┬───────┘
-                  │
-                  ▼
-           ┌──────────────┐
-           │ Plugin 核准   │
-           │ 機制保留      │
-           │ (Gateway API  │
-           │  呼叫明確提示) │
-           └──────────────┘
+  允許讀取   拒絕
+             (symlink 逃逸)
 ```
 
-### ⭐⭐⭐ `/models add` 動態模型註冊 ([#70211](https://github.com/openclaw/openclaw/pull/70211))
+### ⭐⭐⭐ Dotenv Endpoint Blocking ([#70240](https://github.com/openclaw/openclaw/pull/70240))
 
-- **用途**：從聊天中直接執行 `/models add <provider> <modelId>` 註冊新模型，無需重啟 Gateway
-- **解決問題**：新增模型需要手動編輯 config 並重啟 Gateway，中斷所有進行中的對話
-- **影響**：模型管理即時化；`/models` 同時升級為 provider 瀏覽器，提供複製友善的指令範例
+- **用途**：阻止 workspace `.env` 覆寫 Matrix、Mattermost、IRC、Synology 端點設定
+- **解決問題**：cloned workspaces 可透過 local endpoint config 重導 bundled connector traffic
+- **影響**：防止惡意 workspace 劫持連接器流量
 
 ```text
-┌──────────────────────────────┐
-│  /models add ollama llama4   │
-└──────────────┬───────────────┘
-               │
-               ▼
+┌──────────────────────┐
+│  Workspace .env 載入  │
+└──────────┬───────────┘
+           │
+           ▼
 ┌──────────────────────────┐
-│  驗證 provider 與 modelId │
-└──────────────┬───────────┘
-               │
-               ▼
-┌──────────────────────────┐
-│  寫入 agents.defaults     │
-│  .models (merge 語意)     │
-└──────────────┬───────────┘
-               │
-               ▼
-┌──────────────────────────┐
-│  即時可用於 /models 與    │
-│  /model 切換（無需重啟）  │
-└──────────────────────────┘
+│  Endpoint 設定檢查        │
+│  Matrix / Mattermost /   │
+│  IRC / Synology          │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+   非端點設定  端點設定
+   允許覆寫    阻止覆寫
+               (防止流量劫持)
 ```
 
-### ⭐⭐⭐ 診斷匯出功能 ([#70324](https://github.com/openclaw/openclaw/pull/70324))
+### ⭐⭐⭐ Control UI Auth 強化 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
 
-- **用途**：透過 `openclaw gateway diagnostics export` 一鍵產生隱私安全的診斷包，包含 sanitized logs、status、health、config 與 stability snapshots
-- **解決問題**：提交 bug report 時需手動收集多項資訊，且容易洩漏敏感資料
-- **影響**：bug report 流程標準化；聊天內容、webhook body、工具輸出、憑證等均自動遮蔽
+- **用途**：`gateway.auth` 啟用時，`/__openclaw/control-ui-config.json` 需認證才能存取
+- **解決問題**：未認證呼叫者可讀取 bootstrap metadata
+- **影響**：Control UI 設定端點受認證保護
 
 ```text
-┌───────────────────────────────────┐
-│  openclaw gateway diagnostics     │
-│  export                           │
-└──────────────┬────────────────────┘
-               │
-               ▼
 ┌──────────────────────────┐
-│  收集診斷資料             │
-│  • stability recording   │
-│  • sanitized logs        │
-│  • status/health snapshot│
-│  • config shape          │
-└──────────────┬───────────┘
-               │
-               ▼
+│  GET /control-ui-config  │
+└──────────┬───────────────┘
+           │
+           ▼
 ┌──────────────────────────┐
-│  隱私遮蔽                 │
-│  • 移除聊天文字           │
-│  • 移除 webhook body     │
-│  • 移除憑證/cookie       │
-│  • 移除帳號/訊息 ID      │
-└──────────────┬───────────┘
-               │
-               ▼
-┌──────────────────────────┐
-│  輸出 ZIP 診斷包          │
-│  (可安全附加至 bug report)│
-└──────────────────────────┘
+│  gateway.auth 啟用?       │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+    啟用       未啟用
+      │         │
+      ▼         ▼
+  認證檢查    直接回應
+      │
+  ┌───┴───┐
+  │       │
+  ▼       ▼
+通過    拒絕 401
+回應
 ```
 
-### ⭐⭐ 騰訊雲 Provider Plugin ([#68460](https://github.com/openclaw/openclaw/pull/68460))
+### ⭐⭐⭐ Codex Guardian Mode Fail-Closed ([#70356](https://github.com/openclaw/openclaw/pull/70356))
 
-- **用途**：新增 bundled 騰訊雲 provider plugin，含 TokenHub onboarding、文件、`hy3-preview` 模型目錄與分層定價
-- **解決問題**：中國大陸用戶缺乏原生支援的國產雲端 LLM provider
-- **影響**：騰訊雲用戶可直接透過 OpenClaw 使用混元模型
+- **用途**：未知 native app-server approval method 拒絕通過，不再路由至 OpenClaw approval grants
+- **解決問題**：未來新增的 approval shapes 可能被錯誤地自動核准
+- **影響**：Guardian mode 安全性提升，**Breaking Change** — 舊 `OPENCLAW_CODEX_APP_SERVER_GUARDIAN` 捷徑移除
 
-### ⭐⭐ Amazon Bedrock Mantle — Claude Opus 4.7
+```text
+┌──────────────────────┐
+│  App-Server Approval  │
+│  請求                 │
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────────┐
+│  Approval method 已知?    │
+└──────────┬───────────────┘
+      ┌────┴────┐
+      │         │
+      ▼         ▼
+    已知       未知
+    正常處理    拒絕
+    (Guardian   (fail-closed)
+     審核)
+```
 
-- **用途**：透過 Mantle 的 Anthropic Messages 路由新增 Claude Opus 4.7，使用 provider-owned bearer-auth streaming
-- **解決問題**：Bedrock 用戶無法透過標準 AWS bearer token 呼叫 Opus 4.7
-- **影響**：Bedrock 用戶可直接使用最新 Claude 模型；IAM-backed bearer token 支援 runtime 自動刷新
+### ⭐⭐ Telegram Model-Picker Auth ([#70235](https://github.com/openclaw/openclaw/pull/70235))
 
-### ⭐⭐ WhatsApp 原生引用回覆與 per-group systemPrompt ([#59553](https://github.com/openclaw/openclaw/pull/59553))
+- **用途**：群組 model-picker callbacks 需與 `/models` 相同授權
+- **解決問題**：未授權參與者可透過 inline buttons 瀏覽或變更 session model
+- **影響**：群組模型選擇受授權保護
 
-- **用途**：新增可設定的原生引用回覆（`replyToMode`）與 per-group/per-direct `systemPrompt` 注入
-- **解決問題**：WhatsApp 對話缺乏引用上下文；不同群組無法設定不同的行為指令
-- **影響**：支援 `"*"` wildcard fallback 與帳號級覆蓋，帳號 map 完整取代 root map
+### ⭐⭐ Plugin Discovery Escape Rejection ([#69868](https://github.com/openclaw/openclaw/pull/69868))
 
-### ⭐⭐ Session 列表 Mailbox 篩選 ([#69839](https://github.com/openclaw/openclaw/pull/69839))
+- **用途**：拒絕 escape package directory 的 plugin source entries
+- **解決問題**：plugin source entries 可能逃逸至 package directory 外
+- **影響**：plugin 載入路徑更安全
 
-- **用途**：`sessions_list` 新增 label、agent、search 篩選，以及 visibility-scoped 衍生標題與最後訊息預覽
-- **解決問題**：大量 session 時難以快速找到目標對話
-- **影響**：session 管理體驗接近 email client 的 mailbox 模式
+### ⭐⭐ npm Plugin Integrity Drift Fail-Closed
 
-### ⭐⭐ Control UI 個人化身份與佈局優化 ([#70362](https://github.com/openclaw/openclaw/pull/70362))
+- **用途**：exact pinned npm plugin 或 hook-pack 更新偵測到 integrity drift 時 fail closed
+- **解決問題**：integrity 不符的更新可能被靜默接受
+- **影響**：`openclaw update --json` 顯示 aborted plugin drift 詳情
 
-- **用途**：新增 browser-local 個人身份（名稱 + 本地安全頭像），統一 chat/avatar 渲染路徑，優化 Quick Settings 與窄螢幕佈局
-- **解決問題**：操作者缺乏個人化識別；窄螢幕下控制項被裁切
-- **影響**：提升操作者體驗，個人化不再浪費空間
+### ⭐⭐ Gateway Pairing Forwarded-Header 偵測
 
-### ⭐⭐ GPT-5 Prompt Overlay 共享化
+- **用途**：偵測 `Forwarded`、`X-Forwarded-*`、`X-Real-IP` 作為 proxied WebSocket traffic 證據，阻止 loopback shared-secret auto-pairing
+- **解決問題**：reverse-proxy 拓撲可能利用 loopback helper auto-pairing 路徑
+- **影響**：proxy 環境下的 pairing 安全性提升
 
-- **用途**：將 GPT-5 prompt overlay 移至共享 provider runtime，所有相容 GPT-5 模型（OpenAI、OpenRouter、OpenCode、Codex 等）統一接收行為與 heartbeat 指引
-- **解決問題**：各 provider 的 GPT-5 行為不一致
-- **影響**：新增 `agents.defaults.promptOverlays.gpt5.personality` 全域 toggle
+### ⭐⭐ Session History Auth 重新檢查
 
-### ⭐⭐ STT Voice Call 串流轉錄擴展
+- **用途**：SSE keepalive 與 transcript update 前重新檢查 auth 與 `chat.history` scope
+- **解決問題**：active session-history streams 在 auth revocation 後仍可傳送事件
+- **影響**：auth 撤銷即時生效
 
-- **用途**：為 Deepgram、ElevenLabs、Mistral 新增 Voice Call 串流轉錄；ElevenLabs 另增 Scribe v2 批次音訊轉錄
-- **解決問題**：即時語音轉錄僅限 OpenAI 與 xAI
-- **影響**：更多 STT provider 可用於 Voice Call 場景
+### ⭐ Codex ACP 隔離 CODEX_HOME ([#70234](https://github.com/openclaw/openclaw/issues/70234))
 
-### ⭐ Tokenjuice 壓縮 Plugin ([#69946](https://github.com/openclaw/openclaw/pull/69946))
+- **用途**：bundled Codex ACP harness 使用隔離的 `CODEX_HOME`，避免寫入不完整的 ChatGPT auth bridge files
+- **解決問題**：Codex ACP sessions clobber 使用者的 Codex CLI auth
+- **影響**：ACP 與使用者 auth 互不干擾
 
-- **用途**：opt-in plugin，壓縮 Pi embedded run 中 `exec` 和 `bash` 工具的冗長輸出
-- **解決問題**：工具輸出佔用過多 context window
-- **影響**：減少 token 消耗，提升長對話穩定性
+### ⭐ Codex Approval Prompt Sanitized Targets ([#70340](https://github.com/openclaw/openclaw/pull/70340))
 
-### ⭐ ACPX OpenClaw MCP Bridge
-
-- **用途**：新增 `openClawToolsMcpBridge` 選項，為選定的內建工具（如 `cron`）注入 MCP server
-- **解決問題**：ACP 模式下無法使用部分 OpenClaw 內建工具
-- **影響**：ACP 整合更完整
-
-### ⭐ Claude CLI Warm Stdio Session 與 Resume ([#69679](https://github.com/openclaw/openclaw/pull/69679))
-
-- **用途**：`claude-cli` 預設使用 warm stdio session，Gateway 重啟後自動 resume
-- **解決問題**：每次 Gateway 重啟都需要重新建立 Claude CLI session
-- **影響**：Claude CLI 對話連續性提升
-
-### ⭐ Plugin 啟動 Jiti 載入加速 82-90% ([#69925](https://github.com/openclaw/openclaw/pull/69925))
-
-- **用途**：bundled plugin 優先使用原生 Jiti 載入，TypeScript 保留 transform 路徑
-- **解決問題**：plugin 啟動時間過長
-- **影響**：啟動速度顯著提升
-
-### ⭐ Doctor Plugin 啟動加速 74% ([#69840](https://github.com/openclaw/openclaw/pull/69840))
-
-- **用途**：lazy-load doctor plugin 路徑，優先使用已建置的 `dist/*` runtime
-- **解決問題**：`doctor --non-interactive` 執行時間過長
-- **影響**：診斷流程更快速
-
-### ⭐ `/status` Runner 欄位 ([#70595](https://github.com/openclaw/openclaw/pull/70595))
-
-- **用途**：`/status` 新增 `Runner:` 欄位，顯示 session 使用的 runtime（embedded Pi、CLI-backed、ACP harness）
-- **解決問題**：無法從 status 判斷 session 的執行環境
-- **影響**：除錯與監控更直觀
+- **用途**：app-server approval prompts 顯示 bounded、sanitized permission target samples
+- **解決問題**：permission requests 可能洩漏 home usernames 或 URL credentials
+- **影響**：核准提示更安全，保留 hosts/roots/paths 可見性
 
 ---
 
-## 安全性提升詳細說明
+## 錯誤修復 (Bug Fixes) - by Star Rating
 
-### ⭐⭐⭐ OpenShell Sandbox Symlink 穿越防護 ([#69798](https://github.com/openclaw/openclaw/pull/69798))
+### ⭐⭐⭐ Config Clobber 防護 ([#70336](https://github.com/openclaw/openclaw/issues/70336))
 
-- **用途**：pin 已開啟的 file descriptor 進行驗證讀取，走訪 ancestor chain 偵測 symlink parent，並在讀取後重新檢查 file identity，防止 parent symlink swap 將 sandbox 內讀取重導至 host 檔案
-- **解決問題**：parent symlink 替換可繞過 sandbox 的 allowed mount root 限制，讀取 host 上的任意檔案
-- **影響**：sandbox 檔案讀取安全性大幅提升；無 fd-path readlink 的平台也受保護
+- **用途**：偵測 critical clobber signatures（missing metadata、missing `gateway.mode`、sharp size drops），還原 last-known-good config
+- **解決問題**：config 被意外覆寫導致 gateway crash loops
+- **影響**：有效 backup 存在時自動恢復，防止 crash loops
 
 ```text
 ┌──────────────────────┐
-│  Sandbox 檔案讀取請求 │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────┐
-│  開啟檔案 → pin fd   │
+│  Config 寫入/載入     │
 └──────────┬───────────┘
            │
            ▼
 ┌──────────────────────────┐
-│  走訪 ancestor chain      │
-│  偵測 symlink parent      │
-│  (無 fd-path readlink     │
-│   時使用 ancestor walk)   │
-└──────────┬───────────────┘
-           │
-           ▼
-┌──────────────────────────┐
-│  驗證路徑在 allowed       │
-│  mount root 內            │
-└──────────┬───────────────┘
-           │
-      ┌────┴────┐
-      │         │
-      ▼         ▼
-┌─────────┐ ┌──────────┐
-│ 通過 →  │ │ 拒絕 →   │
-│ 讀取 fd │ │ 關閉 fd  │
-└─────────┘ └──────────┘
-```
-
-### ⭐⭐⭐ Control UI Config Auth Gate 強化 ([#70247](https://github.com/openclaw/openclaw/pull/70247))
-
-- **用途**：`gateway.auth` 啟用時，`/__openclaw/control-ui-config.json` 需通過認證才能存取
-- **解決問題**：未認證的呼叫者可讀取 bootstrap metadata
-- **影響**：防止未授權存取 Control UI 設定資訊
-
-```text
-┌──────────────────────────────┐
-│  GET /__openclaw/             │
-│  control-ui-config.json      │
-└──────────────┬───────────────┘
-               │
-               ▼
-┌──────────────────────────┐
-│  gateway.auth 啟用？      │
+│  Clobber Signature 檢查   │
+│  • metadata 存在?         │
+│  • gateway.mode 存在?     │
+│  • size drop > 閾值?      │
 └──────────┬───────────────┘
       ┌────┴────┐
       │         │
       ▼         ▼
-┌─────────┐ ┌──────────┐
-│ 是 →    │ │ 否 →     │
-│ 驗證    │ │ 直接回傳 │
-│ 認證    │ └──────────┘
-└────┬────┘
-┌────┴────┐
-│         │
-▼         ▼
-通過 →   拒絕 →
-回傳     403
+    正常       Clobber 偵測
+    載入            │
+                    ▼
+              ┌──────────────┐
+              │ 還原 last-   │
+              │ known-good   │
+              │ backup       │
+              └──────────────┘
 ```
 
-### ⭐⭐⭐ Gateway Session-History Stream 重新驗證
+### ⭐⭐⭐ MCP Process Tree 清理 ([#68809](https://github.com/openclaw/openclaw/issues/68809), [#69465](https://github.com/openclaw/openclaw/issues/69465))
 
-- **用途**：SSE keepalive 與 transcript 更新前重新檢查 auth 與 `chat.history` scope
-- **解決問題**：auth 撤銷後，已建立的 session-history stream 仍可繼續接收事件
-- **影響**：撤銷權限後立即生效，不再需要等待連線自然斷開
+- **用途**：transport close 時終止 stdio MCP process trees，session delete/reset 時 dispose bundled MCP runtimes
+- **解決問題**：orphaned wrapper/server processes 持續累積
+- **影響**：MCP 生命週期管理正確，資源不再洩漏
 
 ```text
+┌──────────────────┐
+│  MCP Transport   │
+│  Close / Session │
+│  Delete          │
+└────────┬─────────┘
+         │
+         ▼
 ┌──────────────────────┐
-│  SSE keepalive /      │
-│  transcript 更新      │
-└──────────┬───────────┘
-           │
-           ▼
+│  共享清理路徑          │
+│  • isolated cron end │
+│  • session rollover  │
+│  • deleteAfterRun    │
+│  • subagent cleanup  │
+└────────┬─────────────┘
+         │
+         ▼
 ┌──────────────────────┐
-│  重新檢查 auth 狀態   │
-│  + chat.history scope │
-└──────────┬───────────┘
-      ┌────┴────┐
-      │         │
-      ▼         ▼
-┌─────────┐ ┌──────────┐
-│ 有效 →  │ │ 已撤銷 → │
-│ 繼續    │ │ 關閉     │
-│ 推送    │ │ stream   │
-└─────────┘ └──────────┘
+│  終止 process tree    │
+│  + dispose runtime   │
+└──────────────────────┘
 ```
 
-### ⭐⭐ Codex Harness 權限核准 Fail-Closed 強化 ([#70356](https://github.com/openclaw/openclaw/pull/70356))
+### ⭐⭐⭐ Linux OOM Score 調整 ([#70419](https://github.com/openclaw/openclaw/pull/70419))
 
-- **用途**：未知的 app-server approval method 預設拒絕，而非路由至 OpenClaw approval grants
-- **解決問題**：未來新增的 approval shape 可能被錯誤地自動核准
-- **影響**：安全性預設為拒絕，防止未知權限類型被意外授予
-
-### ⭐⭐ npm Plugin 完整性漂移偵測
-
-- **用途**：pinned npm plugin 或 hook-pack 更新時偵測 integrity drift，發現時 fail closed
-- **解決問題**：供應鏈攻擊可能透過修改已安裝的 plugin 內容
-- **影響**：`openclaw update --json` 會揭露被中止的 plugin drift 詳情
-
-### ⭐⭐ Gateway Pairing 反向代理安全
-
-- **用途**：偵測 forwarded header（`Forwarded`、`X-Forwarded-*`、`X-Real-IP`）作為 proxied WebSocket 流量，阻止 loopback shared-secret auto-pairing
-- **解決問題**：反向代理拓撲可能利用 loopback helper 自動配對路徑
-- **影響**：Browser/Control-UI 客戶端維持既有的 approval-required 流程
-
-### ⭐⭐ `.env` Dotenv 覆蓋阻擋 ([#70240](https://github.com/openclaw/openclaw/pull/70240))
-
-- **用途**：阻擋 workspace `.env` 覆蓋 Matrix、Mattermost、IRC、Synology 端點設定
-- **解決問題**：clone 的 workspace 可透過 `.env` 將 bundled connector 流量重導至惡意端點
-- **影響**：防止本地 `.env` 劫持通訊通道
-
-### ⭐⭐ Telegram `/models` 群組授權強化 ([#70235](https://github.com/openclaw/openclaw/pull/70235))
-
-- **用途**：群組中的 model-picker callback 需要與 `/models` 相同的授權
-- **解決問題**：未授權的群組成員可透過 inline button 瀏覽或變更 session model
-- **影響**：群組模型管理權限一致化
-
-### ⭐ Plugin 來源目錄逃逸阻擋 ([#69868](https://github.com/openclaw/openclaw/pull/69868))
-
-- **用途**：拒絕逃逸 package 目錄的 plugin source entry
-- **解決問題**：惡意 plugin 可能透過路徑逃逸存取 package 外的檔案
-- **影響**：plugin 載入安全邊界更嚴格
-
-### ⭐ Matrix DM Allowlist 隔離
-
-- **用途**：Matrix DM allowlist 狀態不再影響 room control-command 授權
-- **解決問題**：受信任的 DM sender 可能意外獲得 room-command 存取權
-- **影響**：DM 與 room 權限完全隔離
-
-### ⭐ `uuid` 依賴安全更新至 14.0.0
-
-- **用途**：覆蓋 transitive `uuid` 依賴至 14.0.0
-- **解決問題**：清除跨依賴的 runtime advisory
-- **影響**：消除已知安全警告
-
----
-
-## 錯誤修復詳細說明
-
-### ⭐⭐⭐ WhatsApp 重複外送訊息防護 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
-
-- **用途**：外送訊息期間持有 in-memory active-delivery claim，防止 concurrent reconnect drain 重複驅動同一 pending queue entry
-- **解決問題**：30 分鐘 inbound-silence watchdog 在 mid-delivery 時觸發，導致 cron 訊息重複發送 7-12 倍
-- **影響**：claim 為 process-local，crash-replay 機制保留；WhatsApp cron 訊息不再重複
+- **用途**：gateway-managed child processes（supervisor、PTY、MCP stdio、browser）透過 `/bin/sh` shim 提升 `oom_score_adj`
+- **解決問題**：cgroup memory pressure 下 kernel 可能 kill 長壽的 gateway 而非暫時性 workers
+- **影響**：kernel 優先終止 transient workers，保護 gateway。可透過 `OPENCLAW_CHILD_OOM_SCORE_ADJ=0` 停用
 
 ```text
+┌──────────────────┐
+│  Gateway 啟動     │
+│  child process   │
+└────────┬─────────┘
+         │
+         ▼
 ┌──────────────────────┐
-│  外送訊息開始         │
-└──────────┬───────────┘
-           │
-           ▼
+│  /bin/sh shim        │
+│  提升 oom_score_adj  │
+└────────┬─────────────┘
+         │
+         ▼
 ┌──────────────────────┐
-│  取得 active-delivery │
-│  claim (in-memory)    │
-└──────────┬───────────┘
-           │
-      ┌────┴──────────────┐
-      │                   │
-      ▼                   ▼
-┌───────────┐    ┌────────────────┐
-│ 正常送出  │    │ Reconnect drain│
-│ → 釋放    │    │ 偵測到 claim   │
-│   claim   │    │ → 跳過此 entry │
-└───────────┘    └────────────────┘
+│  Memory Pressure     │
+│  → kernel 優先 kill  │
+│    child (高 OOM)    │
+│  → gateway 存活     │
+│    (低 OOM)          │
+└──────────────────────┘
 ```
 
-### ⭐⭐⭐ Config Merge 語意修復
+### ⭐⭐ WhatsApp Outbound 重複傳送修復 ([#70428](https://github.com/openclaw/openclaw/pull/70428))
 
-- **用途**：新增 `config set --merge` 進行 additive 更新，`--replace` 進行完整覆蓋；保護 model/provider map 寫入避免意外全部取代
-- **解決問題**：`openclaw models auth login` 重新認證 OAuth provider 時會清除其他 provider 的 aliases 與 per-model params（[#65920](https://github.com/openclaw/openclaw/issues/65920)、[#68392](https://github.com/openclaw/openclaw/issues/68392)、[#68653](https://github.com/openclaw/openclaw/issues/68653)）
-- **影響**：預設行為從 replace 改為 merge；需要 rename key 的 migration（如 Anthropic → Claude CLI）可 opt-in `replaceDefaultModels`
+- **用途**：outbound send 期間持有 in-memory active-delivery claim，防止 concurrent reconnect drain 重複驅動 pending queue
+- **解決問題**：30 分鐘 inbound-silence watchdog 在 mid-delivery 觸發時，cron sends 重複 7-12x
+- **影響**：crash-replay 保留（claim 為 process-local），正常傳送不再重複
 
-```text
-┌──────────────────────────┐
-│  config set 寫入請求      │
-└──────────────┬───────────┘
-               │
-          ┌────┴────┐
-          │         │
-          ▼         ▼
-┌──────────────┐ ┌──────────────┐
-│ --merge      │ │ --replace    │
-│ (預設)       │ │ (明確指定)   │
-│ additive     │ │ 完整覆蓋     │
-│ 合併既有 map │ │ 取代整個 map │
-└──────────────┘ └──────────────┘
-```
+### ⭐⭐ Moonshot/Kimi K2.6 Tool-Call ID 修復 ([#70030](https://github.com/openclaw/openclaw/pull/70030))
 
-### ⭐⭐⭐ Config Gateway 崩潰迴圈恢復
+- **用途**：停止 strict-sanitize Kimi 原生 tool_call IDs（`functions.<name>:<index>` 格式），新增 `sanitizeToolCallIds` opt-out
+- **解決問題**：multi-turn agentic flows 在 2-3 輪 tool-calling 後因 mangled IDs 失敗
+- **影響**：Kimi K2.6 multi-turn 工具呼叫正常運作
 
-- **用途**：偵測 critical clobber signatures（missing metadata、missing `gateway.mode`、sharp size drops），自動還原 last-known-good config
-- **解決問題**：config 被意外損壞時 Gateway 進入無限崩潰迴圈
-- **影響**：有效備份存在時自動恢復；另修復 `openclaw doctor --fix` 或啟動時意外加入非 JSON 前綴的 config
+### ⭐⭐ Config `$include` 寫入修復 ([#41050](https://github.com/openclaw/openclaw/issues/41050), [#66048](https://github.com/openclaw/openclaw/issues/66048))
 
-```text
-┌──────────────────────┐
-│  Gateway 啟動         │
-│  讀取 config          │
-└──────────┬───────────┘
-           │
-           ▼
-┌──────────────────────────┐
-│  檢查 clobber signatures │
-│  • missing metadata      │
-│  • missing gateway.mode  │
-│  • sharp size drop       │
-└──────────┬───────────────┘
-      ┌────┴────┐
-      │         │
-      ▼         ▼
-┌─────────┐ ┌──────────────────┐
-│ 正常 →  │ │ 偵測到損壞 →     │
-│ 繼續    │ │ 還原 last-known- │
-│ 啟動    │ │ good backup      │
-└─────────┘ └──────────────────┘
-```
+- **用途**：single-file top-level includes 的 OpenClaw-owned mutations 寫入 included 檔案（如 `plugins.json5`），不再 flatten modular `$include` configs
+- **解決問題**：`plugins install/update` 覆寫 modular config 結構
+- **影響**：modular config 結構保留
 
-### ⭐⭐ Telegram Webhook/Polling 可靠性修復 ([#70146](https://github.com/openclaw/openclaw/pull/70146), [#69873](https://github.com/openclaw/openclaw/pull/69873))
+### ⭐⭐ Config Reload 從 Source Config 規劃 ([#68732](https://github.com/openclaw/openclaw/issues/68732))
 
-- **用途**：webhook callback timeout 降至 5s 讓 Telegram 及早收到 200；polling 遇到 409 conflict 後重建 HTTP transport
-- **解決問題**：長時間 update 處理導致 Telegram 重試；409 conflict 後 polling 在已終止的 keep-alive socket 上無限迴圈
-- **影響**：Telegram 通道穩定性顯著提升
+- **用途**：gateway reload 從 source-authored config 規劃，非 runtime-materialized snapshots
+- **解決問題**：plugin update writes 觸發 false restarts（derived provider/plugin config paths）
+- **影響**：config reload 更可靠
 
-### ⭐⭐ Discord Partial Thread 崩潰修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
+### ⭐⭐ Models Auth Merge 修復 ([#70435](https://github.com/openclaw/openclaw/pull/70435))
 
-- **用途**：在 slash-command、reaction、model-picker 路徑中使用 safe accessor 讀取 `channel.parentId`
-- **解決問題**：partial `GuildThreadChannel` 的 prototype getter 拋出 `Cannot access rawData on partial Channel`
-- **影響**：`/new` 等指令在 thread 內執行不再崩潰
-
-### ⭐⭐ Plugin 啟動/探索/載入穩定性強化
-
-- **用途**：多項修復涵蓋 plugin install 時自動加入 `plugins.allow`、bundled channel catalog drift 容錯、plugin 依賴隔離
-- **解決問題**：allowlisted config 重啟後不載入已安裝 plugin；一個損壞的 bundled channel 可導致 CLI 崩潰
-- **影響**：plugin 生態系統穩定性全面提升
-
-### ⭐⭐ Gateway 重啟/續接可靠性修復 ([#63406](https://github.com/openclaw/openclaw/pull/63406))
-
-- **用途**：跨 Gateway 重啟保留 group/channel chat context、one-shot continuation instructions、restart sentinel 原子寫入
-- **解決問題**：重啟後 agent turn 遺失 prompt/routing/tool-status；continuation reply 無法回到原始 chat
-- **影響**：Gateway 重啟對使用者幾乎透明
-
-### ⭐⭐ Thinking Defaults 提升至 Medium
-
-- **用途**：reasoning-capable 模型的隱含 thinking level 從 `off`/`low` 提升至 `medium`
-- **解決問題**：未明確設定時，reasoning 模型的思考能力被低估
-- **影響**：`/status` 顯示與 runtime 一致的 resolved default
-
-### ⭐⭐ Moonshot Kimi K2.6 Tool Call ID 修復 ([#70030](https://github.com/openclaw/openclaw/pull/70030))
-
-- **用途**：停止 strict-sanitize Kimi 原生 tool_call ID（形如 `functions.<name>:<index>`），新增 `sanitizeToolCallIds` opt-out
-- **解決問題**：多輪 agentic flow 在 2-3 輪 tool-calling 後因 mangled ID 而中斷
-- **影響**：Kimi K2.6 多輪工具呼叫穩定運作
+- **用途**：`openclaw models auth login` 的 provider-owned default-model additions 改為 merge，非 replace
+- **解決問題**：re-auth OAuth provider（如 OpenAI Codex）覆蓋其他 provider 的 aliases 與 per-model params
+- **影響**：re-auth 不再破壞其他 provider 設定
 
 ### ⭐⭐ Slack Connect Streaming Fallback ([#70370](https://github.com/openclaw/openclaw/pull/70370))
 
-- **用途**：Slack Connect stream 被拒絕時 fallback 至一般 Slack reply
-- **解決問題**：短回覆在 SDK flush 前被拒絕時消失或誤報成功
-- **影響**：Slack Connect 環境下的回覆可靠性提升
+- **用途**：Slack Connect streams 在 SDK flush 前被拒絕時 fallback 至 normal replies
+- **解決問題**：short replies 消失或在 Slack 確認前報告成功
+- **影響**：Slack Connect 短回覆可靠傳送
 
-### ⭐ Memory LanceDB 熱重載修復
+### ⭐⭐ Gateway Stale-Socket Recovery ([#69833](https://github.com/openclaw/openclaw/pull/69833))
 
-- **用途**：多項修復確保 `memory-lancedb` plugin 的 auto-recall/auto-capture hooks 在 live config 變更時正確啟停
-- **解決問題**：停用 plugin 後 hooks 仍在運作；啟用 hooks 需要重啟
-- **影響**：live config 變更即時生效
+- **用途**：stale-socket recovery 改用 provider-proven transport activity 判斷，非 inbound app-event freshness
+- **解決問題**：quiet channels（Slack/Discord/Telegram/Matrix）因無 user traffic 被錯誤重啟
+- **影響**：安靜頻道不再被不必要地重啟
 
-### ⭐ Cron MCP Runtime 清理 ([#69145](https://github.com/openclaw/openclaw/pull/69145))
+### ⭐⭐ Pi Embedded Runs Tool Allowlist 修復 ([#70281](https://github.com/openclaw/openclaw/pull/70281))
 
-- **用途**：統一 cron run 結束、session rollover、`deleteAfterRun` fallback 的 MCP runtime 清理路徑
-- **解決問題**：孤立的 MCP process 累積
-- **影響**：資源洩漏風險降低
+- **用途**：保持 filtered tool-name allowlist 在 embedded OpenAI/Codex GPT-5 runs 與 compaction sessions 中活躍
+- **解決問題**：Pi `0.68.1` session-tool allowlist 變更後，bundled 與 client tools 停止執行，僅產生 plan-only replies
+- **影響**：GPT-5 runs 工具正常執行
 
-### ⭐ Browser Chrome MCP 逾時恢復 ([#69733](https://github.com/openclaw/openclaw/pull/69733))
+### ⭐⭐ 多項 Live Config Hot-Reload 修復
 
-- **用途**：`navigate_page` 逾時後重置 cached session；click 逾時傳播 abort signal
-- **解決問題**：一次卡住的導航/點擊會 poison browser profile 直到 Gateway 重啟
-- **影響**：瀏覽器工具自動恢復，無需手動重啟
+- **用途**：修復 LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Amazon Bedrock、Codex、GitHub Copilot 等 plugin 的 live config hot-reload
+- **解決問題**：多個 plugin 的設定變更需重啟才能生效（startup snapshot 復活已移除設定、disabled 設定無法 hot-enable）
+- **影響**：plugin 設定變更即時生效，無需重啟
 
-### ⭐ Bedrock Prompt Caching Profile 解析修復 ([#69953](https://github.com/openclaw/openclaw/pull/69953))
+### ⭐ Discord Partial Channel 修復 ([#69908](https://github.com/openclaw/openclaw/pull/69908))
 
-- **用途**：解析 opaque application inference profile target 後再注入 cache point；暫時性 lookup 失敗改為重試
-- **解決問題**：false negative 被 cache 導致整個 process 期間 prompt caching 失效
-- **影響**：Bedrock prompt caching 可靠性提升
+- **用途**：thread metadata handling 使用 safe accessor，避免 partial `GuildThreadChannel` prototype getters 拋出錯誤
+- **解決問題**：`/new` 等指令在 thread 內執行時 crash（`Cannot access rawData on partial Channel`）
+- **影響**：Discord thread 內指令正常運作
 
-### ⭐ Gateway Channel Health 誤判重啟修復 ([#69833](https://github.com/openclaw/openclaw/pull/69833))
+### ⭐ Telegram Webhook Timeout 降至 5s ([#70146](https://github.com/openclaw/openclaw/pull/70146))
 
-- **用途**：stale-socket recovery 改為基於 provider-proven transport activity 而非 inbound app-event freshness
-- **解決問題**：安靜的 Slack/Discord/Telegram/Matrix 通道因無用戶流量而被誤判為 stale 並重啟
-- **影響**：低流量通道不再被不必要地重啟
+- **用途**：grammY webhook callback timeout 降至 5s
+- **解決問題**：Telegram 因 read timeout 重試 long-running updates
+- **影響**：Telegram 更早收到 200 回應
 
-### ⭐ 多項 Live Config 熱重載修復
+### ⭐ Telegram Polling 409 重建 HTTP Transport ([#69873](https://github.com/openclaw/openclaw/pull/69873))
 
-- **用途**：Memory-LanceDB、Active Memory、Skill Workshop、Ollama、OpenAI、Amazon Bedrock、Codex、GitHub Copilot 等 plugin 均改為從 live runtime snapshot 讀取 config
-- **解決問題**：toggling plugin config 需要重啟才能生效
-- **影響**：所有主要 plugin 的 config 變更即時生效
+- **用途**：`getUpdates` 409 conflicts 後重建 polling HTTP transport
+- **解決問題**：retries 使用 Telegram-terminated keep-alive socket 持續失敗
+- **影響**：polling 恢復使用 fresh TCP connection
+
+### ⭐ Claude CLI Session OAuth Refresh 穩定性 ([#70452](https://github.com/openclaw/openclaw/pull/70452))
+
+- **用途**：auth epochs 改用 stable account identity 而非 mutable OAuth token material
+- **解決問題**：OAuth refresh-token rotation 導致 stored sessions 失效
+- **影響**：Claude CLI sessions 跨 token refresh 保持穩定
+
+### ⭐ Browser Chrome MCP Timeout 修復 ([#69733](https://github.com/openclaw/openclaw/pull/69733), [#63524](https://github.com/openclaw/openclaw/pull/63524))
+
+- **用途**：`navigate_page` timeout 時 reset cached session；click timeout 與 abort signals 傳播至 existing-session actions
+- **解決問題**：一次 stuck navigation/click 污染 browser profile 直到 gateway restart
+- **影響**：browser tool 自動恢復
+
+### ⭐ Ollama Thinking Control 轉發 ([#69967](https://github.com/openclaw/openclaw/pull/69967))
+
+- **用途**：OpenClaw thinking control 轉發至 native `/api/chat` 的 top-level `think`
+- **解決問題**：`/think off` 與 `openclaw agent --thinking off` 無法抑制 qwen3 等模型的 thinking
+- **影響**：Ollama thinking control 正常運作
+
+### ⭐ OpenAI-Compatible Malformed Tool-Call Argument 修復 ([#70294](https://github.com/openclaw/openclaw/pull/70294))
+
+- **用途**：啟用 malformed streamed tool-call argument repair（Kimi/SGLang 等自架後端）
+- **解決問題**：fragmented tool-call arguments 以空或不可用物件到達 tools
+- **影響**：自架後端工具呼叫可靠性提升
+
+### ⭐ Discord Auto-Thread Inheritance Opt-In ([#69986](https://github.com/openclaw/openclaw/pull/69986))
+
+- **用途**：auto-thread parent transcript inheritance 改為 opt-in（`channels.discord.thread.inheritParent`）
+- **解決問題**：新建 Discord thread sessions 預設繼承 parent transcript
+- **影響**：新 thread 預設隔離，需明確設定才繼承
+
+### ⭐ Amazon Bedrock Prompt Caching 修復 ([#69953](https://github.com/openclaw/openclaw/pull/69953))
+
+- **用途**：resolve opaque application inference profile targets 後再注入 cache points，retry transient profile lookups
+- **解決問題**：false negative 被 cache 導致 prompt caching 失效
+- **影響**：Bedrock prompt caching 更可靠
+
+### ⭐ Gateway Restart Sentinel 原子寫入 ([#70225](https://github.com/openclaw/openclaw/pull/70225))
+
+- **用途**：restart sentinel files 原子寫入
+- **解決問題**：interrupted writes 留下 truncated sentinel
+- **影響**：restart 恢復更可靠
+
+### ⭐ Mattermost Reasoning 洩漏修復 ([#69927](https://github.com/openclaw/openclaw/pull/69927))
+
+- **用途**：抑制 blockquoted `> Reasoning:` text 的 reasoning-only payloads
+- **解決問題**：`/reasoning on` 將 thinking 洩漏至 channel posts
+- **影響**：reasoning 不再洩漏至可見訊息
+
+### ⭐ QQBot INTERACTION Intent ([#70143](https://github.com/openclaw/openclaw/pull/70143))
+
+- **用途**：新增 `INTERACTION` intent（`1 << 26`）至 gateway constants 與 `FULL_INTENTS` mask
+- **解決問題**：interaction events 未被接收
+- **影響**：QQBot interaction 正常運作
+
+### ⭐ Config Validation Warnings 換行修復 ([#70140](https://github.com/openclaw/openclaw/issues/70140))
+
+- **用途**：validation warnings 使用真實換行而非 literal `\n`
+- **解決問題**：CLI/audit output 中的 `\n` 未被渲染
+- **影響**：警告訊息可讀性提升
 
 ---
 
@@ -604,10 +661,12 @@
 
 | 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
 |------|--------|--------|--------|------|
-| 功能更新 | 4 | 7 | 8 | xAI 多模態、TUI 本地模式、/models add、診斷匯出、騰訊雲/Bedrock Mantle、WhatsApp/Session/UI 強化 |
-| 安全性 | 3 | 5 | 3 | Sandbox symlink 防護、Control UI auth gate、session-history 重驗、fail-closed 核准、dotenv 阻擋 |
-| 錯誤修復 | 3 | 7 | 6 | WhatsApp 重複訊息、config merge/恢復、Telegram/Discord 穩定性、plugin 載入、live config 熱重載 |
-| **總計** | **10** | **19** | **17** | **46 項重點更新** |
+| 功能更新 | 3 | 10 | 6 | xAI 全方位媒體、TUI 本地模式、Codex auth 移除、/models add、WhatsApp systemPrompt、Jiti 優化 |
+| 安全性 | 4 | 5 | 2 | OpenShell symlink 防護、dotenv blocking、Control UI auth、Guardian fail-closed |
+| 錯誤修復 | 3 | 9 | 13 | Config clobber 防護、MCP process 清理、Linux OOM、WhatsApp 重複傳送、live config hot-reload |
+| **總計** | **10** | **24** | **21** | **本版本共 55 項重點更新** |
+
+---
 
 **發佈日期**: 2026-04-22
 **版本**: 2026.4.22


### PR DESCRIPTION
## Summary

新增 OpenClaw v2026.4.22 版本發佈說明（zh-TW）。

## 內容

- **升級前必讀**：3 項 Breaking Changes（Codex CLI auth import 移除、Codex Guardian mode 設定變更、Thinking 預設值提升至 medium）
- **功能更新**：19 項（3 ⭐⭐⭐ / 10 ⭐⭐ / 6 ⭐）
- **安全性提升**：11 項（4 ⭐⭐⭐ / 5 ⭐⭐ / 2 ⭐）
- **錯誤修復**：25 項（3 ⭐⭐⭐ / 9 ⭐⭐ / 13 ⭐）
- 所有 ⭐⭐⭐ 項目均含 ASCII flowchart
- Summary table 與 footer 完整

## References

- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.4.22
- Guidelines: `release-notes/GUIDELINES.md`

Closes #492