### PR TITLE
docs(execution-watchdog): scrub personal machine name + bump last_validated

### DIFF
--- a/docs/execution-watchdog.md
+++ b/docs/execution-watchdog.md
@@ -1,11 +1,11 @@
 ---
-last_validated: 2026-04-02
+last_validated: 2026-04-24
 validated_by: wangyuyan-agent
 ---
 
 # OpenClaw Execution Watchdog：Agent 執行驗證監工系統設計提案
 
-> **狀態**：Ready for Review（MVP 已在 icern VPS 實測驗證）
+> **狀態**：Ready for Review（MVP 已在 your machine 實測驗證）
 > **作者**：wangyuyan-agent · claude
 > **日期**：2026-03-20
 > **適用版本**：OpenClaw ≥ 2026.3.7（需要 additive plugin hooks）
@@ -103,7 +103,7 @@ validated_by: wangyuyan-agent
 
 **關鍵發現：`afterTurn` 不可用。** 它屬於 ContextEngine slot 的 lifecycle hook，slot 是排他性的（一次只能有一個 ContextEngine）。使用 `afterTurn` 會與 lossless-claw 等插件衝突。`agent_end`（additive hook）是正確的觸發點。
 
-**Hook payload 已確認（2026-03-20，icern VPS 實測）：**
+**Hook payload 已確認（2026-03-20，your machine 實測）：**
 
 ```
 after_tool_call:


### PR DESCRIPTION
## Summary

- Scrub the machine identifier \"icern VPS\" from `docs/execution-watchdog.md` (2 occurrences: status line + Hook payload note); replace with generic \"your machine\" wording.
- Bump `last_validated` to 2026-04-24. Companion re-validation happened together with the `claw-watchdog` v0.1.0 clean-slate public release on the same day.

Rationale: the `claw-watchdog` upstream was rebuilt with the same neutral wording as part of a privacy cleanup pass. This keeps the design doc in sync so readers don't see a dangling reference to a private host name.

Scope: only `docs/execution-watchdog.md` — the watchdog design doc directly paired with the repo. `usecases/*` also contain `icern` mentions, but those describe other usecase environments and are unrelated to claw-watchdog; leaving them alone.

## Test plan

- [x] `grep -n 'icern' docs/execution-watchdog.md` returns zero matches
- [x] No content / logic / link changes; link to `wangyuyan-agent/claw-watchdog` still valid after the clean-slate rebuild (same URL)
- [x] Markdown renders correctly (verified locally)