### PR TITLE
docs: validate resume-session-id & cron-delivery-migration (2026-05-11)

### DIFF
--- a/usecases/cron-delivery-migration.md
+++ b/usecases/cron-delivery-migration.md
@@ -1,5 +1,5 @@
 ---
-last_validated: 2026-04-20
+last_validated: 2026-05-11
 validated_by: wangyuyan-agent
 ---
 

--- a/usecases/resume-session-id.md
+++ b/usecases/resume-session-id.md
@@ -1,5 +1,5 @@
 ---
-last_validated: 2026-04-20
+last_validated: 2026-05-11
 validated_by: wangyuyan-agent
 ---
 


### PR DESCRIPTION
## 核查摘要

對照 source code 驗證兩份文件：

- **usecases/resume-session-id.md** — 對照 release-notes/2026-03-11.md（PR #41847）、docs/acpx-harness.md 驗證。resumeSessionId 參數、sessions.json 路徑、acpxSessionId 字段名、agent 支援列表（codex/claude）、session/load 協議均與文件描述一致。後續版本（至 2026-04-22）無 breaking change。
- **usecases/cron-delivery-migration.md** — 對照 release-notes/2026-03-11.md（PR #40998）、docs/cron.md 驗證。isolated cron delivery 收緊行為、--announce/--no-deliver 旗標、openclaw doctor --fix 偵測邏輯均與文件描述一致。後續 cron delivery 修正（#69587 等）為 bug fix，不影響文件所述的遷移流程。

無內容變動，僅更新 last_validated 日期。

Fixes #617
Fixes #622