### PR TITLE
docs: add zh-TW release notes for OpenClaw v2026.4.11

### DIFF
--- a/release-notes/2026-04-11.md
+++ b/release-notes/2026-04-11.md
@@ -1,0 +1,296 @@
+# OpenClaw v2026.4.11 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.11)
+
+## 新功能亮點
+
+- **Dreaming / Memory Wiki** — 新增 ChatGPT 匯入引擎與 Imported Insights、Memory Palace 日記子分頁，讓記憶觀測面板真正可用（[#64505](https://github.com/openclaw/openclaw/pull/64505)）
+- **Control UI 結構化氣泡** — assistant 的 media/reply/voice 指令不再洩漏原始文字，改以結構化 UI 元素呈現，並新增 `[embed ...]` 富文本標籤（[#64104](https://github.com/openclaw/openclaw/pull/64104)）
+- **video_generate 大幅擴充** — URL-only 交付、typed providerOptions、reference audio、per-asset role hints、自適應比例、更高圖片上限（[#61987](https://github.com/openclaw/openclaw/pull/61987)、[#61988](https://github.com/openclaw/openclaw/pull/61988)）
+- **Feishu / Teams 互動強化** — Feishu 文件留言 session 加入反應與打字回饋；Teams 新增 reaction 支援與 delegated OAuth（[#63785](https://github.com/openclaw/openclaw/pull/63785)、[#51646](https://github.com/openclaw/openclaw/pull/51646)）
+
+---
+
+## 概述
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ Dreaming / Memory Wiki：新增 ChatGPT 匯入引擎與 Imported Insights、Memory Palace 日記子分頁（[#64505](https://github.com/openclaw/openclaw/pull/64505)）
+- ⭐⭐⭐ Control UI / webchat：assistant 指令結構化渲染、`[embed ...]` 富文本標籤、外部 embed URL 設定閘門（[#64104](https://github.com/openclaw/openclaw/pull/64104)）
+- ⭐⭐⭐ video_generate：URL-only 交付、typed providerOptions、reference audio、per-asset role hints、自適應比例、圖片上限提升（[#61987](https://github.com/openclaw/openclaw/pull/61987)、[#61988](https://github.com/openclaw/openclaw/pull/61988)）
+- ⭐⭐ Feishu：文件留言 session 強化，支援更豐富的上下文解析、留言反應、打字回饋（[#63785](https://github.com/openclaw/openclaw/pull/63785)）
+- ⭐⭐ Microsoft Teams：新增 reaction 支援、reaction 列表、Graph 分頁、delegated OAuth 設定（[#51646](https://github.com/openclaw/openclaw/pull/51646)）
+- ⭐⭐ Plugins：允許 plugin manifest 宣告 activation 與 setup descriptors（[#64780](https://github.com/openclaw/openclaw/pull/64780)）
+- ⭐ Ollama：快取 `/api/show` context-window 與 capability metadata，加速 model discovery（[#64753](https://github.com/openclaw/openclaw/pull/64753)）
+- ⭐ Models/providers：在 embedded-agent debug logs 中顯示 OpenAI-compatible endpoint 分類方式（[#64754](https://github.com/openclaw/openclaw/pull/64754)）
+- ⭐ QA/parity：新增 GPT-5.4 vs Opus 4.6 agentic parity report gate（[#64441](https://github.com/openclaw/openclaw/pull/64441)）
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ OpenAI/Codex OAuth：停止改寫上游 authorize URL scopes，修正新 Codex 登入 `invalid_scope` 失敗（[#64713](https://github.com/openclaw/openclaw/pull/64713)）
+- ⭐⭐ macOS Talk Mode：首次授予麥克風權限後繼續啟動 Talk Mode，不再需要手動重新啟用（[#62459](https://github.com/openclaw/openclaw/pull/62459)）
+- ⭐⭐ Control UI / webchat：將 agent-run TTS 音訊回覆持久化至 webchat 歷史（[#63514](https://github.com/openclaw/openclaw/pull/63514)）
+- ⭐⭐ WhatsApp：使用 active listener helper 時正確套用已設定的預設帳號（[#53918](https://github.com/openclaw/openclaw/pull/53918)）
+- ⭐⭐ Telegram/sessions：topic-scoped session 初始化保持在 canonical topic transcript 路徑（[#64869](https://github.com/openclaw/openclaw/pull/64869)）
+- ⭐⭐ Agents/failover：將 assistant-side fallback 分類限定在當前嘗試範圍（[#62907](https://github.com/openclaw/openclaw/pull/62907)）
+- ⭐⭐ Auto-reply/WhatsApp：media understanding 後保留 inbound 圖片附件備註（[#64918](https://github.com/openclaw/openclaw/pull/64918)）
+- ⭐⭐ MiniMax/OAuth：將 `api: anthropic-messages` 與 `authHeader: true` 寫入 minimax-portal config patch（[#64964](https://github.com/openclaw/openclaw/pull/64964)）
+- ⭐ Audio transcription：僅對 OpenAI-compatible multipart 請求停用 pinned DNS（[#64766](https://github.com/openclaw/openclaw/pull/64766)）
+- ⭐ ACP/agents：在 ACP parent stream 更新中隱藏 commentary-phase child assistant relay 文字
+- ⭐ Agents/timeouts：LLM idle watchdog 正確遵守明確設定的 run timeout
+- ⭐ Config：在生成的 zod schema 中包含 `asyncCompletion`（[#63618](https://github.com/openclaw/openclaw/pull/63618)）
+- ⭐ Google/Veo：停止發送不支援的 `numberOfVideos` 請求欄位（[#64723](https://github.com/openclaw/openclaw/pull/64723)）
+- ⭐ QA/packaging：packaged CLI 啟動不再讀取 repo-only QA scenario markdown（[#64648](https://github.com/openclaw/openclaw/pull/64648)）
+- ⭐ Codex/QA：Codex app-server 協調訊息不再出現在可見回覆中
+- ⭐ WhatsApp：message react 改走 gateway-owned action path
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Dreaming / Memory Wiki：ChatGPT 匯入引擎與觀測面板（[#64505](https://github.com/openclaw/openclaw/pull/64505)）
+- **用途**: 將 Dreaming 日記從純 metadata 展示升級為可用的記憶觀測面板，新增 Imported Insights（主題聚類匯入摘要）與 Memory Palace（已編譯記憶頁面檢視）兩個子分頁，並內建全頁 wiki 檢視器。
+- **解決問題**: 先前的匯入 UI 只顯示 metadata 與原始標題，無法呈現系統認為重要的內容；從 Dreaming 點進去的路徑也是壞的。
+- **影響**: 匯入的 ChatGPT 對話以合成候選材料呈現，而非單純的匯入日誌；Memory Palace 誠實反映是否已有真正的 synthesis/entity/concept 頁面。
+
+```text
+┌─────────────────────────┐
+│ ChatGPT 匯出檔匯入      │
+│ (import ingestion)      │
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│ 主題聚類 + 摘要合成      │
+│ (topic clustering)      │
+└────────────┬────────────┘
+             │
+     ┌───────┴───────┐
+     ▼               ▼
+┌──────────┐  ┌──────────────┐
+│ Imported │  │ Memory       │
+│ Insights │  │ Palace       │
+│ 子分頁    │  │ 子分頁        │
+└────┬─────┘  └──────┬───────┘
+     │               │
+     └───────┬───────┘
+             ▼
+┌─────────────────────────┐
+│ 全頁 Wiki 檢視器         │
+│ (點擊展開原始來源)        │
+└─────────────────────────┘
+```
+
+### ⭐⭐⭐ Control UI / webchat：assistant 指令結構化渲染與 embed 標籤（[#64104](https://github.com/openclaw/openclaw/pull/64104)）
+- **用途**: 將 assistant 輸出中的 `MEDIA:` 行、reply 標籤、`[[audio_as_voice]]` 正規化為結構化 UI 元素，統一富文本標籤為 `[embed ...]`，並加入可設定的 embed sandbox 模式。
+- **解決問題**: Control UI 先前將多種 assistant 輸出指令當作純文字顯示，導致 web session 洩漏原始指令文字到聊天氣泡中；embed 標籤名稱在開發過程中不一致。
+- **影響**: webchat 體驗大幅改善——media、reply、voice 指令以附件/metadata 呈現；`[embed ...]` 可在氣泡內渲染行內富文本；外部 embed URL 可透過 `gateway.controlUi.embedSandbox` 設定控管。
+
+```text
+┌──────────────────────────┐
+│ Assistant 輸出含          │
+│ MEDIA:/reply/voice 指令   │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ message-normalizer       │
+│ 正規化 pass              │
+└────────────┬─────────────┘
+             │
+     ┌───────┴───────┐
+     ▼               ▼
+┌──────────┐  ┌──────────────┐
+│ 結構化    │  │ [embed ...]  │
+│ metadata │  │ 富文本渲染    │
+│ (附件)    │  │ (行內 iframe) │
+└──────────┘  └──────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ embedSandbox config 閘門  │
+│ (powerful / isolated)    │
+└──────────────────────────┘
+```
+
+### ⭐⭐⭐ video_generate：多能力擴充與 URL-only 交付（[#61987](https://github.com/openclaw/openclaw/pull/61987)、[#61988](https://github.com/openclaw/openclaw/pull/61988)）
+- **用途**: 擴充 `video_generate` 工具：新增 typed `providerOptions`（傳遞 vendor-specific 參數如 seed/draft/camerafixed）、`inputAudios`（最多 3 個 reference audio）、`imageRoles`（per-asset 語義角色如 first_frame/last_frame）、自適應比例、圖片上限提升至 9；同時支援 URL-only 交付，provider 可回傳 pre-signed URL 而非下載完整影片。
+- **解決問題**: 真實世界的影片生成 provider（如 BytePlus Seedance 2.0）需要 audio input、per-asset role 與 vendor-specific 參數，且生成檔案可能超過 channel attachment 大小限制。
+- **影響**: video_generate 工具能力大幅擴展，支援更多 provider 與更複雜的生成場景；URL-only 交付解決大檔案傳輸瓶頸。
+
+```text
+┌──────────────────────────┐
+│ Agent 呼叫 video_generate │
+│ (含 images/audios/opts)  │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 驗證 inputAudios 數量     │
+│ 指派 imageRoles           │
+│ 傳遞 providerOptions     │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ Provider 生成影片         │
+└────────────┬─────────────┘
+             │
+     ┌───────┴───────┐
+     ▼               ▼
+┌──────────┐  ┌──────────────┐
+│ buffer   │  │ URL-only     │
+│ 回傳     │  │ 回傳          │
+│ → 存檔   │  │ → MEDIA:url  │
+└──────────┘  └──────────────┘
+```
+
+### ⭐⭐ Feishu：文件留言 session 互動強化（[#63785](https://github.com/openclaw/openclaw/pull/63785)）
+- **用途**: 改善 Feishu 文件留言 session，加入更豐富的上下文解析、留言反應（reactions）與打字回饋。
+- **解決問題**: 先前的留言 session 上下文不夠完整，缺少互動回饋機制。
+- **影響**: Feishu 文件協作體驗更即時、更有互動感。
+
+### ⭐⭐ Microsoft Teams：reaction 支援與 delegated OAuth（[#51646](https://github.com/openclaw/openclaw/pull/51646)）
+- **用途**: 為 Teams 整合新增 reaction 支援、reaction 列表查詢、Graph API 分頁處理與 delegated OAuth 設定。
+- **解決問題**: Teams 整合缺少 reaction 互動能力，且 Graph API 大量資料需要分頁處理。
+- **影響**: Teams 使用者可透過 reaction 與 bot 互動；delegated OAuth 提供更靈活的認證選項。
+
+### ⭐⭐ Plugins：manifest activation 與 setup descriptors（[#64780](https://github.com/openclaw/openclaw/pull/64780)）
+- **用途**: 允許 plugin manifest 宣告 activation descriptor（啟用條件）與 setup descriptor（設定引導）。
+- **解決問題**: plugin 缺乏標準化的啟用條件與設定引導宣告方式。
+- **影響**: plugin 生態系的自描述能力更完整，有助於自動化啟用與引導式設定。
+
+### ⭐ Ollama：model discovery 快取（[#64753](https://github.com/openclaw/openclaw/pull/64753)）
+- **用途**: 快取 `/api/show` 回傳的 context-window 與 capability metadata。
+- **解決問題**: 每次 model discovery 都重新查詢 `/api/show` 造成不必要的延遲。
+- **影響**: Ollama model discovery 更快，減少重複 API 呼叫。
+
+### ⭐ Models/providers：debug log 分類可見性（[#64754](https://github.com/openclaw/openclaw/pull/64754)）
+- **用途**: 在 embedded-agent debug logs 中顯示已設定的 OpenAI-compatible endpoint 如何被分類。
+- **解決問題**: 除錯時不容易判斷 endpoint 被歸類到哪個 provider 路徑。
+- **影響**: 提升 provider 設定的可觀察性。
+
+### ⭐ QA/parity：GPT-5.4 vs Opus 4.6 parity gate（[#64441](https://github.com/openclaw/openclaw/pull/64441)）
+- **用途**: 新增 GPT-5.4 與 Opus 4.6 的 agentic parity report gate。
+- **解決問題**: 缺乏跨模型 agentic 能力對等性的自動化驗證。
+- **影響**: QA 流程可自動比較兩大模型的 agentic 表現。
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ OpenAI/Codex OAuth：修正 `invalid_scope` 登入失敗（[#64713](https://github.com/openclaw/openclaw/pull/64713)）
+- **用途**: 停止改寫上游 OpenAI Codex authorize URL 的 scopes（不再強制附加 `model.request` 和 `api.responses.write`），保留原始 OAuth URL。
+- **解決問題**: 先前的 wrapper 回歸在上游 URL 上強加了額外 scopes，導致 OpenAI 拒絕新帳號登入並回傳 `invalid_scope` 錯誤（[#64687](https://github.com/openclaw/openclaw/issues/64687)）。
+- **影響**: 新 Codex 使用者可正常完成 OAuth 登入流程，這是直接影響使用者入門的關鍵修正。
+
+```text
+┌──────────────────────────┐
+│ 使用者發起 Codex OAuth    │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ 舊行為：wrapper 改寫 URL  │
+│ 附加 model.request 等    │
+│ → OpenAI 拒絕 scope      │
+│ → invalid_scope 錯誤     │
+└──────────────────────────┘
+
+┌──────────────────────────┐
+│ 新行為：保留上游原始 URL   │
+│ 不改寫 scopes            │
+└────────────┬─────────────┘
+             │
+             ▼
+┌──────────────────────────┐
+│ OAuth 正常完成            │
+│ auth code 成功回傳        │
+└──────────────────────────┘
+```
+
+### ⭐⭐ macOS Talk Mode：首次麥克風授權後自動繼續（[#62459](https://github.com/openclaw/openclaw/pull/62459)）
+- **用途**: 首次啟用 Talk Mode 並授予麥克風權限後，自動繼續啟動 Talk Mode，不再需要使用者手動重新啟用。
+- **解決問題**: 先前首次啟用只觸發權限請求，授權後 Talk Mode 不會自動開始，使用者必須再按一次。
+- **影響**: macOS 首次使用體驗更順暢。
+
+### ⭐⭐ Control UI / webchat：TTS 音訊持久化（[#63514](https://github.com/openclaw/openclaw/pull/63514)）
+- **用途**: 將 agent-run 產生的 TTS 音訊回覆持久化至 webchat 歷史記錄。
+- **解決問題**: TTS 音訊回覆在重新載入後消失。
+- **影響**: webchat 歷史完整性提升。
+
+### ⭐⭐ WhatsApp：預設帳號正確套用（[#53918](https://github.com/openclaw/openclaw/pull/53918)）
+- **用途**: 使用 active listener helper 且未明確指定 account id 時，正確套用已設定的預設帳號。
+- **解決問題**: 未指定 account id 時預設帳號被忽略。
+- **影響**: WhatsApp 多帳號設定更可靠。
+
+### ⭐⭐ Telegram/sessions：topic-scoped session 路徑修正（[#64869](https://github.com/openclaw/openclaw/pull/64869)）
+- **用途**: 確保 topic-scoped session 初始化使用 canonical topic transcript 路徑。
+- **解決問題**: session 初始化可能使用非標準路徑，導致 topic 對話記錄不一致。
+- **影響**: Telegram topic 對話的 session 管理更穩定。
+
+### ⭐⭐ Agents/failover：fallback 分類範圍限定（[#62907](https://github.com/openclaw/openclaw/pull/62907)）
+- **用途**: 將 assistant-side fallback 分類限定在當前嘗試（attempt）範圍內。
+- **解決問題**: fallback 分類若跨嘗試累積，可能導致錯誤的 failover 決策。
+- **影響**: agent failover 行為更精確。
+
+### ⭐⭐ Auto-reply/WhatsApp：圖片附件備註保留（[#64918](https://github.com/openclaw/openclaw/pull/64918)）
+- **用途**: media understanding 處理後保留 inbound 圖片附件的備註資訊。
+- **解決問題**: 圖片經過 media understanding 後附件備註被丟棄。
+- **影響**: WhatsApp auto-reply 的圖片上下文更完整。
+
+### ⭐⭐ MiniMax/OAuth：config patch 修正（[#64964](https://github.com/openclaw/openclaw/pull/64964)）
+- **用途**: 將 `api: anthropic-messages` 與 `authHeader: true` 正確寫入 minimax-portal config patch。
+- **解決問題**: MiniMax portal 設定缺少必要的 API 格式與認證標頭宣告。
+- **影響**: MiniMax provider 設定可正確運作。
+
+### ⭐ Audio transcription：pinned DNS 範圍修正（[#64766](https://github.com/openclaw/openclaw/pull/64766)）
+- **用途**: 僅對 OpenAI-compatible multipart 請求停用 pinned DNS。
+- **解決問題**: pinned DNS 停用範圍過廣，影響非相關請求。
+- **影響**: 網路請求行為更精確。
+
+### ⭐ ACP/agents：隱藏 commentary-phase relay 文字
+- **用途**: 在 ACP parent stream 更新中抑制 commentary-phase child assistant relay 文字。
+- **解決問題**: 內部 commentary 文字洩漏到 parent stream。
+- **影響**: ACP stream 輸出更乾淨。
+
+### ⭐ Agents/timeouts：idle watchdog 遵守明確 timeout
+- **用途**: LLM idle watchdog 正確遵守明確設定的 run timeout。
+- **解決問題**: 明確設定的 timeout 可能被 idle watchdog 的預設值覆蓋。
+- **影響**: agent 執行超時控制更可靠。
+
+### ⭐ Config：zod schema 補齊 asyncCompletion（[#63618](https://github.com/openclaw/openclaw/pull/63618)）
+- **用途**: 在生成的 zod schema 中包含 `asyncCompletion` 欄位。
+- **解決問題**: schema 缺少該欄位導致驗證不完整。
+- **影響**: 設定驗證更完整。
+
+### ⭐ Google/Veo：移除不支援的請求欄位（[#64723](https://github.com/openclaw/openclaw/pull/64723)）
+- **用途**: 停止發送 Veo 不支援的 `numberOfVideos` 請求欄位。
+- **解決問題**: 不支援的欄位可能導致 API 錯誤或非預期行為。
+- **影響**: Google Veo 整合更穩定。
+
+### ⭐ QA/packaging：packaged CLI 不再讀取 repo-only 檔案（[#64648](https://github.com/openclaw/openclaw/pull/64648)）
+- **用途**: packaged CLI 啟動時不再嘗試讀取 repo-only QA scenario markdown。
+- **解決問題**: packaged 環境中不存在這些檔案，讀取嘗試造成不必要的錯誤。
+- **影響**: packaged CLI 啟動更乾淨。
+
+### ⭐ Codex/QA：隱藏協調訊息
+- **用途**: 將 Codex app-server 協調訊息排除在可見回覆之外。
+- **解決問題**: 內部協調訊息出現在使用者可見的回覆中。
+- **影響**: Codex 回覆更乾淨。
+
+### ⭐ WhatsApp：message react 路徑修正
+- **用途**: 將 message react 路由至 gateway-owned action path。
+- **解決問題**: react 走錯路徑可能導致處理失敗。
+- **影響**: WhatsApp reaction 功能更可靠。
+
+## 總結
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 3 | 3 | Memory Wiki 匯入、Control UI 結構化渲染、video_generate 擴充、Feishu/Teams/Plugins 強化 |
+| 錯誤修復 | 1 | 7 | 8 | Codex OAuth 修正、macOS Talk Mode、WhatsApp/Telegram session、多項穩定性修補 |
+| **總計** | **4** | **10** | **11** | **共 25 項（9 項功能更新 + 16 項錯誤修復）** |
+
+---
+
+**發佈日期**: 2026-04-11
+**版本**: 2026.4.11
+**狀態**: Production Ready
+**GitHub Release**: [openclaw v2026.4.11](https://github.com/openclaw/openclaw/releases/tag/v2026.4.11)


### PR DESCRIPTION
Add zh-TW release notes for OpenClaw v2026.4.11.

Closes #479