### PR TITLE
docs: add release notes for OpenClaw 2026.4.23

### DIFF
--- a/release-notes/2026-04-23.md
+++ b/release-notes/2026-04-23.md
@@ -1,0 +1,393 @@
+# OpenClaw v2026.4.23 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+本版未標示需要使用者手動遷移的 breaking change。
+
+### 新功能亮點
+
+- **Codex OAuth 圖片生成**：`openai/gpt-image-2` 可透過 Codex OAuth 使用，不再一定需要 `OPENAI_API_KEY`
+- **OpenRouter 圖片生成**：`image_generate` 支援 OpenRouter image models
+- **原生 subagent fork context**：`sessions_spawn` 可選擇讓子代理繼承 requester transcript，預設仍維持 isolated
+- **生成工具 timeoutMs**：圖片、影片、音樂、TTS 工具可針對單次 provider request 設定 timeout
+- **多項安全修復**：涵蓋 Teams、MCP tools bridge、Webhooks、Android pairing、Discord/QQBot command auth、image warning injection 等路徑
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ Codex OAuth 圖片生成：`openai/gpt-image-2` 可透過 Codex OAuth 路徑使用（[#70703](https://github.com/openclaw/openclaw/issues/70703), [#70675](https://github.com/openclaw/openclaw/pull/70675), [#70781](https://github.com/openclaw/openclaw/pull/70781)）
+- ⭐⭐ OpenRouter 圖片生成 provider：`image_generate` 支援 OpenRouter image models（[#55066](https://github.com/openclaw/openclaw/issues/55066), [#67668](https://github.com/openclaw/openclaw/pull/67668)）
+- ⭐⭐ 圖片生成 provider hints：支援 quality、output format 與 OpenAI-specific hints（[#70503](https://github.com/openclaw/openclaw/pull/70503)）
+- ⭐⭐ 原生 subagent fork context：`sessions_spawn` 可選擇繼承 requester transcript，isolated 仍為預設（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- ⭐⭐ 生成工具 per-call timeout：image/video/music/TTS generation tools 支援 `timeoutMs`（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- ⭐ Memory local embeddings 可調 `contextSize`，預設 4096（[#70544](https://github.com/openclaw/openclaw/pull/70544)）
+- ⭐ Pi bundled packages 升級至 0.70.0，並同步 GPT-5.5 catalog metadata（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- ⭐ Codex harness selection 加入結構化 debug logging（[#70760](https://github.com/openclaw/openclaw/pull/70760)）
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Teams global Bot Framework audience token 綁定 app 驗證（[#70724](https://github.com/openclaw/openclaw/pull/70724)）
+- ⭐⭐⭐ MCP tools bridge 阻擋 owner-only tools 暴露給非 owner MCP caller（[#70698](https://github.com/openclaw/openclaw/pull/70698)）
+- ⭐⭐⭐ Webhook route secrets 每次 request 重新解析，支援 secrets reload 即時撤銷（[#70727](https://github.com/openclaw/openclaw/pull/70727)）
+- ⭐⭐ Claude CLI permission bypass 預設移除，改依 OpenClaw YOLO exec policy 決定（[#70723](https://github.com/openclaw/openclaw/pull/70723)）
+- ⭐⭐ Android manual/scanned cleartext gateway 連線限縮為 loopback-only（[#70722](https://github.com/openclaw/openclaw/pull/70722)）
+- ⭐⭐ Mobile pairing cleartext 僅接受 private-IP 或 loopback hosts（[#70721](https://github.com/openclaw/openclaw/pull/70721)）
+- ⭐⭐ Plugin setup-api lookup 不再 fallback 到 launch directory（[#70718](https://github.com/openclaw/openclaw/pull/70718)）
+- ⭐⭐ Exec approval chat client 需要明確啟用，不再由 allowlist/approver 推定開啟（[#70715](https://github.com/openclaw/openclaw/pull/70715)）
+- ⭐⭐ Discord native slash-command channel policy 不再繞過 owner/member restrictions（[#70711](https://github.com/openclaw/openclaw/pull/70711)）
+- ⭐⭐ QQBot `/bot-approve` 要求 framework auth（[#70706](https://github.com/openclaw/openclaw/pull/70706)）
+- ⭐ Android `ASK_OPENCLAW` intent 改為 draft-first，避免外部 app 自動送出 prompt（[#70714](https://github.com/openclaw/openclaw/pull/70714)）
+- ⭐ Image generation warning escape ignored override values，避免 `MEDIA:` directive injection（[#70710](https://github.com/openclaw/openclaw/pull/70710)）
+- ⭐ QA channel 拒絕非 HTTP(S) inbound attachment URLs（[#70708](https://github.com/openclaw/openclaw/pull/70708)）
+- ⭐ WebChat UI 禁止 session compaction mutation（[#70716](https://github.com/openclaw/openclaw/pull/70716)）
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Codex native `request_user_input` 回到原始 chat、保留 queued follow-up，並尊重新 approval amendment decisions（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- ⭐⭐ WhatsApp QuickStart onboarding 不再因 Baileys runtime dependency 尚未 staged 而失敗（[#70932](https://github.com/openclaw/openclaw/issues/70932)）
+- ⭐⭐ Block streaming final assembled text 去重，避免已分段送出的回覆再重複送一次（[#70921](https://github.com/openclaw/openclaw/issues/70921)）
+- ⭐⭐ Windows Codex harness 透過 PATHEXT 解析 npm `codex.cmd` shim（[#70913](https://github.com/openclaw/openclaw/issues/70913)）
+- ⭐⭐ Slack MPIM group DMs 判定為 group context，避免 tool/plan progress 外洩到群組（[#70912](https://github.com/openclaw/openclaw/issues/70912)）
+- ⭐⭐ WebChat 顯示 non-retryable provider failures，不再只留下 `surface_error` log（[#70124](https://github.com/openclaw/openclaw/issues/70124), [#70848](https://github.com/openclaw/openclaw/pull/70848)）
+- ⭐⭐ Memory CLI 宣告 built-in `local` embedding provider，修復 standalone memory commands（[#70836](https://github.com/openclaw/openclaw/issues/70836), [#70873](https://github.com/openclaw/openclaw/pull/70873)）
+- ⭐⭐ Gateway/WebChat 保留 text-only primary models 的 image attachments，改以 media refs offload（[#68513](https://github.com/openclaw/openclaw/issues/68513), [#44276](https://github.com/openclaw/openclaw/issues/44276), [#51656](https://github.com/openclaw/openclaw/issues/51656), [#70212](https://github.com/openclaw/openclaw/issues/70212)）
+- ⭐⭐ OpenAI reference-image edits 改用 guarded multipart uploads，修復 multi-reference `gpt-image-2` edits（[#70642](https://github.com/openclaw/openclaw/issues/70642)）
+- ⭐⭐ OpenRouter multimodal prompts 調整文字/圖片順序，恢復非空 vision responses（[#70410](https://github.com/openclaw/openclaw/issues/70410)）
+- ⭐⭐ Embedded runs 不再降低 process-wide undici stream timeouts，避免慢速 Gemini image generation 受短 timeout 影響（[#70423](https://github.com/openclaw/openclaw/issues/70423)）
+- ⭐⭐ Control UI chat 持久化 assistant-generated images，並允許 paired-device token 存取 assistant media（[#70719](https://github.com/openclaw/openclaw/pull/70719), [#70741](https://github.com/openclaw/openclaw/pull/70741)）
+- ⭐⭐ Memory dreaming cron 從 heartbeat 解耦，改以 isolated lightweight agent turn 執行（[#69811](https://github.com/openclaw/openclaw/issues/69811), [#67397](https://github.com/openclaw/openclaw/issues/67397), [#68972](https://github.com/openclaw/openclaw/issues/68972), [#70737](https://github.com/openclaw/openclaw/pull/70737)）
+- ⭐ Agents/CLI `--agent` + `--session-id` lookup 限定在指定 agent store（[#70985](https://github.com/openclaw/openclaw/pull/70985)）
+- ⭐ Root durable memory split-brain repair：`doctor --fix` 合併 legacy `memory.md` 至 canonical `MEMORY.md`（[#70621](https://github.com/openclaw/openclaw/pull/70621)）
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Codex OAuth 圖片生成（[#70703](https://github.com/openclaw/openclaw/issues/70703), [#70675](https://github.com/openclaw/openclaw/pull/70675), [#70781](https://github.com/openclaw/openclaw/pull/70781)）
+- **用途**: 讓 `openai/gpt-image-2` 可透過既有 Codex OAuth credential route 執行 image generation / reference-image editing。
+- **解決問題**: 先前 `gpt-image-2` 主要走 OpenAI API key path；已有 Codex OAuth 的使用者仍可能需要額外設定 `OPENAI_API_KEY`。
+- **影響**: Codex-authenticated setups 可直接使用 native image generation；API-key path 仍保留，OAuth fallback 只在適當 public OpenAI route 下啟用。
+
+```text
+┌────────────────────┐
+│ image_generate call │
+└─────────┬──────────┘
+          │
+          ▼
+┌────────────────────┐
+│ OpenAI API key 可用? │
+└──────┬─────────┬───┘
+       │Yes      │No
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ Images API   │ │ Codex OAuth route   │
+│ normal path  │ │ Responses backend   │
+└──────┬───────┘ └─────────┬──────────┘
+       │                   │
+       ▼                   ▼
+┌────────────────────────────────────┐
+│ 回傳 generated / edited image media │
+└────────────────────────────────────┘
+```
+
+### ⭐⭐ OpenRouter 圖片生成 provider（[#55066](https://github.com/openclaw/openclaw/issues/55066), [#67668](https://github.com/openclaw/openclaw/pull/67668)）
+- **用途**: 透過 OpenRouter extension 提供 image generation provider，讓 `image_generate` 可使用 OpenRouter image models。
+- **解決問題**: 先前 OpenRouter 使用者即使有 `OPENROUTER_API_KEY`，也無法走共享圖片生成工具。
+- **影響**: 圖片生成 provider choice 更完整；OpenRouter multimodal/image models 可與 OpenClaw shared tool surface 整合。
+
+### ⭐⭐ 圖片生成 provider hints（[#70503](https://github.com/openclaw/openclaw/pull/70503)）
+- **用途**: `image_generate` 支援 provider-supported `quality`、`outputFormat`，以及 OpenAI-specific `background`、`moderation`、`outputCompression`、`user` hints。
+- **解決問題**: 先前 `gpt-image-2` 等 provider 的重要控制項無法從 tool call 傳入，特別是低成本/快速 preview 所需的 quality hint。
+- **影響**: 代理人可針對單次圖片任務精準控制品質、格式與 OpenAI-specific options，降低成本並提升輸出可控性。
+
+### ⭐⭐ 原生 subagent fork context（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- **用途**: `sessions_spawn` 新增可選 forked context，讓 native subagent 在需要時繼承 requester transcript。
+- **解決問題**: 有些 delegated task 需要上下文連續性，但預設 isolated session 又不該被犧牲。
+- **影響**: 預設仍保持 clean isolated sessions；只有明確需要時才 fork context，兼顧安全隔離與任務效率。
+
+### ⭐⭐ 生成工具 per-call timeout（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- **用途**: image、video、music、TTS generation tools 支援單次 `timeoutMs`。
+- **解決問題**: 長時間 provider request 先前容易受固定 timeout 限制；全域調大又會擴大影響面。
+- **影響**: 代理人可只針對特定慢速生成任務延長等待時間，不必更改全域設定。
+
+### ⭐ Memory local embeddings `contextSize` 可調（[#70544](https://github.com/openclaw/openclaw/pull/70544)）
+- **用途**: 新增 `memorySearch.local.contextSize`，預設 4096。
+- **解決問題**: local embedding context 在 constrained hosts 上可能佔用過高 VRAM/記憶體。
+- **影響**: 使用者可依硬體資源調整 local embedding context，而不需 patch memory host。
+
+### ⭐ Pi bundled packages 升級至 0.70.0（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- **用途**: 更新 bundled Pi packages，採用 Pi upstream GPT-5.5 catalog metadata。
+- **解決問題**: 本地 forward-compat handling 與 upstream catalog metadata 容易漂移。
+- **影響**: GPT-5.5 相關模型 metadata 更貼近 upstream，僅保留必要的 `gpt-5.5-pro` forward compatibility。
+
+### ⭐ Codex harness selection debug logging（[#70760](https://github.com/openclaw/openclaw/pull/70760)）
+- **用途**: Codex embedded harness selection 加入結構化 debug logging。
+- **解決問題**: `/status` 應保持簡潔，但 harness auto-selection / Pi fallback 原因仍需要可診斷。
+- **影響**: Gateway logs 可解釋選擇決策，降低 Codex routing 問題排查成本。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Teams global Bot Framework audience token app binding（[#70724](https://github.com/openclaw/openclaw/pull/70724)）
+- **用途**: 當 Teams token 使用 global Bot Framework audience 時，要求 verified payload 的 `appid` 或 `azp` 必須匹配 configured bot `appId`。
+- **解決問題**: 僅接受 global audience 可能導致 cross-bot token replay。
+- **影響**: 保留合法 Bot Framework global audience 支援，同時阻擋不屬於該 bot 的 token 重放。
+
+```text
+┌────────────────────┐
+│ Teams inbound token │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ 驗證 JWT / audience │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ global audience ?   │
+└──────┬─────────┬───┘
+       │No       │Yes
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ 正常 app 檢查 │ │ appid/azp == appId? │
+└──────┬───────┘ └──────┬────────┬───┘
+       │                │Yes     │No
+       ▼                ▼        ▼
+┌──────────────┐ ┌──────────────┐ ┌────────┐
+│ accept       │ │ accept       │ │ reject │
+└──────────────┘ └──────────────┘ └────────┘
+```
+
+### ⭐⭐⭐ MCP tools bridge 阻擋 owner-only tools（[#70698](https://github.com/openclaw/openclaw/pull/70698)）
+- **用途**: 在 `createPluginToolsMcpHandlers` 中過濾 `ownerOnly` tools，避免列出或調用 owner-only control-plane tools。
+- **解決問題**: ACPX / MCP caller 可能透過 bridge 看到或呼叫如 `cron` 這類 owner-only tools，形成 privilege-escalation path。
+- **影響**: 非 owner MCP callers 無法經由 bridge 觸及 owner-only tools；一般工具行為不受影響。
+
+```text
+┌────────────────────┐
+│ MCP tools request   │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ load plugin tools   │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ filter ownerOnly    │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ list/invoke allowed │
+│ non-owner tools     │
+└────────────────────┘
+```
+
+### ⭐⭐⭐ Webhook route secrets per-request reload（[#70727](https://github.com/openclaw/openclaw/pull/70727)）
+- **用途**: Webhook HTTP handler 每次 request 重新解析 `SecretRef`-backed route secrets。
+- **解決問題**: 先前 route secret 可能被 cache 在記憶體中，`openclaw secrets reload` 後舊 secret 仍可用到 gateway restart。
+- **影響**: Secret rotation/revocation 可立即生效；泄漏的舊 webhook secret 不再延長有效期。
+
+```text
+┌────────────────────┐
+│ webhook request     │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ resolve SecretRef   │
+│ for this request    │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ compare credential  │
+└──────┬─────────┬───┘
+       │match    │mismatch
+       ▼         ▼
+┌──────────────┐ ┌────────┐
+│ accept route │ │ reject │
+└──────────────┘ └────────┘
+```
+
+### ⭐⭐ Claude CLI permission bypass defaults 移除（[#70723](https://github.com/openclaw/openclaw/pull/70723)）
+- **用途**: Claude CLI backend 的 `bypassPermissions` 改由 OpenClaw YOLO exec policy 推導，保留 explicit raw override。
+- **解決問題**: 預設 permission bypass 可能讓不可信輸入繞過 OpenClaw tool/sandbox guardrails 觸發本地動作。
+- **影響**: Claude CLI 權限模式與 OpenClaw 安全策略一致， malformed permission args 會被剝除而非默默 fallback bypass。
+
+### ⭐⭐ Android cleartext gateway loopback-only（[#70722](https://github.com/openclaw/openclaw/pull/70722)）
+- **用途**: Android manual/scanned routes 的 `ws://` cleartext gateway 連線只允許 loopback。
+- **解決問題**: 私有 LAN / link-local cleartext 可能暴露 bootstrap/shared/operator tokens 給 LAN MITM。
+- **影響**: 私有 LAN cleartext endpoint fail closed；需要非 loopback 連線時應使用 TLS。
+
+### ⭐⭐ Mobile pairing cleartext host 限縮（[#70721](https://github.com/openclaw/openclaw/pull/70721)）
+- **用途**: Cleartext mobile pairing 要求 private-IP 或 loopback hosts，不再把 `.local` 或 dotless hostname 視為安全。
+- **解決問題**: Hostname 可能解析到非 LAN 位址，導致 pairing token 透過不安全 cleartext 外洩。
+- **影響**: Pairing cleartext 判斷更保守，降低 DNS/hostname 誤判風險。
+
+### ⭐⭐ Plugin setup-api lookup 不 fallback 到 cwd（[#70718](https://github.com/openclaw/openclaw/pull/70718)）
+- **用途**: `resolveSetupApiPath()` 不再把 launch directory 當作 trusted repo root。
+- **解決問題**: Workspace-local `extensions/<plugin>/setup-api.*` 可能在 provider setup resolution 中被執行。
+- **影響**: Plugin setup API resolution 僅走可信位置，降低 workspace code execution 風險。
+
+### ⭐⭐ Exec approvals 需要明確 chat enablement（[#70715](https://github.com/openclaw/openclaw/pull/70715)）
+- **用途**: `execApprovals.enabled` 缺省時，不再因 approvers 或 owner allowlists 推定啟用 chat approvals。
+- **解決問題**: 隱式啟用 approval clients 會改變安全邊界，造成非預期的審批通道。
+- **影響**: 恢復 explicit opt-in 語意；`auto` 與 explicit `true` 仍可使用。
+
+### ⭐⭐ Discord native command auth fallback 修復（[#70711](https://github.com/openclaw/openclaw/pull/70711)）
+- **用途**: Native slash-command channel policy 不再繞過配置中的 user/role allowlists。
+- **解決問題**: Channel-policy authorizer 可能授權整個 allowlisted guild/channel 成員，繞過更嚴格 restrictions。
+- **影響**: Discord slash command 授權回到 owner/member restrictions 優先，僅在無更嚴格規則時 fallback。
+
+### ⭐⭐ QQBot `/bot-approve` auth gate（[#70706](https://github.com/openclaw/openclaw/pull/70706)）
+- **用途**: `/bot-approve` 經由 auth-gated command path 處理。
+- **解決問題**: 未授權 QQ sender 可能透過 pre-dispatch slash-command path 修改 exec approval settings。
+- **影響**: QQBot 的安全敏感 approval command 需要 framework auth。
+
+### ⭐ Android `ASK_OPENCLAW` intent draft-first（[#70714](https://github.com/openclaw/openclaw/pull/70714)）
+- **用途**: 外部 app action 只預填 draft，不自動 dispatch prompt。
+- **解決問題**: Exported activity 可能被不可信 app 用來注入並自動送出 prompt。
+- **影響**: 使用者保留送出前確認權，降低 Android intent prompt injection 風險。
+
+### ⭐ Image generation warning escaping（[#70710](https://github.com/openclaw/openclaw/pull/70710)）
+- **用途**: 對 ignored override values 進行 escape 後再寫入 tool warning。
+- **解決問題**: 使用者控制的 `size` 等 free-form value 可能注入 newline + `MEDIA:` token，被解析為 trusted local-media path。
+- **影響**: Unsupported option warning 不再成為 media directive injection 通道。
+
+### ⭐ QA channel non-HTTP attachment rejection（[#70708](https://github.com/openclaw/openclaw/pull/70708)）
+- **用途**: Inbound attachment URL 只接受 HTTP(S)。
+- **解決問題**: 不可信 attachment URL 若被當作 local path staging，可能造成 local file disclosure。
+- **影響**: 可疑或 misconfigured payload 會被拒絕並記錄 scheme，便於 debugging。
+
+### ⭐ WebChat session compaction mutation guard（[#70716](https://github.com/openclaw/openclaw/pull/70716)）
+- **用途**: 將 WebChat session-mutation guard 擴展到 `sessions.compact` 與 `sessions.compaction.restore`。
+- **解決問題**: `WEBCHAT_UI` 已被禁止 patch/delete，但 sibling compaction mutation handlers 仍可被觸及。
+- **影響**: WebChat UI clients 在 session mutation 權限上更一致。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Codex native input routing / approvals 修復（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.23)）
+- **用途**: 將 native `request_user_input` prompts 回送到 originating chat，保留 queued follow-up answers，並尊重新 app-server command approval amendment decisions。
+- **解決問題**: Codex harness 的互動式輸入、follow-up 排隊與 approval amendment 可能無法正確回到原會話流程。
+- **影響**: Codex native harness 的多輪互動與審批行為更可靠，降低卡住或回覆丟失。
+
+```text
+┌────────────────────┐
+│ Codex requests input│
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ route to origin chat│
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ queue follow-up     │
+│ answer if needed    │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ apply latest        │
+│ approval amendment  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ continue Codex turn │
+└────────────────────┘
+```
+
+### ⭐⭐ WhatsApp QuickStart onboarding dependency path（[#70932](https://github.com/openclaw/openclaw/issues/70932)）
+- **用途**: WhatsApp first-run setup entry loading 避開 Baileys runtime dependency path。
+- **解決問題**: Packaged QuickStart fresh install 中，runtime deps 尚未 staged 時 WhatsApp setup 可能無法顯示。
+- **影響**: 新安裝者可先看到 WhatsApp setup surface，不會被 missing dependency 阻斷 onboarding。
+
+### ⭐⭐ Block streaming duplicate final payload（[#70921](https://github.com/openclaw/openclaw/issues/70921)）
+- **用途**: 當 partial block-delivery 已完整覆蓋 final reply 時，抑制 final assembled text。
+- **解決問題**: Signal、WhatsApp、iMessage/BlueBubbles 等 block-streaming channel 可能同一輪送出分段內容後又送完整內容。
+- **影響**: 避免重複回覆，同時不丟棄 unrelated short messages。
+
+### ⭐⭐ Windows Codex `codex.cmd` shim resolution（[#70913](https://github.com/openclaw/openclaw/issues/70913)）
+- **用途**: Windows Codex harness 透過 PATHEXT 解析 npm-installed `codex.cmd` shim。
+- **解決問題**: `codex/*` models 在 Windows 上可能因 raw spawn 找不到 `codex` 而 `ENOENT`。
+- **影響**: Windows 使用者不需手動建立 `.exe` shim 即可使用 Codex app-server。
+
+### ⭐⭐ Slack MPIM group context / progress suppression（[#70912](https://github.com/openclaw/openclaw/issues/70912)）
+- **用途**: 將 MPIM group DMs 分類為 group chat context，並在 Slack non-DM surfaces 抑制 verbose tool/plan progress。
+- **解決問題**: 內部 `Working…`、tool args 等 traces 可能外洩到 Slack rooms。
+- **影響**: 群組中不再顯示內部進度噪音與工具細節。
+
+### ⭐⭐ WebChat provider failure surface（[#70124](https://github.com/openclaw/openclaw/issues/70124), [#70848](https://github.com/openclaw/openclaw/pull/70848)）
+- **用途**: Embedded runner 直接 surfaced non-retryable provider failures，如 billing、auth、rate limit。
+- **解決問題**: 先前可能只記錄 `surface_error`，WebChat 沒有 rendered error。
+- **影響**: 使用者能看到可行動錯誤，不會誤以為 agent 無回應。
+
+### ⭐⭐ Memory CLI local embedding provider manifest（[#70836](https://github.com/openclaw/openclaw/issues/70836), [#70873](https://github.com/openclaw/openclaw/pull/70873)）
+- **用途**: 在 memory-core manifest 宣告 built-in `local` embedding provider。
+- **解決問題**: Standalone `openclaw memory status/index/search` 可能報 `Unknown memory embedding provider: local`。
+- **影響**: CLI 與 gateway runtime 對 local embeddings 的解析一致。
+
+### ⭐⭐ Gateway/WebChat image attachment preservation（[#68513](https://github.com/openclaw/openclaw/issues/68513), [#44276](https://github.com/openclaw/openclaw/issues/44276), [#51656](https://github.com/openclaw/openclaw/issues/51656), [#70212](https://github.com/openclaw/openclaw/issues/70212)）
+- **用途**: Text-only primary models 的 image attachments 改以 media refs offload，而不是丟棄。
+- **解決問題**: 使用 text-only model 但配置 image tools 時，原始圖片可能無法被後續工具檢查。
+- **影響**: WebChat / Gateway 路徑可保留圖片上下文，讓 image understanding tools 仍能使用原檔。
+
+### ⭐⭐ OpenAI multi-reference image edits（[#70642](https://github.com/openclaw/openclaw/issues/70642)）
+- **用途**: Reference-image edits 改用 guarded multipart uploads。
+- **解決問題**: JSON data URLs 路徑不適合複雜 multi-reference `gpt-image-2` edits。
+- **影響**: 多參考圖編輯更穩定，且保留 guardrails。
+
+### ⭐⭐ OpenRouter vision prompt ordering（[#70410](https://github.com/openclaw/openclaw/issues/70410)）
+- **用途**: OpenRouter image-understanding prompts 先送 user text，再送 image parts。
+- **解決問題**: 某些 OpenRouter multimodal models 先前回傳空 vision response。
+- **影響**: OpenRouter vision 路徑恢復可用性。
+
+### ⭐⭐ Embedded run timeout isolation（[#70423](https://github.com/openclaw/openclaw/issues/70423)）
+- **用途**: Embedded runs 不再降低 process-wide undici stream timeouts。
+- **解決問題**: Slow Gemini image generation 等長時間 provider request 會繼承短 run-attempt headers timeout。
+- **影響**: 長時間生成任務更不容易被 unrelated runner timeout 影響。
+
+### ⭐⭐ Control UI generated image persistence（[#70719](https://github.com/openclaw/openclaw/pull/70719), [#70741](https://github.com/openclaw/openclaw/pull/70741)）
+- **用途**: Assistant-generated images 持久化為 authenticated managed media，assistant media fetch 接受 paired-device token。
+- **解決問題**: Chat history reload 後 generated/assistant images 可能消失。
+- **影響**: Control UI history 重新載入後仍可顯示生成圖片。
+
+### ⭐⭐ Memory dreaming cron decoupled from heartbeat（[#69811](https://github.com/openclaw/openclaw/issues/69811), [#67397](https://github.com/openclaw/openclaw/issues/67397), [#68972](https://github.com/openclaw/openclaw/issues/68972), [#70737](https://github.com/openclaw/openclaw/pull/70737)）
+- **用途**: Managed dreaming cron 改以 isolated lightweight agent turn 執行。
+- **解決問題**: Heartbeat disabled 或 activeHours 限制可能讓 dreaming 被跳過。
+- **影響**: Dreaming 能獨立運作；`doctor --fix` 會遷移 stale main-session dreaming jobs。
+
+### ⭐ Agents/CLI session-id routing（[#70985](https://github.com/openclaw/openclaw/pull/70985)）
+- **用途**: `--agent` + `--session-id` lookup scoped 到 requested agent store。
+- **解決問題**: Explicit agent resumes 可能選到另一個 agent session 或被導回 agent main session。
+- **影響**: CLI resume routing 更精準，避免跨 agent session 誤選。
+
+### ⭐ Root durable memory split-brain repair（[#70621](https://github.com/openclaw/openclaw/pull/70621)）
+- **用途**: `openclaw doctor --fix` 合併 legacy lowercase `memory.md` 到 canonical `MEMORY.md`。
+- **解決問題**: Root durable memory 可能 split-brain，runtime fallback 與 canonical file 不一致。
+- **影響**: Durable memory root 回到單一 canonical `MEMORY.md`，降低記憶分裂風險。
+
+---
+
+## Summary Table
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 1 | 4 | 3 | Codex/OpenRouter 圖片生成、generation tool hints/timeout、subagent context 與 memory tuning |
+| 安全性 | 3 | 7 | 4 | Teams/MCP/Webhooks 重要安全修復，加上 mobile pairing、command auth、plugin lookup 與 injection 防護 |
+| 錯誤修復 | 1 | 12 | 2 | Codex routing、onboarding、streaming、Windows、Slack、WebChat、memory、media generation 多路徑修復 |
+| **總計** | 5 | 23 | 9 | v2026.4.23 以媒體生成能力、安全修補與跨平台穩定性為主 |
+
+---
+
+## Footer
+
+- **發佈日期**: 2026-04-24
+- **版本**: 2026.4.23
+- **狀態**: Production Ready
+- **GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.4.23


### PR DESCRIPTION
## Summary\n\n- Add zh-TW release notes for OpenClaw v2026.4.23\n- Covers feature updates, security improvements, and bug fixes from the upstream release\n- Closes #508\n\n## Validation\n\n- Reviewed upstream GitHub Release v2026.4.23\n- Reviewed release-notes/GUIDELINES.md\n- Spot-checked key upstream PRs/issues for ⭐⭐⭐ flowcharts and security notes\n- Ran public-safety grep for private names, local paths, IPs, and trading terms\n- Checked required sections, fence balance, ⭐⭐⭐ flowchart count, link shape, trailing whitespace, and `git diff --check`