### PR TITLE
docs: add release notes for OpenClaw 2026.4.24

### DIFF
--- a/release-notes/2026-04-24.md
+++ b/release-notes/2026-04-24.md
@@ -1,0 +1,480 @@
+# OpenClaw v2026.4.24 版本發佈說明
+
+[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)
+
+## ⚠️ 升級前必讀
+
+### Breaking Changes 摘要
+
+| 項目 | 影響 | 行動 |
+|------|------|------|
+| Plugin SDK/tool-result transforms 移除 Pi-only `api.registerEmbeddedExtensionFactory(...)` 相容路徑 | Bundled tool-result rewrites 若仍使用舊 Pi-only embedded extension factory，將不再載入；transform 也不會自動套用到 Codex app-server dynamic tools | 改用 `api.registerAgentToolResultMiddleware(...)`，並在 manifest 宣告 `contracts.agentToolResultMiddleware` 的目標 runtimes（例如 `pi`, `codex`） |
+
+### 新功能亮點
+
+- **Google Meet bundled participant plugin**：支援個人 Google auth、Chrome/Twilio realtime、paired-node Chrome、artifact/attendance export 與 recover tooling
+- **Realtime voice loops**：Talk、Voice Call、Google Meet 可透過 realtime voice session 呼叫完整 OpenClaw agent 取得 tool-backed answers
+- **DeepSeek V4 catalog**：新增 DeepSeek V4 Flash / V4 Pro，V4 Flash 成為 onboarding default
+- **Browser automation 強化**：coordinate clicks、60s default action budget、per-profile headless overrides、tab reuse/recovery 更穩
+- **Plugin/model infrastructure 輕量化**：static catalogs、manifest-backed model rows、lazy provider deps、packaged install runtime-dependency repair
+
+---
+
+## 概覽
+
+### 功能更新 (Features)
+
+- ⭐⭐⭐ Google Meet bundled participant plugin，含 Chrome/Twilio realtime、Google OAuth、paired-node Chrome、artifact/attendance exports 與 recover tooling（[#70765](https://github.com/openclaw/openclaw/pull/70765)）
+- ⭐⭐⭐ Plugin SDK/tool-result transform migration：移除 Pi-only `registerEmbeddedExtensionFactory`，改用 runtime-neutral middleware（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- ⭐⭐⭐ Realtime voice consult：Talk、Voice Call、Google Meet 可用 realtime voice loops handoff 到完整 OpenClaw agent（[#70765](https://github.com/openclaw/openclaw/pull/70765), [#70938](https://github.com/openclaw/openclaw/pull/70938)）
+- ⭐⭐ VoiceClaw realtime brain WebSocket endpoint，透過 Gemini Live 與 async OpenClaw tool handoff 提供 realtime brain（[#70938](https://github.com/openclaw/openclaw/pull/70938)）
+- ⭐⭐ Browser coordinate clicks 與 `openclaw browser click-coords`（[#54452](https://github.com/openclaw/openclaw/pull/54452)）
+- ⭐⭐ Browser action timeout 設定與 60s default action budget（[#62589](https://github.com/openclaw/openclaw/pull/62589)）
+- ⭐⭐ Matrix self-device verification 要求完整 cross-signing identity trust，新增 `openclaw matrix verify self`（[#70401](https://github.com/openclaw/openclaw/pull/70401)）
+- ⭐⭐ Gradium bundled TTS provider，支援 voice-note 與 telephony output（[#64958](https://github.com/openclaw/openclaw/pull/64958)）
+- ⭐⭐ Memory hybrid search 結果新增 `vectorScore` 與 `textScore`（[#68166](https://github.com/openclaw/openclaw/issues/68166), [#68286](https://github.com/openclaw/openclaw/pull/68286)）
+- ⭐⭐ DeepSeek V4 Flash / V4 Pro catalog，V4 Flash 成為 onboarding default（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- ⭐⭐ Model catalog/listing infrastructure：static catalogs、manifest-backed rows、provider-filtered/default list 加速（[#70632](https://github.com/openclaw/openclaw/pull/70632), [#70883](https://github.com/openclaw/openclaw/pull/70883), [#70867](https://github.com/openclaw/openclaw/pull/70867), [#71342](https://github.com/openclaw/openclaw/pull/71342), [#71360](https://github.com/openclaw/openclaw/pull/71360), [#71368](https://github.com/openclaw/openclaw/pull/71368)）
+- ⭐⭐ Codex app-server context-engine lifecycle、runtime plan parity 與 native hook bridge（[#70809](https://github.com/openclaw/openclaw/pull/70809), [#71096](https://github.com/openclaw/openclaw/pull/71096), [#71008](https://github.com/openclaw/openclaw/pull/71008), [#70772](https://github.com/openclaw/openclaw/pull/70772)）
+- ⭐ Agents defaults 新增 `contextInjection: "never"`，可停用 workspace bootstrap file injection（[#65006](https://github.com/openclaw/openclaw/pull/65006)）
+- ⭐ Plugin activation/source metadata 與 official external source pinning 改善（[#70943](https://github.com/openclaw/openclaw/pull/70943), [#70951](https://github.com/openclaw/openclaw/pull/70951), [#70997](https://github.com/openclaw/openclaw/pull/70997)）
+- ⭐ Diagnostics/OTEL tracing 與 structured diagnostic events（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+
+### 安全性提升 (Security)
+
+- ⭐⭐⭐ Dashboard 不再將 tokenized Control UI URL 或 SSH hints 寫入 runtime logs（[#70029](https://github.com/openclaw/openclaw/pull/70029)）
+- ⭐⭐⭐ Browser gateway `browser.request` method 要求 `operator.admin`（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- ⭐⭐⭐ Config/doctor 拒絕 legacy `secretref-env:<ENV_VAR>` marker strings，並將有效 marker 遷移為 structured env SecretRefs（[#51794](https://github.com/openclaw/openclaw/issues/51794)）
+- ⭐⭐ Matrix self-device verification 採完整 cross-signing identity trust（[#70401](https://github.com/openclaw/openclaw/pull/70401)）
+- ⭐⭐ Dashboard/Windows 開啟 URL 不再透過 `cmd.exe` parsing 或 PATH-based `rundll32` lookup，並拒絕 non-HTTP inputs（[#71098](https://github.com/openclaw/openclaw/issues/71098)）
+- ⭐⭐ Diagnostics/OTEL raw content export 預設關閉，`captureContent` 必須 opt-in（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+- ⭐⭐ Exec diagnostics spans 不暴露 command text、working directories 或 container identifiers（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+- ⭐ Plugins/catalog 官方 external WeCom source 以 exact npm release + dist integrity pinning（[#70997](https://github.com/openclaw/openclaw/pull/70997)）
+- ⭐ Gateway/nodes `autoApproveCidrs` 預設關閉，首次 node pairing 仍需明確 trusted CIDRs（[#60800](https://github.com/openclaw/openclaw/issues/60800)）
+
+### 錯誤修復 (Bug Fixes)
+
+- ⭐⭐⭐ Heartbeat oversized scheduler delays clamp 到 Node `setTimeout` cap，避免 1ms crash loop（[#71414](https://github.com/openclaw/openclaw/issues/71414), [#71478](https://github.com/openclaw/openclaw/pull/71478)）
+- ⭐⭐⭐ 非 heartbeat run 不再注入 heartbeat system prompt，避免一般回覆被 `HEARTBEAT_OK` 抑制（[#69079](https://github.com/openclaw/openclaw/issues/69079), [#69278](https://github.com/openclaw/openclaw/pull/69278)）
+- ⭐⭐ MCP bundled runtimes run end retire、allowlist startup skip、session idle eviction（[#71106](https://github.com/openclaw/openclaw/issues/71106), [#71110](https://github.com/openclaw/openclaw/issues/71110), [#70389](https://github.com/openclaw/openclaw/issues/70389), [#70808](https://github.com/openclaw/openclaw/issues/70808)）
+- ⭐⭐ Gateway restart continuation 改由 durable session-delivery queue 接手（[#70780](https://github.com/openclaw/openclaw/pull/70780)）
+- ⭐⭐ Tool-result pruning 對 malformed `{ type: "text" }` blocks 做防護（[#34979](https://github.com/openclaw/openclaw/issues/34979), [#51267](https://github.com/openclaw/openclaw/pull/51267)）
+- ⭐⭐ Gateway service env 加入 Nix Home Manager profile bin directories（[#44402](https://github.com/openclaw/openclaw/issues/44402), [#59935](https://github.com/openclaw/openclaw/pull/59935)）
+- ⭐⭐ Telegram/agents 不再於已成功送出回覆後追加 phantom fallback（[#70623](https://github.com/openclaw/openclaw/issues/70623)）
+- ⭐⭐ Discord cron text-only isolated delivery 避免 streamed block payload 與 final answer 重複貼文（[#71406](https://github.com/openclaw/openclaw/issues/71406)）
+- ⭐⭐ Silent cron jobs `delivery.mode="none"` 抑制 background exec completion wakes（[#71391](https://github.com/openclaw/openclaw/pull/71391)）
+- ⭐⭐ Gemini reasoning-only / empty / planning-only turns 會 retry，不再 silent stall（[#71074](https://github.com/openclaw/openclaw/issues/71074), [#71362](https://github.com/openclaw/openclaw/pull/71362)）
+- ⭐⭐ Compaction 修復 `keepRecentTokens`、summary snowballing，並預設啟用 safeguard quality checks（[#71357](https://github.com/openclaw/openclaw/issues/71357)）
+- ⭐⭐ Sessions load-time maintenance 尊重 configured `session.maintenance`（[#71356](https://github.com/openclaw/openclaw/issues/71356)）
+- ⭐ Control UI/browser 避免 browser bundle 因 `node:fs` constants stub crash（[#48930](https://github.com/openclaw/openclaw/pull/48930)）
+- ⭐ Agents/TTS 使用 resolved shared config，避免 tool-triggered speech 回落到 fresh config load（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- ⭐ Reply media 去重與 sandboxed managed media delivery 修復（[#71138](https://github.com/openclaw/openclaw/issues/71138), [#65468](https://github.com/openclaw/openclaw/issues/65468), [#66092](https://github.com/openclaw/openclaw/issues/66092)）
+
+---
+
+## 功能更新 (Features) - by Star Rating
+
+### ⭐⭐⭐ Google Meet bundled participant plugin（[#70765](https://github.com/openclaw/openclaw/pull/70765)）
+- **用途**: 新增 bundled Google Meet participant plugin，提供 `googlemeet` CLI、personal Google OAuth、explicit meeting URL joins、Chrome/Twilio realtime transports、paired-node `chrome-node` 支援，以及會議 artifact/attendance workflows。
+- **解決問題**: 先前 OpenClaw 沒有一個 bundled path 可把 agent 作為會議參與者加入 Google Meet，並同時處理 realtime audio、OAuth、會議記錄與已開啟 tab recovery。
+- **影響**: 使用者可讓 OpenClaw 進入 Meet、透過 realtime session 互動、匯出 conference records/recordings/transcripts/smart notes/attendance，並用 doctor/recover tooling 排查 OAuth 或 browser state。
+
+```text
+┌────────────────────┐
+│ googlemeet join     │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ resolve OAuth/token │
+│ and meeting URL     │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ choose transport    │
+│ chrome/twilio/node  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ realtime audio loop │
+│ + agent consult     │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ artifacts/attendance│
+│ export or recover   │
+└────────────────────┘
+```
+
+### ⭐⭐⭐ Plugin SDK/tool-result transform migration（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- **用途**: 移除 Pi-only `api.registerEmbeddedExtensionFactory(...)` 相容路徑，改以 `api.registerAgentToolResultMiddleware(...)` 搭配 `contracts.agentToolResultMiddleware` 宣告 runtime-neutral transform。
+- **解決問題**: Pi-only tool-result rewrites 無法一致套用到 Pi 與 Codex app-server dynamic tools，也讓 plugin SDK contract 邊界不清。
+- **影響**: Bundled tool-result transforms 必須明確宣告目標 runtimes；Pi 與 Codex 會走同一個高信任 middleware seam。External plugins 不能註冊此 middleware，因為它可改寫送回模型前的 tool output。
+
+```text
+┌────────────────────┐
+│ bundled plugin load │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ manifest declares   │
+│ agentToolResult...  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ register middleware │
+│ runtimes pi/codex   │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ PI/Codex tool result│
+│ passes middleware   │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ model sees rewritten│
+│ trusted output      │
+└────────────────────┘
+```
+
+### ⭐⭐⭐ Realtime voice consult loops（[#70765](https://github.com/openclaw/openclaw/pull/70765), [#70938](https://github.com/openclaw/openclaw/pull/70938)）
+- **用途**: Talk、Voice Call、Google Meet realtime voice sessions 可透過 shared `openclaw_agent_consult` / realtime brain path，把需要 deeper answer 的問題交給完整 OpenClaw agent。
+- **解決問題**: Realtime voice loop 若只靠語音 provider 本身，難以使用完整工具、記憶、工作區與 agent reasoning。
+- **影響**: 現場語音對話可以快速回應，同時在需要時非同步 consult full agent，取得 tool-backed answers 後再注入 realtime context。
+
+```text
+┌────────────────────┐
+│ live voice session  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ realtime provider   │
+│ hears user request  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ needs deeper answer?│
+└──────┬─────────┬───┘
+       │No       │Yes
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ reply live   │ │ consult OpenClaw    │
+└──────────────┘ │ agent/tools         │
+                 └─────────┬──────────┘
+                           ▼
+                 ┌────────────────────┐
+                 │ inject answer back  │
+                 │ into voice context  │
+                 └────────────────────┘
+```
+
+### ⭐⭐ VoiceClaw realtime brain gateway（[#70938](https://github.com/openclaw/openclaw/pull/70938)）
+- **用途**: 新增 `/voiceclaw/realtime` Gateway WebSocket path，讓 VoiceClaw-compatible clients 直接連到 Gemini Live realtime brain。
+- **解決問題**: 外部 realtime clients 需要一個 owner-auth gated bridge，把 Gemini Live audio/function-call 與 OpenClaw tool handoff 整合起來。
+- **影響**: VoiceClaw session 可用 isolated namespace、auth checks、reconnect handling 與 tool cancellation handling 執行 realtime brain workflows。
+
+### ⭐⭐ Browser coordinate clicks（[#54452](https://github.com/openclaw/openclaw/pull/54452)）
+- **用途**: Managed 與 existing-session browser automation 支援 viewport coordinate clicks，CLI 新增 `openclaw browser click-coords`。
+- **解決問題**: 有些 UI 元素不易用 selector/accessibility ref 定位，或需要直接座標操作。
+- **影響**: Browser automation 對 canvas、圖形 UI、難定位元素更可靠。
+
+### ⭐⭐ Browser action timeout budget（[#62589](https://github.com/openclaw/openclaw/pull/62589)）
+- **用途**: 新增 `browser.actionTimeoutMs`，並讓 browser action 預設使用 60s budget。
+- **解決問題**: 健康的長等待 browser act 可能撞上固定 20s transport/client timeout，被誤判為 bridge/gateway 問題。
+- **影響**: 長等待瀏覽器任務更穩定，錯誤提示也不再誤導使用者重啟 gateway。
+
+### ⭐⭐ Matrix full identity trust verification（[#70401](https://github.com/openclaw/openclaw/pull/70401)）
+- **用途**: Matrix self-device verification 改要求完整 cross-signing identity trust，並新增 `openclaw matrix verify self`。
+- **解決問題**: 僅 owner-signed device state 不足以代表完整 identity trust，E2EE 設定容易留下錯誤安全假設。
+- **影響**: Operators 可透過 CLI 建立與檢查自己的 Matrix identity trust，降低 E2EE setup ambiguity。
+
+### ⭐⭐ Gradium TTS provider（[#64958](https://github.com/openclaw/openclaw/pull/64958)）
+- **用途**: 新增 Gradium text-to-speech bundled provider，支援一般 TTS、voice-note 與 telephony output。
+- **解決問題**: TTS provider choice 需要更多聲音與電話/語音訊息輸出選項。
+- **影響**: 使用 `GRADIUM_API_KEY` 可接入 Gradium speech synthesis，並整合 OpenClaw media/TTS surfaces。
+
+### ⭐⭐ Memory hybrid search scores（[#68166](https://github.com/openclaw/openclaw/issues/68166), [#68286](https://github.com/openclaw/openclaw/pull/68286)）
+- **用途**: Hybrid memory search result 額外回傳 raw `vectorScore` 與 `textScore`。
+- **解決問題**: 只有 combined score 時，operator 無法判斷 ranking 是由 vector retrieval 還是 text retrieval 主導。
+- **影響**: 多代理與 embedding 調校場景能更清楚診斷 retrieval quality、weight config 與 temporal/MMR 排序效果。
+
+### ⭐⭐ DeepSeek V4 catalog / onboarding default（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- **用途**: Bundled catalog 新增 DeepSeek V4 Flash 與 V4 Pro，並將 V4 Flash 設為 onboarding default。
+- **解決問題**: DeepSeek 新模型與 thinking/replay 行為需要被 catalog 與 onboarding 正確呈現。
+- **影響**: 新使用者可直接選到 DeepSeek V4 Flash；既有 follow-up tool-call turns 的 replay 行為也更穩。
+
+### ⭐⭐ Model catalog/listing infrastructure（[#70632](https://github.com/openclaw/openclaw/pull/70632), [#70883](https://github.com/openclaw/openclaw/pull/70883), [#70867](https://github.com/openclaw/openclaw/pull/70867), [#71342](https://github.com/openclaw/openclaw/pull/71342), [#71360](https://github.com/openclaw/openclaw/pull/71360), [#71368](https://github.com/openclaw/openclaw/pull/71368)）
+- **用途**: 將 model catalog metadata 轉向 static catalog、manifest `modelCatalog` contract、集中 normalization 與 planner。
+- **解決問題**: `models list` 與 onboarding 若廣泛載入 provider runtime，啟動成本高且 catalog ownership 分散。
+- **影響**: 預設 `models list` 和 provider-filtered listing 更快，provider/model metadata 可在不載入 runtime 的情況下解析。
+
+### ⭐⭐ Codex app-server parity / hooks / context-engine（[#70809](https://github.com/openclaw/openclaw/pull/70809), [#71096](https://github.com/openclaw/openclaw/pull/71096), [#71008](https://github.com/openclaw/openclaw/pull/71008), [#70772](https://github.com/openclaw/openclaw/pull/70772)）
+- **用途**: 讓 Codex app-server 支援 context-engine lifecycle、Pi/Codex parity contract、native hook bridge 與 provider-owned seams。
+- **解決問題**: Codex harness 與 PI path 之間容易產生 tool/auth/prompt/transcript/delivery policy drift。
+- **影響**: Codex native runtime 能更一致地參與 OpenClaw hooks、approvals、fallback policy 與 context-engine semantics。
+
+### ⭐ Agents `contextInjection: "never"`（[#65006](https://github.com/openclaw/openclaw/pull/65006)）
+- **用途**: 新增 `agents.defaults.contextInjection: "never"`，停用 workspace bootstrap file injection。
+- **解決問題**: 某些 memory/context-engine plugins 完全掌控 prompt lifecycle 時，AGENTS/SOUL 等 bootstrap injection 會造成重複或衝突。
+- **影響**: 特殊 agent runtime 可完全自行管理 prompt context。
+
+### ⭐ Plugin activation/source metadata（[#70943](https://github.com/openclaw/openclaw/pull/70943), [#70951](https://github.com/openclaw/openclaw/pull/70951), [#70997](https://github.com/openclaw/openclaw/pull/70997)）
+- **用途**: Plugin activation plan reason、install-source facts、official external source integrity pinning 更完整。
+- **解決問題**: Plugin 為何被選中、npm source 是否 pin/integrity-safe、catalog metadata 是否 drift 先前不易診斷。
+- **影響**: Onboarding 和 catalog diagnostics 可更清楚說明 plugin source、availability 與 trust 狀態。
+
+### ⭐ Diagnostics/OTEL tracing（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+- **用途**: 匯出 run、model-call、tool-execution、exec-process diagnostic lifecycle events 為 OTEL spans/logs。
+- **解決問題**: Operator 需要跨 run/tool/model call 的 observability，但不能把 raw content 或命令細節直接暴露。
+- **影響**: 可用 trace context 做日後 span correlation；raw content export 預設仍關閉。
+
+---
+
+## 安全性提升 (Security) - by Star Rating
+
+### ⭐⭐⭐ Dashboard tokenized URL log redaction（[#70029](https://github.com/openclaw/openclaw/pull/70029)）
+- **用途**: Dashboard 不再把含 gateway bearer fragment 的 Control UI URL 或 SSH fallback hint 寫入 runtime logs。
+- **解決問題**: 具 `operator.read` 的 paired client 若能讀 `logs.tail`，可能從 console-captured logs 取得 `#token=` fragment 並重用 bearer。
+- **影響**: Dashboard/control UI token 不再經由 shared gateway log 外洩。
+
+```text
+┌────────────────────┐
+│ openclaw dashboard  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ build Control UI URL│
+│ with bearer token   │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ redact before log   │
+│ / avoid token hints │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ logs.tail cannot    │
+│ recover bearer      │
+└────────────────────┘
+```
+
+### ⭐⭐⭐ Browser request admin gate（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- **用途**: Gateway method `browser.request` 需要 `operator.admin`。
+- **解決問題**: 該 route 暴露 host/browser-node control authority，低權限 scope 不應可操作。
+- **影響**: Browser control surface 與其實際控制能力匹配，降低 paired client 權限擴張風險。
+
+```text
+┌────────────────────┐
+│ browser.request     │
+│ gateway call        │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ check caller scope  │
+└──────┬─────────┬───┘
+       │admin    │not admin
+       ▼         ▼
+┌──────────────┐ ┌────────┐
+│ allow browser│ │ reject │
+│ control      │ │ call   │
+└──────────────┘ └────────┘
+```
+
+### ⭐⭐⭐ SecretRef legacy marker rejection/migration（[#51794](https://github.com/openclaw/openclaw/issues/51794)）
+- **用途**: Config/doctor 拒絕 legacy `secretref-env:<ENV_VAR>` marker strings，並把有效 marker 遷移為 structured env SecretRefs。
+- **解決問題**: Credential paths 使用字串 marker 容易混淆 schema 與 secret resolution 邊界。
+- **影響**: SecretRef credential config 更結構化、可驗證，legacy marker 由 `openclaw doctor --fix` 清理。
+
+```text
+┌────────────────────┐
+│ load credential cfg │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ legacy marker ?     │
+└──────┬─────────┬───┘
+       │No       │Yes
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ validate     │ │ doctor --fix builds │
+│ structured   │ │ env SecretRef       │
+└──────────────┘ └─────────┬──────────┘
+                           ▼
+                 ┌────────────────────┐
+                 │ reject invalid /    │
+                 │ save structured ref │
+                 └────────────────────┘
+```
+
+### ⭐⭐ Matrix full identity trust（[#70401](https://github.com/openclaw/openclaw/pull/70401)）
+- **用途**: Self-device verification 以完整 cross-signing identity trust 為準。
+- **解決問題**: 只看 owner-signed device state 會低估 Matrix E2EE 信任需求。
+- **影響**: Matrix channel 的安全狀態更準確，operator 可用 CLI 補齊信任流程。
+
+### ⭐⭐ Windows dashboard URL opening hardening（[#71098](https://github.com/openclaw/openclaw/issues/71098)）
+- **用途**: Dashboard/Windows 透過 system URL handler 開啟 Control UI/OAuth URL，不經 `cmd.exe` parsing 或 PATH-based `rundll32` lookup。
+- **解決問題**: Windows browser-open path 可能 silent failure 或被 PATH 解析影響。
+- **影響**: 只接受 HTTP browser-open inputs，降低 URL opener 的命令解析風險。
+
+### ⭐⭐ OTEL raw content opt-in（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+- **用途**: `diagnostics.otel.captureContent` 為未來 model/tool content span attributes 提供 opt-in 控制。
+- **解決問題**: Observability 不能預設輸出 raw model/tool content。
+- **影響**: 預設 telemetry 不含 raw content，需要 operator 明確打開才會捕捉。
+
+### ⭐⭐ Exec-process diagnostics redaction（[#70424](https://github.com/openclaw/openclaw/pull/70424)）
+- **用途**: Exec-process diagnostics 匯出為 `openclaw.exec` spans，但不暴露 command text、working directories 或 container identifiers。
+- **解決問題**: Exec observability 容易意外洩漏敏感命令或環境路徑。
+- **影響**: 可觀測性與資訊安全取得較佳平衡。
+
+### ⭐ Official external source integrity pinning（[#70997](https://github.com/openclaw/openclaw/pull/70997)）
+- **用途**: 官方 external WeCom channel catalog entry 固定 exact npm release 與 dist integrity。
+- **解決問題**: Floating npm specs 可能讓官方推薦來源 silent drift。
+- **影響**: 官方 external plugin source 更可重現，update flow 可 fail closed。
+
+### ⭐ Node pairing `autoApproveCidrs` 預設關閉（[#60800](https://github.com/openclaw/openclaw/issues/60800)）
+- **用途**: 新增 disabled-by-default `gateway.nodes.pairing.autoApproveCidrs`。
+- **解決問題**: 首次 node pairing 自動批准必須只在 operator 明確信任 CIDR 時發生。
+- **影響**: Browser/operator pairing 與 upgrade flows 維持 manual；只有明確設定的 trusted CIDR 才可 auto-approve first-time node pairing。
+
+---
+
+## 錯誤修復 (Bug Fixes) - by Star Rating
+
+### ⭐⭐⭐ Heartbeat oversized delay clamp（[#71414](https://github.com/openclaw/openclaw/issues/71414), [#71478](https://github.com/openclaw/openclaw/pull/71478)）
+- **用途**: 將 heartbeat scheduler delay clamp 到 Node `setTimeout` 上限。
+- **解決問題**: `agents.defaults.heartbeat.every` 若大於約 24.85 天，Node 會把 timeout clamp 成 1ms，造成 crash loop 與 `TimeoutOverflowWarning` flood。
+- **影響**: 超大 heartbeat interval 不再讓 gateway 進入 1ms tight loop。
+
+```text
+┌────────────────────┐
+│ heartbeat schedule  │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ resolve every delay │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ delay > Node cap ?  │
+└──────┬─────────┬───┘
+       │No       │Yes
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ setTimeout   │ │ clamp to safe cap   │
+└──────────────┘ └─────────┬──────────┘
+                           ▼
+                 ┌────────────────────┐
+                 │ no 1ms crash loop   │
+                 └────────────────────┘
+```
+
+### ⭐⭐⭐ Heartbeat prompt isolation（[#69079](https://github.com/openclaw/openclaw/issues/69079), [#69278](https://github.com/openclaw/openclaw/pull/69278)）
+- **用途**: 只在 heartbeat runs 注入 heartbeat system prompt。
+- **解決問題**: 普通 user runs 若被注入 heartbeat prompt，agent 可能回 `HEARTBEAT_OK`，而 delivery runtime 將其視為 no-reply，造成使用者看到沉默。
+- **影響**: 一般對話不再被 heartbeat acknowledgement 語意污染。
+
+```text
+┌────────────────────┐
+│ agent run starts    │
+└─────────┬──────────┘
+          ▼
+┌────────────────────┐
+│ trigger is heartbeat│
+│ ?                   │
+└──────┬─────────┬───┘
+       │Yes      │No
+       ▼         ▼
+┌──────────────┐ ┌────────────────────┐
+│ inject HB    │ │ skip HB prompt      │
+│ prompt       │ │ injection           │
+└──────┬───────┘ └─────────┬──────────┘
+       ▼                   ▼
+┌──────────────┐ ┌────────────────────┐
+│ HEARTBEAT_OK │ │ normal user reply   │
+│ allowed      │ │ delivered           │
+└──────────────┘ └────────────────────┘
+```
+
+### ⭐⭐ MCP runtime lifecycle cleanup（[#71106](https://github.com/openclaw/openclaw/issues/71106), [#71110](https://github.com/openclaw/openclaw/issues/71110), [#70389](https://github.com/openclaw/openclaw/issues/70389), [#70808](https://github.com/openclaw/openclaw/issues/70808)）
+- **用途**: One-shot embedded bundled MCP runtimes 在 run end retired，bundle-MCP startup 在 allowlist 無法觸及工具時跳過，並新增 `mcp.sessionIdleTtlMs` eviction。
+- **解決問題**: MCP runtimes 可能在 session 後洩漏或無必要啟動。
+- **影響**: MCP resource lifecycle 更乾淨，idle session runtime 可被回收。
+
+### ⭐⭐ Restart continuation durable queue（[#70780](https://github.com/openclaw/openclaw/pull/70780)）
+- **用途**: Gateway restart continuation 在刪除 sentinel 前先交給 durable session-delivery queue。
+- **解決問題**: Crashy restart 可能遺失 continuation work 或在 restart notice 前 replay。
+- **影響**: Restart 後可 recover queued continuation，無 channel route 時退回 session-only wake。
+
+### ⭐⭐ Tool-result pruning malformed text block guard（[#34979](https://github.com/openclaw/openclaw/issues/34979), [#51267](https://github.com/openclaw/openclaw/pull/51267)）
+- **用途**: Context-pruning 與 char estimator 對 `{ type: "text" }` 但缺少 string `text` 的 block 做防護。
+- **解決問題**: Void/undefined tool handler result 可能形成 malformed text block，繞過 size accounting 或讓 truncation pipeline crash。
+- **影響**: Tool result pruning 更穩定，非字串 payload 會被安全序列化或拒絕繞過 trimming。
+
+### ⭐⭐ Nix Home Manager service PATH（[#44402](https://github.com/openclaw/openclaw/issues/44402), [#59935](https://github.com/openclaw/openclaw/pull/59935)）
+- **用途**: Generated gateway service PATH 加入 Nix Home Manager profile bin directories。
+- **解決問題**: `openclaw gateway install` 產生的 plist/unit 可能找不到 Nix-installed binaries，導致 skills 在 boot 時被判定 blocked。
+- **影響**: macOS/Linux Nix users 不需手動 PATH workaround 即可讓 gateway 使用 Nix tools。
+
+### ⭐⭐ Telegram phantom fallback suppression（[#70623](https://github.com/openclaw/openclaw/issues/70623)）
+- **用途**: Agent 已透過 messaging tool 成功送出 reply 後，不再追加 `Agent couldn't generate a response` fallback。
+- **解決問題**: Telegram/Discord 使用者可能看到成功回覆後又看到錯誤 fallback。
+- **影響**: Channel delivery 狀態更準確，避免混淆使用者。
+
+### ⭐⭐ Discord cron duplicate post suppression（[#71406](https://github.com/openclaw/openclaw/issues/71406)）
+- **用途**: Text-only isolated cron / heartbeat announce output 從 canonical final assistant text delivery 一次。
+- **解決問題**: Streamed block payload 與 final answer 相同時，Discord 可能重複貼文。
+- **影響**: Cron/heartbeat announce 在 Discord 上不再重複。
+
+### ⭐⭐ Silent cron exec completion noise suppression（[#71391](https://github.com/openclaw/openclaw/pull/71391)）
+- **用途**: `delivery.mode="none"` 的 silent isolated cron jobs 抑制 automatic background exec completion wakes。
+- **解決問題**: 靜默 cron 仍可能因 background exec completion 產生噪音。
+- **影響**: Silent cron 保持安靜；webhook/announce 或 real failures 仍可觀測。
+
+### ⭐⭐ Gemini incomplete-turn recovery（[#71074](https://github.com/openclaw/openclaw/issues/71074), [#71362](https://github.com/openclaw/openclaw/pull/71362)）
+- **用途**: Gemini reasoning-only、empty、planning-only turns 會走 retry nudge path。
+- **解決問題**: 原 guard 只認 strict-agentic GPT-5 OpenAI lanes，Gemini 可能 silent stall。
+- **影響**: Gemini sessions 在 incomplete turns 後更有機會自動恢復。
+
+### ⭐⭐ Compaction quality fixes（[#71357](https://github.com/openclaw/openclaw/issues/71357)）
+- **用途**: Manual `/compact` 尊重 `agents.defaults.compaction.keepRecentTokens`，重新 distill safeguard summaries，並預設啟用 safeguard summary quality checks。
+- **解決問題**: 長 session 反覆 compaction 可能 snowballing，且 recent messages 未被如預期保留。
+- **影響**: Compaction summary 品質與近期上下文保留更可靠。
+
+### ⭐⭐ Session maintenance config honored（[#71356](https://github.com/openclaw/openclaw/issues/71356)）
+- **用途**: Load-time session maintenance 尊重 configured `session.maintenance`。
+- **解決問題**: 先前可能 fallback 到 default entry caps，忽略使用者設定。
+- **影響**: 大 session store 不再被非預期裁切到硬編碼預設。
+
+### ⭐ Control UI browser bundle crash fix（[#48930](https://github.com/openclaw/openclaw/pull/48930)）
+- **用途**: 延後 temp-dir access-mode constants 到 Node-only resolution 階段。
+- **解決問題**: Browser bundle 中 `node:fs` constants 為 stub，top-level eval 會讓 Control UI 黑屏。
+- **影響**: Control UI browser build 不再因 Node-only constants crash。
+
+### ⭐ Agents/TTS resolved shared config（[GitHub Release](https://github.com/openclaw/openclaw/releases/tag/v2026.4.24)）
+- **用途**: `tts` tool 使用 resolved shared config。
+- **解決問題**: Tool-triggered speech 可能 fallback 到 fresh config load，忽略已解析 provider/voice。
+- **影響**: Talk/TTS 行為更符合實際 runtime config。
+
+### ⭐ Reply media delivery/dedup fixes（[#71138](https://github.com/openclaw/openclaw/issues/71138), [#65468](https://github.com/openclaw/openclaw/issues/65468), [#66092](https://github.com/openclaw/openclaw/issues/66092)）
+- **用途**: Sandboxed replies 可送出 OpenClaw-managed media roots；block streaming 已送出的 media 不再於 final reply 重複；`NO_REPLY` sentinel 不會丟失 voice media。
+- **解決問題**: Managed media 可能被誤判 sandbox escape，或 Telegram voice/files 重複，或 audio payload 因 `NO_REPLY` 被丟棄。
+- **影響**: Media reply delivery 更可靠且更少重複。
+
+---
+
+## Summary Table
+
+| 類別 | 3 顆星 | 2 顆星 | 1 顆星 | 摘要 |
+|------|--------|--------|--------|------|
+| 功能更新 | 3 | 9 | 3 | Google Meet、realtime voice、browser automation、DeepSeek/model catalog、Codex parity 與 diagnostics |
+| 安全性 | 3 | 4 | 2 | Dashboard token redaction、browser/admin gating、SecretRef migration、Matrix trust、URL opener 與 OTEL redaction |
+| 錯誤修復 | 2 | 10 | 3 | Heartbeat、MCP lifecycle、restart continuation、tool pruning、cron/Discord/Telegram、Gemini、compaction、sessions 與 media 修復 |
+| **總計** | 8 | 23 | 8 | v2026.4.24 是大型功能與穩定性版本，包含一項 plugin SDK breaking migration |
+
+---
+
+## Footer
+
+- **發佈日期**: 2026-04-25
+- **版本**: 2026.4.24
+- **狀態**: Production Ready
+- **GitHub Release**: https://github.com/openclaw/openclaw/releases/tag/v2026.4.24


### PR DESCRIPTION
## Summary\n\n- Add zh-TW release notes for OpenClaw v2026.4.24\n- Call out the Plugin SDK/tool-result transform breaking migration in 升級前必讀\n- Cover feature updates, security improvements, and bug fixes from the upstream release\n- Closes #510\n\n## Validation\n\n- Reviewed upstream GitHub Release v2026.4.24\n- Reviewed release-notes/GUIDELINES.md\n- Spot-checked key upstream PRs/issues and source/docs for ⭐⭐⭐ flowcharts\n- Ran public-safety grep for private names, local paths, IPs, and trading terms\n- Checked required sections, fence balance, ⭐⭐⭐ flowchart count, link shape, overview counts, trailing whitespace, and `git diff --check`