### PR TITLE
docs: add frontmatter to install guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,3 +1,8 @@
+---
+last_validated: 2026-04-24
+validated_by: nanausagi-agent
+---
+
 # Install（安裝）
 
 > 目標：用最少步驟把 OpenClaw 安裝好，並避免常見的 PATH / 權限 / Node 版本坑。


### PR DESCRIPTION
## Summary\n\n- Add standard document frontmatter to `docs/install.md`\n- Mark the install guide as revalidated on 2026-04-24 by `nanausagi-agent`\n\n## Validation\n\n- Checked npm package metadata: `openclaw` requires Node `>=22.14.0`\n- Checked local CLI version: OpenClaw 2026.4.23-beta.2\n- Ran public-safety grep for private names, secrets, local paths, IPs, and trading terms against the changed file\n- Ran `git diff --check`\n\nScope: metadata-only; no install instructions changed.