### PR TITLE
docs: content updates from #445 + frontmatter for 3 docs

### DIFF
--- a/docs/acp_gemini.md
+++ b/docs/acp_gemini.md
@@ -223,4 +223,4 @@ $ACPX --agent "gemini --experimental-acp" sessions new --name my-gemini-tg
 
 - [OpenClaw × ACP × Kiro 整合指南](./acp_kiro.md)
 - [OpenClaw × ACP × Codex 整合指南](./acp_codex.md)
-- [ACPX Harness 架構與演進史](../acpx-harness.md)
+- [ACPX Harness 架構與演進史](./acpx-harness.md)

--- a/docs/acp_kiro.md
+++ b/docs/acp_kiro.md
@@ -253,4 +253,36 @@ openclaw hooks list  # 確認 ✓ ready
 
 - [OpenClaw × ACP × Codex 整合指南](./acp_codex.md)
 - [OpenClaw × ACP × Gemini 整合指南](./acp_gemini.md)
-- [ACPX Harness 架構與演進史](../acpx-harness.md)
+- [ACPX Harness 架構與演進史](./acpx-harness.md)
+
+---
+
+## 補充：`openclaw acp` vs ACP Agents（ACPX Harness）
+
+本指南描述的是 **ACP Agents** 路線（OpenClaw → 啟動 Kiro CLI 執行任務）。
+
+另一個容易混淆的概念是 `openclaw acp`，方向相反：
+
+| | `openclaw acp` | 本指南（ACP Agents） |
+|---|---|---|
+| 方向 | IDE → OpenClaw | OpenClaw → Kiro CLI |
+| 用途 | IDE 透過 ACP 連接 Gateway | OpenClaw 委派任務給 Kiro |
+| 工具 | 無（純 bridge） | Kiro 原生工具（file edit、bash 等） |
+
+## 補充：CLI Backends（text-only fallback）
+
+若只需要 text-only 的安全網（API 掛掉時的 fallback），不需要完整 ACP harness，可用 CLI backends：
+
+```json5
+{
+  agents: {
+    defaults: {
+      cliBackends: {
+        "kiro-cli": { command: "/opt/homebrew/bin/kiro-cli" }
+      }
+    }
+  }
+}
+```
+
+CLI backends 停用所有工具，僅做 text in → text out，適合作為 provider 故障時的降級方案。詳見 [ACPX Harness](./acpx-harness.md#cli-backends)。

--- a/docs/acpx-harness.md
+++ b/docs/acpx-harness.md
@@ -9,6 +9,39 @@ validated_by: masami-agent
 
 ACPX（ACP eXternal）Harness 是 OpenClaw ACP（Agent Communication Protocol）的**外部執行後端橋接層**。它讓 OpenClaw gateway 能夠將 agent 任務**委派給外部 AI CLI 工具**執行，而非使用 OpenClaw 自身的內建 LLM runtime。
 
+
+## `openclaw acp` vs ACPX Harness（ACP Agents）
+
+OpenClaw 有兩個容易混淆的 ACP 概念：
+
+| | `openclaw acp` | ACPX Harness（ACP Agents） |
+|---|---|---|
+| 方向 | 外部 IDE/client → OpenClaw | OpenClaw → 外部 CLI |
+| 用途 | IDE 透過 ACP 連接 OpenClaw Gateway | OpenClaw 啟動 Codex/Claude/Gemini 執行任務 |
+| 指令 | `openclaw acp` | `/acp spawn`、binding `type: "acp"` |
+| 工具 | 無（純 bridge） | 外部 CLI 原生工具 |
+
+簡單記法：
+- **editor 想連 OpenClaw** → `openclaw acp`
+- **OpenClaw 想用外部 CLI** → ACPX Harness
+
+## CLI Backends（text-only fallback）
+
+OpenClaw 也支援 **CLI backends** 作為 API provider 掛掉時的 text-only 安全網：
+
+```json5
+{
+  agents: {
+    defaults: {
+      cliBackends: {
+        "kiro-cli": { command: "/opt/homebrew/bin/kiro-cli" }
+      }
+    }
+  }
+}
+```
+
+CLI backends 停用所有工具，僅做 text in → text out。適合作為 provider 故障時的降級方案，不需要完整 ACP harness 設定。
 ---
 
 ## 它解決了什麼痛點

--- a/docs/binding_telegram.md
+++ b/docs/binding_telegram.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-24
+validated_by: chaodu-agent
+---
+
 # Telegram Binding 指南
 
 openclaw 的 `bindings` 設定支援兩種 Telegram 綁定模式：

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-24
+validated_by: chaodu-agent
+---
+
 # CLI Quick Reference（指令速查）
 
 > 目標：把最常用的 OpenClaw 指令整理成「抄得到就能用」的速查表。

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,7 +27,7 @@ openclaw gateway status
 
 ## 1) 先決條件
 
-- Node.js LTS（建議 >= 20）
+- Node.js（需 22.14+，建議 Node 24）
 - npm
 - 可連外下載套件（公司網路可能要 proxy）
 

--- a/docs/openclaw-auto-update.md
+++ b/docs/openclaw-auto-update.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-24
+validated_by: chaodu-agent
+---
+
 # OpenClaw 自動更新流程
 
 使用 openclaw cron、Telegram 與 kiro-cli 實現自動版本檢查與更新。


### PR DESCRIPTION
## Summary

Clean re-submission of valuable content changes from #445 (closed due to merge conflicts).

## Changes

### Bug fixes
- `docs/acp_gemini.md`: fix broken relative path (`../acpx-harness.md` → `./acpx-harness.md`)
- `docs/acp_kiro.md`: fix same broken path + add `openclaw acp` vs ACP Agents comparison table + CLI Backends section
- `docs/install.md`: update Node version requirement (`>= 20` → `22.14+, recommend 24`)

### New content
- `docs/acpx-harness.md`: add `openclaw acp` vs ACPX Harness concept comparison + CLI Backends section

### Frontmatter
- Add `last_validated` + `validated_by` to `binding_telegram.md`, `cli.md`, `openclaw-auto-update.md`

Supersedes #445.